### PR TITLE
Bracketed nested params in the URI query

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -124,7 +124,7 @@ module Faraday
       end
 
       def to_query
-        Utils.build_query(self)
+        Utils.build_nested_query(self)
       end
 
       private

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -169,6 +169,12 @@ class TestConnection < Faraday::TestCase
     assert_equal "a%5Bb%5D=1+%2B+2", uri.query
   end
 
+  def test_build_url_bracketizes_nested_params_in_query
+    conn = Faraday::Connection.new
+    uri = conn.build_url("http://sushi.com/sake.html", 'a' => {'b' => 'c'})
+    assert_equal "a%5Bb%5D=c", uri.query
+  end
+
   def test_build_url_mashes_default_and_given_params_together
     conn = Faraday::Connection.new 'http://sushi.com/api?token=abc', :params => {'format' => 'json'}
     url = conn.build_url("nigiri?page=1", :limit => 5)


### PR DESCRIPTION
I propose that `Utils.build_nested_query` is used for constructing the query string rather than `Utils.build_query`, as it will better handle nested hashes being passed in as params.

This is similar to the issue raised in #78 - it was argued that the bracket-style syntax for arrays was non-standard, but the the consensus seemed to favor defaulting to the bracket-style (which matches Rack, PHP and jQuery). Also, unlike the with arrays, there is no existing sensible behaviour for nested hashes that this would replace.
