### PR TITLE
Add rack-test as runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :test do
   gem 'excon', '~> 0.6'
   gem 'net-http-persistent', '~> 2.5', :require => false
   gem 'leftright', '~> 0.9', :require => false
-  gem 'rack-test', '~> 0.6', :require => 'rack/test'
 end
 
 platforms :ruby do

--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/technoweenie/faraday'
 
   s.add_dependency 'multipart-post', '~> 1.1'
+  s.add_dependency 'rack-test', '~> 0.6'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit'


### PR DESCRIPTION
The new Rack Adapter uses Rack::Test::Session in runtime
