### PR TITLE
in connection.rb #get #head && ##delete always passes nil params

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -85,7 +85,7 @@ module Faraday
     %w[get head delete].each do |method|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{method}(url = nil, params = nil, headers = nil)
-          run_request(:#{method}, url, nil, headers) { |request|
+          run_request(:#{method}, url, params, headers) { |request|
             request.params.update(params) if params
             yield request if block_given?
           }


### PR DESCRIPTION
yard docs appear to support it
https://github.com/technoweenie/faraday/blob/master/lib/faraday/connection.rb#L84

but it passes nil regaurdless
https://github.com/technoweenie/faraday/blob/master/lib/faraday/connection.rb#L88

I need delete params support for the github api
http://developer.github.com/v3/users/emails/#delete-email-addresses

I was able to support the api method using run_request directly
https://github.com/rauhryan/ghee/blob/master/lib/ghee/api/emails.rb#L17

I figured I'd send a pull request, seems like an easy fix
all the specs pass for me locally
