### PR TITLE
Add support for setting SSL ca_path

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -22,6 +22,7 @@ module Faraday
           http.cert        = ssl[:client_cert] if ssl[:client_cert]
           http.key         = ssl[:client_key]  if ssl[:client_key]
           http.ca_file     = ssl[:ca_file]     if ssl[:ca_file]
+          http.ca_path     = ssl[:ca_path]     if ssl[:ca_path]
           http.cert_store  = ssl[:cert_store]  if ssl[:cert_store]
         end
 


### PR DESCRIPTION
At least on Ubuntu, calling sites such as Facebook via SSL will fail without setting the ca_path to /etc/ssl/certs - this is causing a lot of people to disable SSL verification (and other even worse monkeypatching) when using gems like omniauth, which depends on Faraday. See for example [this Stackoverflow thread](http://stackoverflow.com/questions/3977303/omniauth-facebook-certificate-verify-failed) and this [Omniauth ticket](https://github.com/intridea/omniauth/issues/260)

Ideally, this option should be settable on a global config level so it doesn't have to be passed with each request.
