### PR TITLE
Cache net_http client

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -74,7 +74,7 @@ module Faraday
       end
 
       def net_http_connection(env)
-        @net_http_connection ||= net_http_connection(env)
+        @net_http_connection ||= fetch_net_http_connection(env)
       end
       
       def fetch_net_http_connection(env)


### PR DESCRIPTION
Would like to use faraday with a connection pool (keep-alive), but need to reuse the request client. If this is accepted I would like to submit more for em_synchrony and em_http_request
