### PR TITLE
Use the default system CA certs if available

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -17,8 +17,18 @@ module Faraday
 
         if http.use_ssl = (url.scheme == 'https' && (ssl = env[:ssl]) && true)
           http.verify_mode = ssl[:verify_mode] || begin
-            ssl.fetch(:verify, true) ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+            if ssl.fetch(:verify, true) 
+              OpenSSL::SSL::VERIFY_PEER
+              # Use the default cert store by default, i.e. system ca certs
+              store = OpenSSL::X509::Store.new
+              store.set_default_paths
+              http.cert_store = store
+              OpenSSL::SSL::VERIFY_PEER
+            else
+              OpenSSL::SSL::VERIFY_NONE
+            end
           end
+
           http.cert         = ssl[:client_cert]  if ssl[:client_cert]
           http.key          = ssl[:client_key]   if ssl[:client_key]
           http.ca_file      = ssl[:ca_file]      if ssl[:ca_file]


### PR DESCRIPTION
With certain builds of OpenSSL, you won't get this for free, and as a result, using VERIFY_PEER will throw errors without the user manually setting ca_file or cert_store. This patch allows the user simply to expect that VERIFY_PEER will use the system installed certs by default, as per openssl(1)
