### PR TITLE
Convert Env keys to symbols

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -67,7 +67,7 @@ module Faraday
       hash = {}
       members.each do |key|
         value = send(key)
-        hash[key] = value if value
+        hash[key.to_sym] = value if value
       end
       hash
     end

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -184,6 +184,9 @@ class ResponseTest < Faraday::TestCase
     hash = @response.to_hash
     assert_kind_of Hash, hash
     assert_equal @env.to_hash, hash
+    assert_equal hash[:status], @response.status
+    assert_equal hash[:response_headers], @response.headers
+    assert_equal hash[:body], @response.body
   end
 end
 


### PR DESCRIPTION
Just for a smoother upgrade path on 1.8, where `Struct#members` is an Array of Strings instead of Symbols.
