### PR TITLE
Unescape basic authentication username and password when pulling them fro

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -177,7 +177,9 @@ module Faraday
       self.path_prefix = uri.path
 
       @params.merge_query(uri.query)
-      basic_auth(uri.user, uri.password) if uri.user && uri.password
+      if uri.user && uri.password
+        basic_auth(CGI.unescape(uri.user), CGI.unescape(uri.password))
+      end
 
       uri
     end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -73,6 +73,11 @@ class TestConnection < Faraday::TestCase
     assert_equal 'Basic YWxhZGRpbjpvcGVuc2VzYW1l', conn.headers['Authorization']
   end
 
+  def test_auto_parses_basic_auth_from_url_and_unescapes
+    conn = Faraday::Connection.new :url => "http://foo%40bar.com:pass%20word@sushi.com/fish"
+    assert_equal 'Basic Zm9vQGJhci5jb206cGFzcyB3b3Jk', conn.headers['Authorization']
+  end
+
   def test_token_auth_sets_authorization_header
     conn = Faraday::Connection.new
     conn.token_auth 'abcdef'


### PR DESCRIPTION
Unescape basic authentication username and password when pulling them from a URL.
