### PR TITLE
Add ability to set options for a Patron::Session and reuse Patron::Session for each 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # faraday [![Build Status](https://secure.travis-ci.org/technoweenie/faraday.png?branch=master)][travis] [![Dependency Status](https://gemnasium.com/technoweenie/faraday.png?travis)][gemnasium]
 Modular HTTP client library that uses middleware. Heavily inspired by Rack.
 
-## Additions on this fork
-
-I have added support to enable cURL's cookie management on the Patron adapter.
-
 [travis]: http://travis-ci.org/technoweenie/faraday
 [gemnasium]: https://gemnasium.com/technoweenie/faraday
 

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -138,7 +138,6 @@ module Faraday
         nil
       }
       yield
-      p 'run!'
       @parallel_manager && @parallel_manager.run
     ensure
       @parallel_manager = nil


### PR DESCRIPTION
Adding two features to the Patron adapter:
- Ability to set options for a Patron::Session
- Reuse Patron::Session between requests on a single Faraday::Connection.

Example:

``` ruby
connection = Faraday.new(:url => url) do |conn|   
  conn.adapter :patron do |session|
    session.handle_cookies
  end
end

connection.post(login_path, {:login => username, :pass => password})  # => Authenticated.
connection.get(target_path)  # => Still authenticated.
```
