### PR TITLE
manifest list updated against files in lib/faraday/

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -36,7 +36,9 @@ Gem::Specification.new do |s|
     lib/faraday/adapter/rack.rb
     lib/faraday/adapter/test.rb
     lib/faraday/adapter/typhoeus.rb
-    lib/faraday/builder.rb
+    lib/faraday/rack_builder.rb
+    lib/faraday/parameters.rb
+    lib/faraday/options.rb
     lib/faraday/connection.rb
     lib/faraday/error.rb
     lib/faraday/middleware.rb


### PR DESCRIPTION
The latest list of files in the manifest list in the Gemspec contains
three new files: options.rb, parameters.rb, rack_builder.rb.
The rack_builder.rb is present in the place builder.rb. Without this
list, the command 'gem build faraday.gemspec' fails when trying to 
install the gem from source.
