### PR TITLE
use parse_nested_query instead of parse_query

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -126,7 +126,7 @@ module Faraday
 
       def merge_query(query)
         if query && !query.empty?
-          update Utils.parse_query(query)
+          update Utils.parse_nested_query(query)
         end
         self
       end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -372,4 +372,21 @@ class TestRequestParams < Faraday::TestCase
     end
     assert_query_equal %w[b=b], query
   end
+
+  def test_util_parse_params
+    expected = {'colors' => ['red', 'blue']}
+    assert_equal expected, Faraday::Utils.parse_nested_query("colors[]=red&colors[]=blue")
+  end
+
+  def test_array_params_in_url
+    create_connection 'http://a.co/page1?color[]=red&color[]=blue'
+    query = get
+    assert_equal "color%5B%5D=red&color%5B%5D=blue", query
+  end
+
+  def test_array_params_in_params
+    create_connection 'http://a.co/page1', :params => {:color => ['red', 'blue']}
+    query = get
+    assert_equal "color%5B%5D=red&color%5B%5D=blue", query
+  end
 end


### PR DESCRIPTION
when sending url with array parameters, faraday adds additional brackets into the url. so 

``` ruby
'http://a.co/page1?color[]=red&color[]=blue' becomes 
'http://a.co/page1?color[][]=red&color[][]=blue' when request is sent.
```

this patch prevents additional brackets to be added, by calling parse_nested_query instead of parse_query.
