### PR TITLE
Fix Faraday::Middleware::Rack documentation

### DIFF
--- a/lib/faraday/adapter/rack.rb
+++ b/lib/faraday/adapter/rack.rb
@@ -11,7 +11,7 @@ module Faraday
     #   end
     #
     #   Faraday.new do |conn|
-    #     conn.adapter :rack, MyRackApp
+    #     conn.adapter :rack, MyRackApp.new
     #   end
     class Rack < Faraday::Adapter
       dependency 'rack/test'


### PR DESCRIPTION
the adapter needs an actual rack application, so you have to instantiate the MyRackApp.
