### PR TITLE
Added SSL options support to EM Synchrony adapter

### DIFF
--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -26,7 +26,8 @@ module Faraday
         process_body_for_request(env)
         request = EventMachine::HttpRequest.new(URI::parse(env[:url].to_s))
         options = {:head => env[:request_headers]}
-
+        options[:ssl] = env[:ssl] if env[:ssl]
+        
         if env[:body]
           if env[:body].respond_to? :read
             options[:body] = env[:body].read


### PR DESCRIPTION
This commit passes SSL options along to EM Synchrony to enable SSL certificate authentication.
