### PR TITLE
The 'retry' middleware should retry the request only on timeout

### DIFF
--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -1,7 +1,8 @@
 module Faraday
   class Request::Retry < Faraday::Middleware
-    def initialize(app, retries = 2)
+    def initialize(app, retries = 2, options = {})
       @retries = retries
+      @exceptions = options[:on]
       super(app)
     end
 
@@ -9,7 +10,7 @@ module Faraday
       retries = @retries
       begin
         @app.call(env)
-      rescue StandardError, Timeout::Error
+      rescue *@exceptions || Error::TimeoutError
         if retries > 0
           retries -= 1
           retry

--- a/test/middleware/retry_test.rb
+++ b/test/middleware/retry_test.rb
@@ -2,24 +2,55 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "helper"))
 
 module Middleware
   class RetryTest < Faraday::TestCase
-    def setup
-      @stubs = Faraday::Adapter::Test::Stubs.new
-      @conn = Faraday.new do |b|
-        b.request :retry, 2
-        b.adapter :test, @stubs
+    def test_default_exception
+      test_retry { raise Faraday::Error::TimeoutError, 'execution expired' }
+    end
+
+    def test_custom_exception
+      @exceptions = ArgumentError
+
+      test_retry    { raise ArgumentError, 'there has been an error' }
+      test_no_retry { raise Faraday::Error::TimeoutError, 'execution expired' }
+    end
+
+    def test_multiple_custom_exceptions
+      @exceptions = [ArgumentError, Faraday::Error::TimeoutError]
+
+      test_retry { raise ArgumentError, 'there has been an error' }
+      test_retry { raise Faraday::Error::TimeoutError, 'execution expired' }
+    end
+
+    private
+
+    def prepare_new_connection
+      stubs = Faraday::Adapter::Test::Stubs.new
+      stubs.post("/echo") do
+        @times_called += 1
+        yield
+      end
+
+      Faraday.new do |b|
+        b.request :retry, 2, :on => @exceptions
+        b.adapter :test, stubs
       end
     end
 
-    def test_retries
-      times_called = 0
+    def test_retry(&block)
+      @times_called = 0
 
-      @stubs.post("/echo") do
-        times_called += 1
-        raise "Error occurred"
-      end
+      conn = prepare_new_connection(&block)
+      conn.post("/echo") rescue nil
 
-      @conn.post("/echo") rescue nil
-      assert_equal times_called, 3
+      assert_equal 3, @times_called
+    end
+
+    def test_no_retry(&block)
+      @times_called = 0
+
+      conn = prepare_new_connection(&block)
+      conn.post("/echo") rescue nil
+
+      assert_equal 1, @times_called
     end
   end
 end


### PR DESCRIPTION
Before, `StandardError` was also being rescued, which caused a problem that, if you wanted to write your own middleware (that can raise errors), your error wouldn't be properly raised, instead, some primitive `Net::HTTP` error would be raised. Also, it doesn't really make sense to me that it retries after `StandardError`s.

I also corrected a typo, it was rescuing `Timeout::Error` instead of `Error::TimeoutError`.
