### PR TITLE
Change how params, headers & options are handled in the request phase

### DIFF
--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -9,7 +9,7 @@ module Faraday
   #     req.body = 'abc'
   #   end
   #
-  class Request < Struct.new(:path, :params, :headers, :body, :options)
+  class Request < Struct.new(:method, :path, :params, :headers, :body, :options)
     extend AutoloadHelper
     extend MiddlewareRegistry
 
@@ -28,24 +28,38 @@ module Faraday
       :basic_auth  => :BasicAuthentication,
       :token_auth  => :TokenAuthentication
 
-    attr_reader :method
-
     def self.create(request_method)
       new(request_method).tap do |request|
         yield request if block_given?
       end
     end
 
-    def initialize(request_method)
-      @method = request_method
-      self.params  = {}
-      self.headers = {}
-      self.options = {}
+    # Public: Replace params, preserving the existing hash type
+    def params=(hash)
+      if params then params.replace hash
+      else super
+      end
     end
 
-    def url(path, params = {})
-      self.path   = path
-      self.params = params
+    # Public: Replace request headers, preserving the existing hash type
+    def headers=(hash)
+      if headers then headers.replace hash
+      else super
+      end
+    end
+
+    def url(path, params = nil)
+      if path.respond_to? :query
+        if query = path.query
+          path = path.dup
+          path.query = nil
+        end
+      else
+        path, query = path.split('?', 2)
+      end
+      self.path = path
+      self.params.merge_query query
+      self.params.update(params) if params
     end
 
     def [](key)
@@ -73,17 +87,12 @@ module Faraday
     #     :password   - Proxy server password
     # :ssl - Hash of options for configuring SSL requests.
     def to_env(connection)
-      env_params  = connection.params.merge(params)
-      env_headers = connection.headers.merge(headers)
-      request_options = Utils.deep_merge(connection.options, options)
-      Utils.deep_merge!(request_options, :proxy => connection.proxy)
-
       { :method           => method,
         :body             => body,
-        :url              => connection.build_url(path, env_params),
-        :request_headers  => env_headers,
+        :url              => connection.build_exclusive_url(path, params),
+        :request_headers  => headers,
         :parallel_manager => connection.parallel_manager,
-        :request          => request_options,
+        :request          => options,
         :ssl              => connection.ssl}
     end
   end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -162,26 +162,6 @@ class TestConnection < Faraday::TestCase
     assert_equal "a%5Bb%5D=1+%2B+2", uri.query
   end
 
-  def test_build_url_mashes_default_and_given_params_together
-    conn = Faraday::Connection.new 'http://sushi.com/api?token=abc', :params => {'format' => 'json'}
-    url = conn.build_url("nigiri?page=1", :limit => 5)
-    assert_equal %w[format=json limit=5 page=1 token=abc], url.query.split('&').sort
-  end
-
-  def test_build_url_overrides_default_params_with_given_params
-    conn = Faraday::Connection.new 'http://sushi.com/api?token=abc', :params => {'format' => 'json'}
-    url = conn.build_url("nigiri?page=1", :limit => 5, :token => 'def', :format => 'xml')
-    assert_equal %w[format=xml limit=5 page=1 token=def], url.query.split('&').sort
-  end
-
-  def test_default_params_hash_has_indifferent_access
-    conn = Faraday::Connection.new :params => {'format' => 'json'}
-    assert conn.params.has_key?(:format)
-    conn.params[:format] = 'xml'
-    url = conn.build_url("")
-    assert_equal %w[format=xml], url.query.split('&').sort
-  end
-
   def test_build_url_parses_url
     conn = Faraday::Connection.new
     uri = conn.build_url("http://sushi.com/sake.html")
@@ -288,5 +268,83 @@ class TestConnection < Faraday::TestCase
     }
     assert_equal 1, conn.builder.handlers.size
     assert_equal '/omnom', conn.path_prefix
