### PR TITLE
Add SSL options to Typheous

### DIFF
--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -21,6 +21,13 @@ module Faraday
           :headers => env[:request_headers],
           :disable_ssl_peer_verification => (env[:ssl] && !env[:ssl].fetch(:verify, true))
 
+        if ssl = env[:ssl]
+          req.ssl_cert   = ssl[:client_cert_file] if ssl[:client_cert_file]
+          req.ssl_key    = ssl[:client_key_file]  if ssl[:client_key_file]
+          req.ssl_cacert = ssl[:ca_file]          if ssl[:ca_file]
+          req.ssl_capath = ssl[:ca_path]          if ssl[:ca_path]
+        end
+
         env_req = env[:request]
         req.timeout = req.connect_timeout = (env_req[:timeout] * 1000) if env_req[:timeout]
         req.connect_timeout = (env_req[:open_timeout] * 1000)          if env_req[:open_timeout]


### PR DESCRIPTION
I tried to stay in the spirit of Net::HTTP in terms of how the options
are set. Typhoeus takes paths to the cert files so I'm considering those
different options (*_file) for ssl that are a complement the ca_file
option already present.
