### PR TITLE
Bug fixes associated with Faraday::Request#create

### DIFF
--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -95,7 +95,7 @@ module Faraday
         :url              => connection.build_exclusive_url(path, params),
         :request_headers  => headers,
         :parallel_manager => connection.parallel_manager,
-        :request          => options,
+        :request          => options || {},
         :ssl              => connection.ssl}
     end
   end

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -75,6 +75,12 @@ class EnvTest < Faraday::TestCase
     assert_equal request.params, {"a" => "1"}
   end
 
+  def test_request_create_accepts_url_with_query_parameters_set_in_block
+    request = Faraday::Request.create(:get) { |request| request.url('http://sushi.com') }
+    env = request.to_env(@conn)
+    assert_not_nil env[:request]
+  end
+
   private
 
   def make_env(method = :get, connection = @conn, &block)


### PR DESCRIPTION
Bug fixes:
1. Setting a req.url in a block with query parameters currently fails because params is nil in #url and if there are query parameters in the url, it tries to set them on the nil parameter. Updated #create to initialize params.
2. If no options are set, then they are nil and the env[:request] is also nil. This causes any code trying to check for a value on the env[:request]  to raise an error. Solved by returning empty has if options are nil.
