### PR TITLE
Base64.encode64 adds \n every 60 chars. Need to strip them out

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -81,7 +81,9 @@ module Faraday
     end
 
     def basic_auth(login, pass)
-      @headers['authorization'] = "Basic #{Base64.encode64("#{login}:#{pass}").strip}"
+      auth = Base64.encode64("#{login}:#{pass}")
+      auth.gsub!("\n", "")
+      @headers['authorization'] = "Basic #{auth}"
     end
 
     def token_auth(token, options = {})

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -58,6 +58,12 @@ class TestConnection < Faraday::TestCase
     assert_equal 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==', conn.headers['Authorization']
   end
 
+  def test_long_basic_auth_sets_authorization_header_without_new_lines
+    conn = Faraday::Connection.new
+    conn.basic_auth "A" * 255, ""
+    assert_equal "Basic #{'QUFB' * 85}Og==", conn.headers['Authorization']
+  end
+
   def test_auto_parses_basic_auth_from_url
     conn = Faraday::Connection.new :url => "http://aladdin:opensesame@sushi.com/fish"
     assert_equal 'Basic YWxhZGRpbjpvcGVuc2VzYW1l', conn.headers['Authorization']


### PR DESCRIPTION
This should fix it.
