### PR TITLE
Sort query params for test stubs

### DIFF
--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -93,7 +93,11 @@ module Faraday
 
       def request_uri url
         (url.path != "" ? url.path : "/") +
-        (url.query ? "?#{url.query}" : "")
+        (url.query ? "?#{sort_query_params(url.query)}" : "")
+      end
+
+      def sort_query_params query
+        query.split('&').sort.join('&')
       end
 
       def call(env)


### PR DESCRIPTION
I found it hard (impossible?) to ensure the query params were sorted properly unless I had this to not put me at the whim of the hash sorting order.
