### PR TITLE
Fix a (serious) bug in Faraday 0.5.0 where NoMethodError is raised if no stubs are found

### DIFF
--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -105,14 +105,16 @@ module Faraday
       end
 
       def call(env)
-        if stub = stubs.match(env[:method], Faraday::Utils.normalize_path(env[:url]), env[:body])
+        normalized_path = Faraday::Utils.normalize_path(env[:url])
+
+        if stub = stubs.match(env[:method], normalized_path, env[:body])
           status, headers, body = stub.block.call(env)
           env.update \
             :status           => status,
             :response_headers => headers,
             :body             => body
         else
-          raise "no stubbed request for #{env[:method]} #{request_uri(env[:url])} #{env[:body]}"
+          raise "no stubbed request for #{env[:method]} #{normalized_path} #{env[:body]}"
         end
         @app.call(env)
       end

--- a/test/adapters/test_middleware_test.rb
+++ b/test/adapters/test_middleware_test.rb
@@ -33,5 +33,11 @@ module Adapters
       assert_equal 'hello', @conn.get("/hello").body
       assert_equal 'world', @conn.get("/hello").body
     end
+
+    def test_raises_an_error_if_no_stub_is_found_for_request
+      assert_raise RuntimeError do
+        @conn.get('/invalid'){ [200, {}, []] }
+      end
+    end
   end
 end


### PR DESCRIPTION
Added a fix and a test case (which did not exist previously).
