### PR TITLE
Changed Faraday::Utils#escape to use block parameter instead of $1 to ...

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -125,8 +125,8 @@ module Faraday
     # Be sure to URI escape '+' symbols to %2B. Otherwise, they get interpreted
     # as spaces.
     def escape(s)
-      s.to_s.gsub(/([^a-zA-Z0-9_.-]+)/n) do
-        '%' << $1.unpack('H2'*bytesize($1)).join('%').tap { |c| c.upcase! }
+      s.to_s.gsub(/([^a-zA-Z0-9_.-]+)/n) do |match|
+        '%' << match.unpack('H2'*bytesize(match)).join('%').tap { |c| c.upcase! }
       end
     end
 


### PR DESCRIPTION
...sidestep a bug in ActiveSupport::SafeBuffer#gsub in Rails 3.1 (as described in https://github.com/rails/rails/issues/3496)

All tests are passing.
