### PR TITLE
Remove editor residue from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,3 @@
-## TEXTMATE
-*.tmproj
-tmtags
-
-## EMACS
-*~
-\#*
-.\#*
-
-## VIM
-*.swp
-
-## RUBYMINE
-.idea
-
 ## PROJECT::GENERAL
 coverage
 rdoc


### PR DESCRIPTION
These should be in a user's ~/.gitignore_global

(follow-up to commit 44e53b1)
