### PR TITLE
Add Faraday.register_middleware

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -3,6 +3,7 @@ module Faraday
     CONTENT_LENGTH = 'Content-Length'.freeze
 
     extend AutoloadHelper
+    extend MiddlewareRegistry
 
     autoload_all 'faraday/adapter',
       :ActionDispatch => 'action_dispatch',
@@ -13,7 +14,7 @@ module Faraday
       :Excon          => 'excon',
       :Test           => 'test'
 
-    register_lookup_modules \
+    register_middleware \
       :action_dispatch => :ActionDispatch,
       :test            => :Test,
       :net_http        => :NetHttp,

--- a/lib/faraday/builder.rb
+++ b/lib/faraday/builder.rb
@@ -88,9 +88,13 @@ module Faraday
     end
 
     def use(klass, *args)
-      raise_if_locked
       block = block_given? ? Proc.new : nil
-      @handlers << self.class::Handler.new(klass, *args, &block)
+      if klass.is_a? Symbol
+        use_symbol(Faraday::Middleware, klass, *args, &block)
+      else
+        raise_if_locked
+        @handlers << self.class::Handler.new(klass, *args, &block)
+      end
     end
 
     def request(key, *args)
@@ -144,7 +148,7 @@ module Faraday
 
     def use_symbol(mod, key, *args)
       block = block_given? ? Proc.new : nil
-      use(mod.lookup_module(key), *args, &block)
+      use(mod.lookup_middleware(key), *args, &block)
     end
 
     def assert_index(index)

--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -1,5 +1,8 @@
 module Faraday
   class Middleware
+    extend AutoloadHelper
+    extend MiddlewareRegistry
+
     class << self
       attr_accessor :load_error, :supports_parallel_requests
       alias supports_parallel_requests? supports_parallel_requests

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -11,6 +11,7 @@ module Faraday
   #
   class Request < Struct.new(:path, :params, :headers, :body, :options)
     extend AutoloadHelper
+    extend MiddlewareRegistry
 
     autoload_all 'faraday/request',
       :UrlEncoded => 'url_encoded',
@@ -20,7 +21,7 @@ module Faraday
       :BasicAuthentication => 'basic_authentication',
       :TokenAuthentication => 'token_authentication'
 
-    register_lookup_modules \
+    register_middleware \
       :url_encoded => :UrlEncoded,
       :multipart   => :Multipart,
       :retry       => :Retry,

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -21,12 +21,13 @@ module Faraday
 
     extend Forwardable
     extend AutoloadHelper
+    extend MiddlewareRegistry
 
     autoload_all 'faraday/response',
       :RaiseError => 'raise_error',
       :Logger     => 'logger'
 
-    register_lookup_modules \
+    register_middleware \
       :raise_error => :RaiseError,
       :logger      => :Logger
 

--- a/test/adapters/live_test.rb
+++ b/test/adapters/live_test.rb
@@ -6,7 +6,7 @@ else
   module Adapters
     class LiveTest < Faraday::TestCase
       adapters = if ENV['ADAPTER']
-        ENV['ADAPTER'].split(':').map { |name| Faraday::Adapter.lookup_module name.to_sym }
+        ENV['ADAPTER'].split(':').map { |name| Faraday::Adapter.lookup_middleware name.to_sym }
       else
         loaded_adapters  = Faraday::Adapter.all_loaded_constants
         loaded_adapters -= [Faraday::Adapter::ActionDispatch]
@@ -217,7 +217,7 @@ else
 
       def real_adapter_for(adapter)
         if adapter == :default
-          Faraday::Adapter.lookup_module(Faraday.default_adapter)
+          Faraday::Adapter.lookup_middleware(Faraday.default_adapter)
         else
           adapter
         end


### PR DESCRIPTION
Allows 3rd-party libraries to register named shortcuts to resolve to full qualified constant names for specific middleware.

Usage:

``` ruby
Faraday.register_middleware :aloha => MyModule::Aloha
Faraday.register_middleware :boom => MyModule::Boom, :type => :response
Faraday.register_middleware :lazy => lambda { ... }
```

Those shortcuts are then available in Builder:

``` ruby
builder.use :aloha
builder.response :boom
```

What do you think of the API?
