### PR TITLE
Improve error if no JSON adapter is available

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -34,5 +34,7 @@ module Faraday
     class ConnectionFailed < ClientError;   end
     class ResourceNotFound < ClientError;   end
     class ParsingError     < ClientError;   end
+
+    class MissingDependency < StandardError; end
   end
 end

--- a/lib/faraday/request/json.rb
+++ b/lib/faraday/request/json.rb
@@ -4,9 +4,9 @@ module Faraday
 
     class << self
       attr_writer :adapter
-      
+
       def adapter
-        @adapter or raise "No JSON adapter available. Install either activesupport or yajl-ruby."
+        @adapter or raise Error::MissingDependency, "No JSON adapter available. Install either activesupport or yajl-ruby."
       end
     end
 

--- a/test/request_middleware_test.rb
+++ b/test/request_middleware_test.rb
@@ -48,8 +48,8 @@ class RequestMiddlewareTest < Faraday::TestCase
       # assert_raise doesn't work to check the message (at least on 1.8.7)
       begin
         @conn.post('/echo', { :fruit => %w[apples oranges] }, 'content-type' => 'application/json')
-        fail "Exception not thrown"
-      rescue RuntimeError => e
+        fail "Exception not raised"
+      rescue Faraday::Error::MissingDependency => e
         assert_equal expected_msg, e.message
       end
     end


### PR DESCRIPTION
Currently, if you try to use `Faraday::JSON::Request` with neither yajl-ruby or activesupport installed, you will get a `NoMethodError` at runtime with the message "undefined method `encode' for nil:NilClass". This commit forestalls that error by raising one that indicates that you need to install one of the supported JSON libraries.
