### PR TITLE
Normalize proxy[:user]

### DIFF
--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -37,8 +37,8 @@ module Faraday
               :host => uri.host,
               :port => uri.port
             }
-            if proxy[:username] && proxy[:password]
-              options[:proxy][:authorization] = [proxy[:username], proxy[:password]]
+            if proxy[:user] && proxy[:password]
+              options[:proxy][:authorization] = [proxy[:user], proxy[:password]]
             end
           end
 

--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -75,8 +75,8 @@ module Faraday
 
         req.proxy = "#{proxy[:uri].host}:#{proxy[:uri].port}"
 
-        if proxy[:username] && proxy[:password]
-          req.proxy_username = proxy[:username]
+        if proxy[:user] && proxy[:password]
+          req.proxy_username = proxy[:user]
           req.proxy_password = proxy[:password]
         end
       end


### PR DESCRIPTION
 The Typhoeus and em-synchrony expected proxy[:username] rather than proxy[:user] for proxy authentication.
