### PR TITLE
Allow non-bracketized param encoding

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -74,8 +74,9 @@ module Faraday
       @headers = Utils::Headers.new
       @params  = Utils::ParamsHash.new
       @options = options[:request] || {}
+      @options[:param_encoding] ||= :nested
       @ssl     = options[:ssl]     || {}
-
+      
       @parallel_manager = nil
       @default_parallel_manager = options[:parallel_manager]
 
@@ -438,19 +439,19 @@ module Faraday
 
       query_values = self.params.dup.merge_query(uri.query)
       query_values.update extra_params if extra_params
-      uri.query = query_values.empty? ? nil : query_values.to_query
+      uri.query = query_values.empty? ? nil : query_values.to_query(options[:param_encoding])
 
       uri
     end
 
     # Internal: Build an absolute URL based on url_prefix.
     #
-    # url    - A String or URI-like object
-    # params - A Faraday::Utils::ParamsHash to replace the query values
-    #          of the resulting url (default: nil).
-    #
+    # url            - A String or URI-like object
+    # params         - A Faraday::Utils::ParamsHash to replace the query values
+    #                  of the resulting url (default: nil).
+    # param_encoding - Scheme for encoding query parameters
     # Returns the resulting URI instance.
-    def build_exclusive_url(url, params = nil)
+    def build_exclusive_url(url, params = nil, param_encoding = nil)
       url = nil if url.respond_to?(:empty?) and url.empty?
       base = url_prefix
       if url and base.path and base.path !~ /\/$/
@@ -458,7 +459,7 @@ module Faraday
         base.path = base.path + '/'  # ensure trailing slash
       end
       uri = url ? base + url : base
-      uri.query = params.to_query if params
+      uri.query = params.to_query(param_encoding) if params
       uri.query = nil if uri.query and uri.query.empty?
       uri
     end

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -91,7 +91,7 @@ module Faraday
     def to_env(connection)
       { :method           => method,
         :body             => body,
-        :url              => connection.build_exclusive_url(path, params),
+        :url              => connection.build_exclusive_url(path, params, options[:param_encoding]),
         :request_headers  => headers,
         :parallel_manager => connection.parallel_manager,
         :request          => options,

--- a/lib/faraday/request/url_encoded.rb
+++ b/lib/faraday/request/url_encoded.rb
@@ -9,7 +9,8 @@ module Faraday
 
     def call(env)
       match_content_type(env) do |data|
-        env[:body] = Faraday::Utils.build_nested_query data
+        params = Faraday::Utils::ParamsHash[data]
+        env[:body] = params.to_query(env[:request][:param_encoding])
       end
       @app.call env
     end

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -131,8 +131,12 @@ module Faraday
         self
       end
 
-      def to_query
-        Utils.build_nested_query(self)
+      def to_query(encoding=nil)
+        if encoding == :nested
+          Utils.build_nested_query(self)
+        else
+          Utils.build_query(self)
+        end
       end
 
       private
@@ -219,7 +223,12 @@ module Faraday
       return if k.empty?
 
       if after == ""
-        params[k] = v
+        if params[k]
+          params[k] = Array[params[k]] unless params[k].kind_of?(Array)
+          params[k] << v 
+        else
+          params[k] = v
+        end
       elsif after == "[]"
         params[k] ||= []
         raise TypeError, "expected Array (got #{params[k].class.name}) for param `#{k}'" unless params[k].is_a?(Array)

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -191,6 +191,13 @@ class TestConnection < Faraday::TestCase
     assert_equal "a%5Bb%5D=c", uri.query
   end
 
+  def test_build_url_without_braketizing_params_in_query
+    conn = Faraday::Connection.new
+    conn.options[:param_encoding] = nil
+    uri = conn.build_url("http://sushi.com/sake.html", 'a' => [1, 2])
+    assert_equal "a=1&a=2", uri.query
+  end
+
   def test_build_url_parses_url
     conn = Faraday::Connection.new
     uri = conn.build_url("http://sushi.com/sake.html")

--- a/test/request_middleware_test.rb
+++ b/test/request_middleware_test.rb
@@ -48,6 +48,15 @@ class RequestMiddlewareTest < Faraday::TestCase
     assert_equal expected, Faraday::Utils.parse_nested_query(response.body)
   end
 
+  def test_url_encoded_non_nested
+    response = @conn.post('/echo', { :dimensions => ['date', 'location']}) do |req|
+      req.options[:param_encoding] = nil
+    end
+    assert_equal 'application/x-www-form-urlencoded', response.headers['Content-Type']
+    expected = { 'dimensions' => ['date', 'location'] }
+    assert_equal expected, Faraday::Utils.parse_nested_query(response.body)
+  end
+  
   def test_url_encoded_unicode
     err = capture_warnings {
       response = @conn.post('/echo', {:str => "eé cç aã aâ"})


### PR DESCRIPTION
Fixes technoweenie/faraday#78. Left the default to nested param encoding, but can be set on connection or per-request basis by setting options[:param_encoding] to anything other than the default :nested value.
