### PR TITLE
Typhoeus adapter does not accept custom user agent

### DIFF
--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -19,6 +19,7 @@ module Faraday
           :method  => env[:method],
           :body    => env[:body],
           :headers => env[:request_headers],
+          :user_agent => env[:request_headers][:user_agent],
           :disable_ssl_peer_verification => (env[:ssl] && !env[:ssl].fetch(:verify, true))
 
         if ssl = env[:ssl]

--- a/test/adapters/typhoeus_test.rb
+++ b/test/adapters/typhoeus_test.rb
@@ -1,0 +1,24 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'helper'))
+
+module Adapters
+  class TyphoeusTest < Faraday::TestCase
+    def setup
+      @connection = Faraday.new('http://disney.com') do |b|
+        b.adapter :typhoeus
+      end
+    end
+
+    def test_handles_user_agent
+      # default typhoeus agent
+      stub_request(:get, 'disney.com/hello').with(:headers => {'User-Agent'=>'Typhoeus - http://github.com/dbalatero/typhoeus/tree/master'}){ |request|
+        request.headers["User-Agent"] == 'Typhoeus - http://github.com/dbalatero/typhoeus/tree/master'
+      }
+      @connection.get('/hello')
+      stub_request(:get, 'disney.com/world').with(:headers => {'User-Agent'=>'Faraday Agent'}){ |request|
+        request.headers["User-Agent"] == 'Faraday Agent'
+      }
+      @connection.get('/world', :user_agent => 'Faraday Agent')
+    end
+
+  end
+end


### PR DESCRIPTION
Ran into this problem in faraday 0.7.5 when switching from net/http to typhoeus.

See full problem and solution noted here: https://github.com/dbalatero/typhoeus/issues/78#issuecomment-1025115

Thanks for all your work on this project!
