### PR TITLE
GET method with body using 'net_http' adapter

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -40,7 +40,7 @@ module Faraday
         http.read_timeout = http.open_timeout = req[:timeout] if req[:timeout]
         http.open_timeout = req[:open_timeout]                if req[:open_timeout]
 
-        if :get != env[:method]
+        if :get != env[:method] or env[:body]
           http_request = Net::HTTPGenericRequest.new \
             env[:method].to_s.upcase,    # request method
             !!env[:body],                # is there request body
@@ -55,7 +55,7 @@ module Faraday
         end
 
         begin
-          http_response = if :get == env[:method]
+          http_response = if :get == env[:method] and env[:body].nil?
             # prefer `get` to `request` because the former handles gzip (ruby 1.9)
             http.get url.request_uri, env[:request_headers]
           else

--- a/test/adapters/live_test.rb
+++ b/test/adapters/live_test.rb
@@ -39,6 +39,17 @@ else
           end
         end
 
+        #GET request with body
+        unless %[Faraday::Adapter::NetHttp] == adapter.to_s
+          define_method "test_#{adapter}_GET_with_body" do
+            body = '{hello: world}'
+            response = create_connection(adapter).get('get/body') do |req|
+              req.body = body
+            end
+            assert_equal body, response.body
+          end
+        end
+
         define_method "test_#{adapter}_POST_send_url_encoded_params" do
           resp = create_connection(adapter).post do |req|
             req.url 'echo_name'

--- a/test/live_server.rb
+++ b/test/live_server.rb
@@ -48,3 +48,7 @@ get '/slow' do
   sleep 10
   [200, {}, 'ok']
 end
+
+get '/get/body' do
+  [200, {} , request.body]
+end


### PR DESCRIPTION
Currently in Faraday::Adapter::NetHttp  'GET' method call using 'http.get'. So we can not call get request with body.

So I tweak code  to call get request with body, for this check env[:body] is present or not if present  then make Net::HTTPGenericRequest and call as like other request(:put, :post etc) otherwise call as it is using 'http.get'.

Sample code: 

``` ruby
 conn = Faraday.new(:url => 'http://localhost:4567')
 res = conn.get do |req|
    req.url '/get/body'
    req.body =  "{hello: world}"
 end
```
