### PR TITLE
Common config to bind local socket

### DIFF
--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -51,6 +51,15 @@ module Faraday
           end
         end
 
+        def configure_socket(options, env)
+          if bind = request_options(env)[:bind]
+            options[:bind] = {
+              :host => bind[:host],
+              :port => bind[:port]
+            }
+          end
+        end
+
         def configure_timeout(options, env)
           timeout, open_timeout = request_options(env).values_at(:timeout, :open_timeout)
           options[:connect_timeout] = options[:inactivity_timeout] = timeout

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -19,7 +19,7 @@ module Faraday
 
       def call(env)
         super
-        request = EventMachine::HttpRequest.new(URI::parse(env[:url].to_s), connection_config(env))        #   end
+        request = EventMachine::HttpRequest.new(URI::parse(env[:url].to_s), connection_config(env))
 
         http_method = env[:method].to_s.downcase.to_sym
 

--- a/test/adapters/em_http_test.rb
+++ b/test/adapters/em_http_test.rb
@@ -10,5 +10,11 @@ module Adapters
       undef :test_timeout
     end
 
+    def test_binds_local_socket
+      host = '1.2.3.4'
+      conn = create_connection :request => { :bind => { :host => host } }
+      #puts conn.get('/who-am-i').body
+      assert_equal host, conn.options[:bind][:host]
+    end
   end
 end

--- a/test/adapters/em_synchrony_test.rb
+++ b/test/adapters/em_synchrony_test.rb
@@ -10,5 +10,11 @@ module Adapters
       undef :test_timeout
     end
 
+    def test_binds_local_socket
+      host = '1.2.3.4'
+      conn = create_connection :request => { :bind => { :host => host } }
+      #put conn.get('/who-am-i').body
+      assert_equal host, conn.options[:bind][:host]
+    end
   end unless RUBY_VERSION < '1.9' or (defined? RUBY_ENGINE and 'jruby' == RUBY_ENGINE)
 end

--- a/test/live_server.rb
+++ b/test/live_server.rb
@@ -35,6 +35,10 @@ class FaradayTestServer < Sinatra::Base
     [200, { 'Set-Cookie' => 'one, two' }, '']
   end
 
+  get '/who-am-i' do
+    request.env['REMOTE_ADDR']
+  end
+
   get '/slow' do
     sleep 10
     [200, {}, 'ok']


### PR DESCRIPTION
Gents:

Long story short: Some HTTP libraries expose the local socket, some don't. I will, in turn, expose the option in Faraday wherever available.

I like igrigorik's naming, so am going with:

``` ruby
request: bind: host: 'foo', port: 'bar'
```

I've done the `EM::Http` libs and will do `Typhoeus` (which only exposes the bind host) shortly. In case you pull in the `HttpClient` adapter, I'll also fix the naming there to make all clean and consistent.

Also, while doing this, it's caught my attention that the fiber `EM::Http` config was broken: All options were shoved into the request config, so the adapter was essentially ignoring proxy, ssl, etc. settings.

I killed the bad config setup in the fiber adapter and shared that of the EM with it. They are essentially the same library, so it makes sense to do so, in any case.
