### PR TITLE
Alias Faraday Response #status to #code

### DIFF
--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -42,6 +42,7 @@ module Faraday
     def status
       finished? ? env[:status] : nil
     end
+    alias_method :code, :status
 
     def headers
       finished? ? env[:response_headers] : {}

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -156,6 +156,10 @@ class ResponseTest < Faraday::TestCase
     assert_equal 404, @response.status
   end
 
+  def test_status_code
+    assert_equal 404, @response.code
+  end
+
   def test_body
     assert_equal 'yikes', @response.body
   end


### PR DESCRIPTION
We're using this library in combination with faraday_middleware to sign outgoing ActiveResource requests with an oauth signature. However, net/http expects the response to respond to #code. But, as you know, to get the status code, faraday expects the method #status.

This pull request introduces a simple alias_method (and test!) for compatibility.

Thanks!
