### PR TITLE
Fix configuring open_timeout

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -26,7 +26,7 @@ module Faraday
           http.ca_file = ssl[:ca_file]     if ssl[:ca_file]
         end
         req = env[:request]
-        http.read_timeout = net.open_timeout = req[:timeout] if req[:timeout]
+        http.read_timeout = http.open_timeout = req[:timeout] if req[:timeout]
         http.open_timeout = req[:open_timeout]               if req[:open_timeout]
 
         full_path = full_path_for(env[:url].path, env[:url].query, env[:url].fragment)


### PR DESCRIPTION
Tiny fix: Use http local variable instead of undefined net.

Unfortunately, I don't believe this has test coverage.
