### PR TITLE
Data stored in an array within the body hash should be preserved.

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -77,9 +77,14 @@ module Faraday
     end
 
     def process_to_params(pieces, params, base = nil, &block)
-      params.each do |key, value|
+      params.to_a.each do |key, value|
         key_str = base ? "#{base}[#{key}]" : key
-        if value.kind_of?(Hash)
+
+        case value
+        when Array
+          values = value.inject([]) { |a,v| a << [nil, v] }
+          process_to_params(pieces, values, key_str, &block)
+        when Hash
           process_to_params(pieces, value, key_str, &block)
         else
           pieces << block.call(key_str, value)

--- a/test/form_post_test.rb
+++ b/test/form_post_test.rb
@@ -39,4 +39,20 @@ class FormPostTest < Faraday::TestCase
     @app.process_body_for_request @env
     assert_equal 'abc', @env[:body]
   end
+
+  def test_processes_array_values
+    @env[:body] = {:a => [:b, 1]}
+    @app.process_body_for_request @env
+    assert_equal 'a[]=b&a[]=1', @env[:body]
+  end
+
+  def test_processes_nested_array_values
+    @env[:body] = {:a => [:b, {:c => :d}, [:e]]}
+    @app.process_body_for_request @env
+
+    # a[]=b&a[][c]=d&a[][]=e
+    assert_match /a\[\]=b/,      @env[:body]
+    assert_match /a\[\]\[c\]=d/, @env[:body]
+    assert_match /a\[\]\[\]=e/,  @env[:body]
+  end
 end


### PR DESCRIPTION
At present, `process_to_params` loses information when converting a body hash that contains an array:

```
{:a => [:b, :c], :easy_as => 123} # becomes => "easy_as=123&a=bc"
```

The attached commit preserves the array using the control name format for form fields with multiple values:

```
{:a => [:b, :c], :easy_as => 123} # becomes => "easy_as=123&a[]=b&a[]=c"
```

Request recipients can now use the parameter string to reconstruct the array with values intact.
