### PR TITLE
Support Errno::ENETUNREACH

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -13,6 +13,7 @@ module Faraday
         EOFError,
         Errno::ECONNABORTED,
         Errno::ECONNREFUSED,
+        Errno::ENETUNREACH,
         Errno::ECONNRESET,
         Errno::EINVAL,
         Net::HTTPBadResponse,


### PR DESCRIPTION
This can happen in a number of cases, a good example is when your stack
tries to make an IPv6 connection and it is not possible.
