### PR TITLE
Synchrony

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ group :development, :test do
   gem 'patron', '~> 0.4'
   gem 'sinatra', '~> 1.1'
   gem 'typhoeus', '~> 0.1'
+  gem 'eventmachine', '~> 0.12'
+  gem 'em-http-request', '~> 0.2', :require => 'em-http'
+  gem 'em-synchrony', '~> 0.2', :require => ['em-synchrony', 'em-synchrony/em-http']
 end
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,12 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.2.2)
+    em-http-request (0.2.14)
+      addressable (>= 2.0.0)
+      eventmachine (>= 0.12.9)
+    em-synchrony (0.2.0)
+      eventmachine (>= 0.12.9)
+    eventmachine (0.12.10)
     multipart-post (1.0.1)
     patron (0.4.9)
     rack (1.2.1)
@@ -26,6 +32,9 @@ PLATFORMS
 
 DEPENDENCIES
   addressable (~> 2.2.2)
+  em-http-request (~> 0.2)
+  em-synchrony (~> 0.2)
+  eventmachine (~> 0.12)
   faraday!
   multipart-post (~> 1.0.1)
   patron (~> 0.4)

--- a/README.md
+++ b/README.md
@@ -7,16 +7,18 @@ This mess is gonna get raw, like sushi. So, haters to the left.
 ## Usage
 
     conn = Faraday::Connection.new(:url => 'http://sushi.com') do |builder|
-      builder.use Faraday::Request::Yajl     # convert body to json with Yajl lib
-      builder.use Faraday::Adapter::Logger   # log the request somewhere?
-      builder.use Faraday::Adapter::Typhoeus # make http request with typhoeus
-      builder.use Faraday::Response::Yajl    # # parse body with yajl
+      builder.use Faraday::Request::Yajl        # convert body to json with Yajl lib
+      builder.use Faraday::Adapter::Logger      # log the request somewhere?
+      builder.use Faraday::Adapter::Typhoeus    # make http request with typhoeus
+      builder.use Faraday::Adapter::EMSynchrony # make http request with eventmachine and synchrony
+      builder.use Faraday::Response::Yajl       # parse body with yajl
 
       # or use shortcuts
-      builder.request  :yajl     # Faraday::Request::Yajl
-      builder.adapter  :logger   # Faraday::Adapter::Logger
-      builder.adapter  :typhoeus # Faraday::Adapter::Typhoeus
-      builder.response :yajl     # Faraday::Response::Yajl
+      builder.request  :yajl         # Faraday::Request::Yajl
+      builder.adapter  :logger       # Faraday::Adapter::Logger
+      builder.adapter  :typhoeus     # Faraday::Adapter::Typhoeus
+      builder.adapter  :em_synchrony # Faraday::Adapter::EMSynchrony
+      builder.response :yajl         # Faraday::Response::Yajl
     end
 
     resp1 = conn.get '/nigiri/sake.json'

--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -55,6 +55,7 @@ Gem::Specification.new do |s|
     lib/faraday/adapter/patron.rb
     lib/faraday/adapter/test.rb
     lib/faraday/adapter/typhoeus.rb
+    lib/faraday/adapter/em_synchrony.rb
     lib/faraday/builder.rb
     lib/faraday/connection.rb
     lib/faraday/error.rb

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -10,6 +10,7 @@ module Faraday
       :ActionDispatch => 'action_dispatch',
       :NetHttp        => 'net_http',
       :Typhoeus       => 'typhoeus',
+      :EMSynchrony   => 'em_synchrony',
       :Patron         => 'patron',
       :Test           => 'test'
 
@@ -19,7 +20,7 @@ module Faraday
       :net_http        => :NetHttp,
       :typhoeus        => :Typhoeus,
       :patron          => :Patron,
-      :net_http        => :NetHttp
+      :em_synchrnoy    => :EMSynchrony
 
     def call(env)
       process_body_for_request(env)

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -1,0 +1,78 @@
+require 'em-synchrony/em-http'
+require 'fiber'
+
+module Faraday
+  class Adapter
+    class EMSynchrony < Faraday::Adapter
+
+      class Header
+        include Net::HTTPHeader
+        def initialize response
+          @header = {}
+          response.response_header.each do |key, value|
+            case key
+            when "CONTENT_TYPE"; self.content_type = value
+            when "CONTENT_LENGTH"; self.content_length = value
+            else; self[key] = value
+            end
+          end
+        end
+      end
+
+      def call(env)
+        process_body_for_request(env)
+        
+        request = EventMachine::HttpRequest.new(URI::parse(env[:url].to_s))
+        
+        options = {:head => env[:request_headers]}
+
+        if env[:body]
+          if env[:body].respond_to? :read
+            options[:body] = env[:body].read
+          else
+            options[:body] = env[:body]
+          end
+        end
+
+        if req = env[:request]
+          if proxy = req[:proxy]
+            uri = Addressable::URI.parse(proxy[:uri])
+            options[:proxy] = {
+              :host => uri.host,
+              :port => uri.port
+            }
+            if proxy[:username] && proxy[:password]
+              options[:proxy][:authorization] = [proxy[:username], proxy[:password]]
+            end
+          end
+
+          # only one timeout currently supported by em http request
+          if req[:timeout] or req[:open_timeout]
+            options[:timeout] = [req[:timeout] || 0, req[:open_timeout] || 0].max
+          end
+        end
+
+        client = nil
+        block = lambda { request.send env[:method].to_s.downcase.to_sym, options }
+        if !EM.reactor_running?
+          EM.run {
+            Fiber.new do
+              client = block.call
+              EM.stop
+            end.resume
+          }
+        else
+          client = block.call
+        end
+
+        env.update(:status           => client.response_header.http_status.to_i,
+                   :response_headers => Header.new(client),
+                   :body             => client.response)
+
+        @app.call env
+      rescue Errno::ECONNREFUSED
+        raise Error::ConnectionFailed, "connection refused"
+      end
+    end
+  end
+end

--- a/test/adapters/live_test.rb
+++ b/test/adapters/live_test.rb
@@ -124,6 +124,21 @@ if Faraday::TestCase::LIVE_SERVER
           assert_equal '[1,2,3]', resp1.body
           assert_equal '[1,2,3]', resp2.body
         end
+
+        if adapter.to_s == "Faraday::Adapter::EMSynchrony"
+          instance_methods.grep(%r{Faraday::Adapter::EMSynchrony}).each do |method|
+            em = method.to_s.sub %r{^test_}, "test_under_em_"
+            define_method em do
+              EM.run do
+                Fiber.new do
+                  self.send method
+                  EM.stop
+                end.resume
+              end          
+            end
+          end
+          
+        end
       end
 
       def create_connection(adapter)


### PR DESCRIPTION
Here's the pull request.

This isn't generic EM: require's Ilya's synchrony and needs to be run on its own fiber, e.g., via synchrony or rack-fiberpool.

I thought about a "first class" em adapter, but I think the faraday api is sync right now, right? Interesting idea to add something like rack's async support to faraday, but that's an itch I don't have right now.
