### PR TITLE
Add support for http_proxy environment variable

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -34,8 +34,7 @@ module Faraday
 
       self.url_prefix = url if url
 
-      options[:proxy] = ENV['http_proxy'] if options[:proxy].nil?
-      proxy(options[:proxy])
+      proxy(options.fetch(:proxy) { ENV['http_proxy'] })
 
       @params.update options[:params]   if options[:params]
       @headers.update options[:headers] if options[:headers]

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -2,9 +2,6 @@ require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
 
 class EnvTest < Faraday::TestCase
   def setup
-    @tmp_http_proxy = ENV['http_proxy']
-    ENV['http_proxy'] = "http://duncan.proxy.com:80"
-
     @conn = Faraday.new :url => 'http://sushi.com/api',
       :headers => {'Mime-Version' => '1.0'},
       :request => {:oauth => {:consumer_key => 'anonymous'}}
@@ -13,10 +10,6 @@ class EnvTest < Faraday::TestCase
     @conn.options[:open_timeout] = 5
     @conn.ssl[:verify]           = false
     @conn.proxy 'http://proxy.com'
-  end
-
-  def teardown
-    ENV['http_proxy'] = @tmp_http_proxy
   end
 
   def test_request_create_stores_method


### PR DESCRIPTION
If no proxy is provided, but the http_proxy environment var
is set, this is used transparently.