+  end
+end
+
+class TestRequestParams < Faraday::TestCase
+  def create_connection(*args)
+    @conn = Faraday::Connection.new(*args) do |conn|
+      yield conn if block_given?
+      class << conn
+        undef app
+        def app() lambda { |env| env } end
+      end
+    end
+  end
+
+  def get(*args)
+    env = @conn.get(*args) do |req|
+      yield req if block_given?
+    end
+    env[:url].query
+  end
+
+  def assert_query_equal(expected, query)
+    assert_equal expected, query.split('&').sort
+  end
+
+  def test_merges_connection_and_request_params
+    create_connection 'http://a.co/?token=abc', :params => {'format' => 'json'}
+    query = get '?page=1', :limit => 5
+    assert_query_equal %w[format=json limit=5 page=1 token=abc], query
+  end
+
+  def test_overrides_connection_params
+    create_connection 'http://a.co/?a=a&b=b&c=c', :params => {:a => 'A'} do |conn|
+      conn.params[:b] = 'B'
+      assert_equal 'c', conn.params[:c]
+    end
+    assert_query_equal %w[a=A b=B c=c], get
+  end
+
+  def test_all_overrides_connection_params
+    create_connection 'http://a.co/?a=a', :params => {:c => 'c'} do |conn|
+      conn.params = {'b' => 'b'}
+    end
+    assert_query_equal %w[b=b], get
+  end
+
+  def test_overrides_request_params
+    create_connection
+    query = get '?p=1&a=a', :p => 2
+    assert_query_equal %w[a=a p=2], query
+  end
+
+  def test_overrides_request_params_block
+    create_connection
+    query = get '?p=1&a=a', :p => 2 do |req|
+      req.params[:p] = 3
+    end
+    assert_query_equal %w[a=a p=3], query
+  end
+
+  def test_overrides_request_params_block_url
+    create_connection
+    query = get nil, :p => 2 do |req|
+      req.url '?p=1&a=a', 'p' => 3
+    end
+    assert_query_equal %w[a=a p=3], query
+  end
+
+  def test_overrides_all_request_params
+    create_connection :params => {:c => 'c'}
+    query = get '?p=1&a=a', :p => 2 do |req|
+      assert_equal 'a', req.params[:a]
+      assert_equal 'c', req.params['c']
+      assert_equal 2, req.params['p']
+      req.params = {:b => 'b'}
+      assert_equal 'b', req.params['b']
+    end
+    assert_query_equal %w[b=b], query
   end
 end

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -50,7 +50,7 @@ class EnvTest < Faraday::TestCase
     env = make_env do |req|
       req.options[:timeout] = 10
       req.options[:custom] = true
-      req.options[:oauth] = {:consumer_secret => 'xyz'}
+      req.options[:oauth][:consumer_secret] = 'xyz'
     end
     assert_equal 10, env[:request][:timeout]
     assert_equal 5, env[:request][:open_timeout]
@@ -73,7 +73,7 @@ class EnvTest < Faraday::TestCase
   private
 
   def make_env(method = :get, connection = @conn, &block)
-    request = Faraday::Request.create(method, &block)
+    request = connection.build_request(method, &block)
     request.to_env(connection)
   end
 end


### PR DESCRIPTION
Quick quiz before we proceed:

``` rb
conn = Faraday.new params: {a:1}, request: {oauth: {secret:'xyz'}}

conn.get '/?b=2' do |req|
  req.params[:a]      # what's the value of :a?
  req.params[:b]      # what's the value of :b?
  req.params = {c:3}  # does this replace all parameters or just add?

  # does this merge with or replace existing configuration?
  req.options = {oauth: {key:'abc'}}
end
```

Answers to questions (before these changes):
1. `:a` is not accessible at this point.
2. Neither is `:b`.
3. Assignment just adds extra params, it doesn't erase old ones.
4. It deep-merges with existing options instead of overriding them.

This was all counter-intuitive to me. This pull request changes all this.

New behavior:

``` rb
conn.get '/?b=2' do |req|
  req.params[:a]          #=> 1
  req.params[:b]          #=> '2'
  req.params.update(c:3)  # merges extra params
  req.params = {c:3}      # replaces ALL params

  req.options[:oauth][:secret]  #=> 'xyz'
  # add extra nested request options:
  req.options[:oauth][:key] = 'abc'
end
```

These backwards-incompatible changes resulted when I started to make test coverage for all the various ways we have for setting query parameters:

``` rb
conn = Faraday.new 'http://disney.com?a=1', params: {b:2} do |c|
  c.params[:c] = 3
end

conn.get('/?d=4', e: 5) do |req|
  req.url '/?f=6', g: 7
  req.params[:h] = 8
end
```

Yes, 8 different ways to set URL query values. During testing and inspecting the code I realized that there are no ways to remove or overide params during the request phase. Also, there were inconsistencies, e.g. `req.params` was an ordinary hash and not one with indifferent access (Utils::ParamsHash).

This affects `params`, `headers` and `options` in the request phase (the request block). It breaks compatibility for people who performed assignments on these values.
