### PR TITLE
Add support for headers to the test adapter

### DIFF
--- a/test/adapters/test_middleware_test.rb
+++ b/test/adapters/test_middleware_test.rb
@@ -41,6 +41,13 @@ module Adapters
       end
     end
 
+    def test_middleware_with_http_headers
+      @stubs.get('/yo', { 'X-HELLO' => 'hello' }) { [200, {}, 'a'] }
+      @stubs.get('/yo') { [200, {}, 'b'] }
+      assert_equal 'a', @conn.get('/yo') { |env| env.headers['X-HELLO'] = 'hello' }.body
+      assert_equal 'b', @conn.get('/yo').body
+    end
+
     def test_middleware_allow_different_outcomes_for_the_same_request
       @stubs.get('/hello') { [200, {'Content-Type' => 'text/html'}, 'hello'] }
       @stubs.get('/hello') { [200, {'Content-Type' => 'text/html'}, 'world'] }
@@ -64,6 +71,13 @@ module Adapters
     def test_raises_an_error_if_no_stub_is_found_for_request
       assert_raises Faraday::Adapter::Test::Stubs::NotFound do
         @conn.get('/invalid'){ [200, {}, []] }
+      end
+    end
+
+    def test_raises_an_error_if_no_stub_is_found_for_request_without_this_header
+      @stubs.get('/yo', { 'X-HELLO' => 'hello' }) { [200, {}, 'a'] }
+      assert_raises Faraday::Adapter::Test::Stubs::NotFound do
+        @conn.get('/yo')
       end
     end
   end


### PR DESCRIPTION
Makes it possible to test for request headers with the test adapter. The second argument to Faraday::Adapter::Test::Stubs#get is a hash of request headers and their values.
