### PR TITLE
Duplicate SSL settings on #dup call

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -237,7 +237,7 @@ module Faraday
     end
 
     def dup
-      self.class.new(build_url(''), :headers => headers.dup, :params => params.dup, :builder => builder.dup)
+      self.class.new(build_url(''), :headers => headers.dup, :params => params.dup, :builder => builder.dup, :ssl => ssl.dup)
     end
 
     def proxy_arg_to_uri(arg)

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -238,15 +238,16 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_dups_connection_object
-    conn = Faraday::Connection.new 'http://sushi.com/foo' do |b|
+    conn = Faraday::Connection.new 'http://sushi.com/foo', :ssl => { :verify => :none } do |b|
       b.adapter :net_http
     end
     conn.headers['content-type'] = 'text/plain'
     conn.params['a'] = '1'
 
     duped = conn.dup
+
     assert_equal conn.build_url(''), duped.build_url('')
-    [:headers, :params, :builder].each do |attr|
+    [:headers, :params, :builder, :ssl].each do |attr|
       assert_equal     conn.send(attr),           duped.send(attr)
       assert_not_equal conn.send(attr).object_id, duped.send(attr).object_id
     end


### PR DESCRIPTION
Hello,

It seems logical to duplicate SSL settings as well since there is no setter for them. I monkey patched my current application to make this work, so I thought it might be useful for others. The alternative of course would be to redefine :ssl as accessor. What do you think?

Thanks
