### PR TITLE
Add support for Builder#unshift

### DIFF
--- a/lib/faraday/builder.rb
+++ b/lib/faraday/builder.rb
@@ -136,6 +136,11 @@ module Faraday
       @handlers.delete(handler)
     end
 
+    def unshift(handler, &block)
+      raise_if_locked
+      insert(0, handler, &block)
+    end
+
     private
 
     def raise_if_locked

--- a/test/middleware_stack_test.rb
+++ b/test/middleware_stack_test.rb
@@ -69,6 +69,12 @@ class MiddlewareStackTest < Faraday::TestCase
     assert_handlers %w[Orange]
   end
 
+  def test_unshift_handler
+    build_stack Apple, Orange
+    @builder.unshift Banana
+    assert_handlers %w[Banana Apple Orange]
+  end
+
   def test_stack_is_locked_after_making_requests
     build_stack Apple
     assert !@builder.locked?


### PR DESCRIPTION
After using `builder.insert(0, MyMiddleware)` for a while, I thought something like `builder.unshift(MyMiddleware)` would be prettier. Isn’t it?
