### PR TITLE
Fix bug in typhoeus adapter that causes post with body as a hash to fail.

### DIFF
--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -30,7 +30,16 @@ module Faraday
         env[:body] = env[:body].read if env[:body].respond_to? :read
       end
 
+      def convert_body_to_string_if_hash(env)
+        if env[:body].is_a? Hash
+          env[:body] = URI.encode_www_form(env[:body])
+        end
+      end
+
       def request(env)
+
+        convert_body_to_string_if_hash env
+
         req = ::Typhoeus::Request.new env[:url].to_s,
           :method  => env[:method],
           :body    => env[:body],

--- a/test/adapters/typhoeus_test.rb
+++ b/test/adapters/typhoeus_test.rb
@@ -16,5 +16,30 @@ module Adapters
       @connection.get('/world', nil, :user_agent => 'Faraday Agent')
     end
 
+    def test_typhoeus_adapter_can_post_with_hash
+      stub_request(:post, "http://disney.com/world").
+          with(:body => "q=1&x=2").
+          to_return(:status => 200, :body => "", :headers => {})
+
+      conn = Faraday.new(:url => 'http://disney.com') do |b|
+        b.adapter :typhoeus
+      end
+
+      hash = { :q => 1, :x => 2 }
+      conn.post('/world', hash)
+    end
+
+    def test_default_adapter_can_post_with_hash
+      stub_request(:post, "http://disney.com/world").
+          with(:body => {"q"=>"1", "x"=>"2"},
+               :headers => {'Accept'=>'*/*', 'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>'Ruby'}).
+          to_return(:status => 200, :body => "", :headers => {})
+
+      conn = Faraday.new(:url => 'http://disney.com')
+
+      hash = { :q => 1, :x => 2 }
+      conn.post('/world', hash)
+    end
+
   end if defined? ::Typhoeus
 end


### PR DESCRIPTION
Basically I just added a check to see if the post body is a hash, then use URI.encode_www_form to convert it into a string before passing the body into Typhoeus.

I added 2 test cases to demonstrate that the bug is fixed. The first just demonstrates that the default adapter works with the hash body. The second demonstrates that the Typhoeus adapter succeeds after the fix.
