### PR TITLE
Correctly sets the timeout parameters for the em_synchrony adapter

### DIFF
--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -32,10 +32,10 @@ module Faraday
             end
           end
 
-          # only one timeout currently supported by em http request
-          if req[:timeout] or req[:open_timeout]
-            options[:timeout] = [req[:timeout] || 0, req[:open_timeout] || 0].max
+          if req[:timeout]
+            options[:connect_timeout] = options[:inactivity_timeout] = req[:timeout]
           end
+          options[:inactivity_timeout] = req[:open_timeout]  if req[:open_timeout]
         end
 
         client = nil

--- a/test/adapters/em_synchrony_test.rb
+++ b/test/adapters/em_synchrony_test.rb
@@ -1,0 +1,17 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'helper'))
+
+module Adapters
+  class EMSynchronyTest < Faraday::TestCase
+    def setup
+      @connection = Faraday.new('http://disney.com') do |b|
+        b.adapter :em_synchrony
+      end
+    end
+
+    def test_connection
+      stub_request(:any, 'http://disney.com')
+      resp = @connection.get "/"
+      assert_equal 200, resp.status
+    end
+  end
+end


### PR DESCRIPTION
em-http supports both connection timeout (:connection_timeout) and inactivity timeout (:inactivity_timeout) options. The correct mapping from Faraday's global timeout options (:timeout, :open_timeout) to em-http should be:

:timeout => :connection_timeout
:open_timeout => :inactivity_timeout

Where '=>' denotes 'maps to'

See https://github.com/igrigorik/em-http-request/wiki/Redirects-and-Timeouts

This commit is made to mirror the timeout behavior of the net_http adapter.
