### PR TITLE
Introduce 'artifice' for Faraday

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -10,6 +10,10 @@ module Faraday
       Faraday::Connection.new(url, options, &block)
     end
 
+    def artifice
+      @artifice ||= Artifice.new
+    end
+
   private
     def method_missing(name, *args, &block)
       default_connection.send(name, *args, &block)
@@ -61,7 +65,8 @@ module Faraday
     :Response        => 'response',
     :CompositeReadIO => 'upload_io',
     :UploadIO        => 'upload_io',
-    :Parts           => 'upload_io'
+    :Parts           => 'upload_io',
+    :Artifice        => 'artifice'
 end
 
 require 'faraday/utils'

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -11,7 +11,8 @@ module Faraday
       :EMSynchrony    => 'em_synchrony',
       :Patron         => 'patron',
       :Excon          => 'excon',
-      :Test           => 'test'
+      :Test           => 'test',
+      :Artifice       => 'artifice'
 
     register_lookup_modules \
       :action_dispatch => :ActionDispatch,
@@ -20,7 +21,8 @@ module Faraday
       :typhoeus        => :Typhoeus,
       :patron          => :Patron,
       :em_synchrony    => :EMSynchrony,
-      :excon           => :Excon
+      :excon           => :Excon,
+      :artifice        => :Artifice
 
     def call(env)
       if !env[:body] and Connection::METHODS_WITH_BODIES.include? env[:method]

--- a/lib/faraday/adapter/artifice.rb
+++ b/lib/faraday/adapter/artifice.rb
@@ -1,0 +1,46 @@
+require 'rack'
+
+module Faraday
+  class Adapter
+    # This adapter acts much like Yehudas artifice gem, allowing you to
+    # forcefully dispatch all requests to a rack endpoint.
+    #
+    # Faraday.artifice.activate_with(rack_app) do
+    #   Faraday.new(:url => 'https://graph.facebook.com').get('/btaylor')
+    # end
+    class Artifice < Faraday::Adapter
+      def self.endpoint=(endpoint)
+        Thread.current[:faraday_artifice_endpoint] = endpoint
+      end
+      def self.endpoint
+        Thread.current[:faraday_artifice_endpoint]
+      end
+
+      def call(env)
+        super
+        mock_req_opts = env[:request_headers]
+        mock_req_opts ||= {}
+        mock_req_opts.merge!(
+          :method => env[:method],
+          :input => env[:body]
+        )
+        host_key = mock_req_opts.keys.grep(/^http_host$/i).first || 'HTTP_HOST'
+        mock_req_opts[host_key] ||= env[:url].host
+        if env[:url].host || env[:url].port
+          name_key = mock_req_opts.keys.grep(/^server_name$/i).first || 'SERVER_NAME'
+          mock_req_opts[name_key] ||= "#{env[:url].host}:#{env[:url].port}"
+        end
+        port_key = mock_req_opts.keys.grep(/^server_port$/i).first || 'SERVER_PORT'
+        mock_req_opts[port_key] ||= env[:url].port || "80"
+        rack_env = Rack::MockRequest.env_for(env[:url].to_s, mock_req_opts)
+        status, headers, body = self.class.endpoint.call(rack_env)
+        flat_body = ""
+        body.each do |chunk|
+          flat_body << chunk
+        end
+        save_response(env, status, flat_body, headers)
+        @app.call env
+      end
+    end
+  end
+end

--- a/lib/faraday/artifice.rb
+++ b/lib/faraday/artifice.rb
@@ -1,0 +1,41 @@
+# Faraday.artifice.activate_with(rack_app) do
+#   Faraday.new(:url => 'https://graph.facebook.com').get('/btaylor')
+# end
+module Faraday
+  class Artifice
+
+    # Drop a rack endpoint in front of all requests by switching to the
+    # Artifice adapter.
+    #
+    # Example:
+    #   Faraday.artifice.activate_with(proc { |env| [200, {}, ['hello']] }) do
+    #     Faraday.new.get('/').body # => 'hello'
+    #   end
+    def activate_with(endpoint)
+      activate
+      self.endpoint = endpoint
+      yield if block_given?
+    ensure
+      deactivate if block_given?
+    end
+
+    def activate
+      if Faraday.default_adapter != :artifice
+        @default_adapter = Faraday.default_adapter
+      end
+      Faraday.default_adapter = :artifice
+    end
+
+    def deactivate
+      Faraday.default_adapter = @default_adapter
+    end
+
+    def endpoint=(endpoint)
+      Faraday::Adapter::Artifice.endpoint = endpoint
+    end
+
+    def endpoint
+      Faraday::Adapter::Artifice.endpoint
+    end
+  end
+end

--- a/test/artifice_test.rb
+++ b/test/artifice_test.rb
@@ -1,0 +1,61 @@
+require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
+require 'rack'
+
+class ArtificeTest < Faraday::TestCase
+  class App
+    def call(env)
+      [200, {'Content-Type' => 'text/plain'}, [env['HTTP_HOST'] || 'artifice']]
+    end
+  end
+
+  def test_sets_default_adapter
+    assert_equal :net_http, Faraday.default_adapter
+    Faraday.artifice.activate
+    assert_equal :artifice, Faraday.default_adapter
+  ensure
+    Faraday.artifice.deactivate
+  end
+
+  def test_unsets_default_adapter
+    assert_equal :net_http, Faraday.default_adapter
+    Faraday.artifice.activate
+    Faraday.artifice.deactivate
+    assert_equal :net_http, Faraday.default_adapter
+  ensure
+    Faraday.artifice.deactivate
+  end
+
+  def test_sets_endpoint
+    app = App.new
+    Faraday.artifice.activate_with(app) do
+      assert_equal app, Faraday::Adapter::Artifice.endpoint
+    end
+  end
+
+  def test_hits_rack_app
+    Faraday.artifice.activate_with(App.new) do
+      res = Faraday.new.get('/')
+      assert_equal 'artifice', res.body
+    end
+  end
+
+  def test_dispatches_domains_and_ssl
+    app = Rack::Builder.app do
+      map("http://one/") { run App.new }
+      map("http://two/") { run App.new }
+      map("http://three:8080/") { run App.new }
+      map("https://four/") { run lambda { |e| [200, {}, [e['HTTPS']]]} }
+    end
+    Faraday.artifice.activate_with(app) do
+      res = Faraday.new(:url => 'http://one').get('/')
+      assert_equal 'one', res.body
+      res = Faraday.new(:url => 'http://two').get('/')
+      assert_equal 'two', res.body
+      res = Faraday.new(:url => 'http://three:8080').get('/')
+      assert_equal 'three', res.body
+      res = Faraday.new(:url => 'https://four').get('/')
+      assert_equal 'on', res.body
+    end
+  end
+
+end


### PR DESCRIPTION
Add support for mocking with rack apps.
Supports multi domains mocking.
Supports ssl mocking.
Implements the same API as artifice so you can drop-in to artifice tested apps with:

```
 Artifice = Faraday.artifice
```

The general idea is simple:

```
Faraday.artifice.activate_with(lambda { |env| [200, {}, ['hello']] })
Faraday.new.get('/').body # => 'hello'
```
