### PR TITLE
Stringify given URL in Faraday::Connection#build_url

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -196,7 +196,7 @@ module Faraday
     #   conn.build_url("nigiri", :page => 2) # => https://sushi.com/api/nigiri?token=abc&page=2
     #
     def build_url(url, extra_params = nil)
-      url = nil if url and url.empty?
+      url = nil if url and url.respond_to?(:empty?) and url.empty?
       base = url_prefix
       if url and base.path and base.path !~ /\/$/
         base = base.dup

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -204,6 +204,14 @@ class TestConnection < Faraday::TestCase
     assert_equal 'https://sushi.com/sushi/sake.html', uri.to_s
   end
 
+  def test_build_url_handles_given_url_without_empty_method
+    conn = Faraday::Connection.new
+    path = URI('/sake.html')
+    uri = conn.build_url(path)
+    assert !path.respond_to?(:empty?), 'given uri should not respond to #empty?'
+    assert_equal '/sake.html', uri.path
+  end
+
   def test_proxy_accepts_string
     with_proxy_env "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new


### PR DESCRIPTION
I ran into a possible regression in `Faraday::Connection#build_url` going from 0.7.5 to master. I've been passing an `Addressable::URI` to `#build_url` without issue as it calls `#to_s`.

``` ruby
#0.7.5
>> Faraday::Connection.new.build_url(Addressable::URI.parse('/sake.html')).to_s
=> "/sake.html"

# master
>> Faraday::Connection.new.build_url(Addressable::URI.parse('/sake.html')).to_s
NoMethodError: undefined method `empty?' for #<Addressable::URI:0x3ffe911a3b94 URI:/sake.html>
```

The first commit adds a test for the case where a given URL is empty as I couldn't fine one and removing it didn't break any tests (I was simply running `rake`). The second commit simply stringifies the given URL.
