### PR TITLE
Add support for no_proxy environment variable when using http_proxy

### DIFF
--- a/lib/faraday/autoload.rb
+++ b/lib/faraday/autoload.rb
@@ -73,7 +73,8 @@ module Faraday
       :Authorization => 'authorization',
       :BasicAuthentication => 'basic_authentication',
       :TokenAuthentication => 'token_authentication',
-      :Instrumentation => 'instrumentation'
+      :Instrumentation => 'instrumentation',
+      :Proxy => 'proxy'
   end
 
   class Response

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -50,7 +50,6 @@ module Faraday
     #           :request - Hash of request options.
     #           :ssl     - Hash of SSL options.
     #           :proxy   - URI, String or Hash of HTTP proxy options
-    #                     (default: "http_proxy" environment variable).
     #                     :uri      - URI or String
     #                     :user     - String (optional)
     #                     :password - String (optional)
@@ -79,7 +78,7 @@ module Faraday
       @params.update(options.params)   if options.params
       @headers.update(options.headers) if options.headers
 
-      proxy(options.fetch(:proxy)) if options.include?(:proxy)
+      proxy(options.fetch(:proxy)) if options.proxy
 
       yield self if block_given?
 

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -79,14 +79,7 @@ module Faraday
       @params.update(options.params)   if options.params
       @headers.update(options.headers) if options.headers
 
-      @proxy = nil
-      proxy(options.fetch(:proxy) {
-        uri = ENV['http_proxy']
-        if uri && !uri.empty?
-          uri = 'http://' + uri if uri !~ /^http/i
-          uri
-        end
-      })
+      proxy(options.fetch(:proxy)) if options.include?(:proxy)
 
       yield self if block_given?
 
@@ -278,10 +271,12 @@ module Faraday
       @parallel_manager = nil
     end
 
-    # Public: Gets or Sets the Hash proxy options.
+    # Public: Mounts proxy middleware
     def proxy(arg = nil)
-      return @proxy if arg.nil?
-      @proxy = ProxyOptions.from(arg)
+      # dont allow middleware to be set multiple times
+      unless builder.handlers.include?(Faraday::Request::Proxy)
+        builder.use Request::Proxy, arg
+      end
     end
 
     def_delegators :url_prefix, :scheme, :scheme=, :host, :host=, :port, :port=
@@ -371,7 +366,7 @@ module Faraday
         req.body = body             if body
         yield req if block_given?
       end
-
+      
       builder.build_response(self, request)
     end
 
@@ -382,7 +377,7 @@ module Faraday
       Request.create(method) do |req|
         req.params  = self.params.dup
         req.headers = self.headers.dup
-        req.options = self.options.merge(:proxy => self.proxy)
+        req.options = self.options.dup
         yield req if block_given?
       end
     end

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -19,7 +19,8 @@ module Faraday
       :authorization => [:Authorization, 'authorization'],
       :basic_auth => [:BasicAuthentication, 'basic_authentication'],
       :token_auth => [:TokenAuthentication, 'token_authentication'],
-      :instrumentation => [:Instrumentation, 'instrumentation']
+      :instrumentation => [:Instrumentation, 'instrumentation'],
+      :proxy => [:Proxy, 'proxy']
 
     def self.create(request_method)
       new(request_method).tap do |request|

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -112,7 +112,7 @@ module Faraday
           no_proxy_pattern  = "#{no_proxy_domain.host}:#{no_proxy_domain.port}"
         end
         
-        if uri_pattern.match(/#{Regexp.quote(no_proxy_pattern)}$/i)
+        if uri_pattern.downcase == no_proxy_pattern.downcase
           proxy_required = false
           break
         end

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -1,0 +1,131 @@
+module Faraday
+  # Uses Environment variables to set proxies on a per-connection basis.
+  #
+  # If a proxy is not explicitly set, the following environment variables
+  # are used (lower case instances are used in the absence of upper case equivalents).
+  #   HTTP_PROXY, HTTPS_PROXY, NO_PROXY
+  #
+  # The NO_PROXY list specifies a comma-separated list of domains 
+  # (and optionally ports) for which the proxy should not be used.
+  #
+  # Examples:
+  # # uses environment variables
+  # Faraday.new do |conn|
+  #   conn.request :proxy
+  #   conn.adapter ..
+  # end
+  #
+  # # ignores environment variables
+  # Faraday.new do |conn|
+  #   conn.request :proxy 'http://my.proxy.com', /
+  #                :user => 'dan', :password => '123' 
+  #   conn.adapter ..
+  # end
+  class Request::Proxy < Faraday::Middleware
+    Proxies = Struct.new(:http, :https)
+
+    def initialize(app, proxy_url=nil, options={})
+      @proxies = Proxies.new
+      parse_proxy_options(proxy_url, options)
+      super(app)
+    end
+    
+    def call(env)
+      env[:request][:proxy] = proxy_for(env.url)
+      @app.call(env)
+    end
+    
+    private
+    def parse_proxy_options(proxy, options)
+      parse_proxies(proxy, options)
+      parse_no_proxy_list
+    end
+
+    def parse_proxies(uri=nil, options={})
+      proxy = parse_uri(uri)
+
+      case proxy.scheme
+      when 'http'
+        @proxies[:http]  = parse_proxy_uri('http_proxy',  uri, options)
+      when 'https'
+        @proxies[:https] = parse_proxy_uri('https_proxy', uri, options)
+      when nil
+        # set both proxies according to ENV variables
+        @proxies[:http]  = parse_proxy_uri('http_proxy',  nil, options)
+        @proxies[:https] = parse_proxy_uri('https_proxy', nil, options)
+      else
+        raise ::TypeError, \
+          "#{uri} is not a http(s) proxy URL."
+      end
+    end
+
+    def parse_proxy_uri(proxy_type, uri, options)
+      proxy = uri || ENV[proxy_type.upcase] || ENV[proxy_type.downcase]
+
+      proxy_uri = parse_uri(proxy)
+
+      if options.include?(:user)
+        proxy_uri.user = options[:user]
+      end
+
+      if options.include?(:password)
+        proxy_uri.password = options[:password]
+      end
+
+      proxy_uri = nil if proxy_uri.scheme == nil
+
+      proxy_uri
+    end
+
+    def parse_no_proxy_list
+      proxy_list = ENV['NO_PROXY'] || ENV['no_proxy']
+      @no_proxy = proxy_list.split(',') rescue false
+    end
+
+    def proxy_for(uri)
+      {:uri => @proxies[uri.scheme]} if proxy_allowed_for(uri)
+    end
+
+    def proxy_allowed_for(uri)
+      return false unless @proxies[uri.scheme]
+      return true  unless @no_proxy
+
+      proxy_required = true
+
+      @no_proxy.each do |no_proxy_domain|
+        # ignore wildcards in domain
+        no_proxy_domain = no_proxy_domain.gsub('*.','')
+        no_proxy_domain = parse_uri(no_proxy_domain)
+
+        if no_proxy_domain.port == 80
+          # domain matching is fine
+          uri_pattern       = uri.host
+          no_proxy_pattern  = no_proxy_domain.host
+        else
+          # need to match ports exactly
+          uri_pattern       = "#{uri.host}:#{uri.port}"
+          no_proxy_pattern  = "#{no_proxy_domain.host}:#{no_proxy_domain.port}"
+        end
+        
+        if uri_pattern.match(/#{Regexp.quote(no_proxy_pattern)}$/i)
+          proxy_required = false
+          break
+        end
+      end
+
+      proxy_required
+    end
+
+    def parse_uri(uri='')
+      uri = uri.to_s
+      parsed = Utils::URI(uri)
+
+      # assume strings without scheme are of http
+      if parsed.class == URI::Generic && !uri.empty?
+        parsed = Utils::URI("http://#{uri}")
+      end
+
+      parsed
+    end
+  end
+end

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -101,7 +101,7 @@ module Faraday
         # ignore wildcards in domain
         no_proxy_uri = no_proxy_domain.gsub('*.','')
 
-        if domains_match? uri, no_proxy_uri
+        if domains_match? uri, parse_uri(no_proxy_uri)
           proxy_required = false
           break
         end
@@ -111,16 +111,14 @@ module Faraday
     end
 
     def domains_match?(uri, no_proxy_uri)
-      no_proxy_domain = parse_uri(no_proxy_uri)
-
-      if no_proxy_domain.port == 80
+      if no_proxy_uri.port == 80
         # domain matching is fine
         uri_pattern       = uri.host
-        no_proxy_pattern  = no_proxy_domain.host
+        no_proxy_pattern  = no_proxy_uri.host
       else
         # need to match ports exactly
         uri_pattern       = "#{uri.host}:#{uri.port}"
-        no_proxy_pattern  = "#{no_proxy_domain.host}:#{no_proxy_domain.port}"
+        no_proxy_pattern  = "#{no_proxy_uri.host}:#{no_proxy_uri.port}"
       end
 
       uri_pattern.downcase == no_proxy_pattern.downcase

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -87,6 +87,7 @@ module Faraday
     end
 
     def proxy_allowed_for(uri)
+      return true  if uri.nil? || uri.host.nil?
       return false unless @proxies[uri.scheme]
       return true  unless @no_proxy
 

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -99,26 +99,31 @@ module Faraday
 
       @no_proxy.each do |no_proxy_domain|
         # ignore wildcards in domain
-        no_proxy_domain = no_proxy_domain.gsub('*.','')
-        no_proxy_domain = parse_uri(no_proxy_domain)
+        no_proxy_uri = no_proxy_domain.gsub('*.','')
 
-        if no_proxy_domain.port == 80
-          # domain matching is fine
-          uri_pattern       = uri.host
-          no_proxy_pattern  = no_proxy_domain.host
-        else
-          # need to match ports exactly
-          uri_pattern       = "#{uri.host}:#{uri.port}"
-          no_proxy_pattern  = "#{no_proxy_domain.host}:#{no_proxy_domain.port}"
-        end
-        
-        if uri_pattern.downcase == no_proxy_pattern.downcase
+        if domains_match? uri, no_proxy_uri
           proxy_required = false
           break
         end
       end
 
       proxy_required
+    end
+
+    def domains_match?(uri, no_proxy_uri)
+      no_proxy_domain = parse_uri(no_proxy_uri)
+
+      if no_proxy_domain.port == 80
+        # domain matching is fine
+        uri_pattern       = uri.host
+        no_proxy_pattern  = no_proxy_domain.host
+      else
+        # need to match ports exactly
+        uri_pattern       = "#{uri.host}:#{uri.port}"
+        no_proxy_pattern  = "#{no_proxy_domain.host}:#{no_proxy_domain.port}"
+      end
+
+      uri_pattern.downcase == no_proxy_pattern.downcase
     end
 
     def parse_uri(uri='')

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -22,10 +22,8 @@ module Faraday
   #   conn.adapter ..
   # end
   class Request::Proxy < Faraday::Middleware
-    Proxies = Struct.new(:http, :https)
-
     def initialize(app, proxy_url=nil, options={})
-      @proxies = Proxies.new
+      @proxies = {:http => nil, :https => nil}
       parse_proxy_options(proxy_url, options)
       super(app)
     end
@@ -88,12 +86,12 @@ module Faraday
     end
 
     def proxy_for(uri)
-      {:uri => @proxies[uri.scheme]} if proxy_allowed_for(uri)
+      {:uri => @proxies[uri.scheme.to_sym]} if proxy_allowed_for(uri)
     end
 
     def proxy_allowed_for(uri)
       return true  if uri.nil? || uri.host.nil?
-      return false unless @proxies[uri.scheme]
+      return false unless @proxies[uri.scheme.to_sym]
       return true  unless @no_proxy
 
       proxy_required = true

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -37,6 +37,11 @@ module Faraday
     
     private
     def parse_proxy_options(proxy, options)
+      if proxy.is_a?(Hash)
+        options = proxy
+        proxy = options.delete(:uri)
+      end
+
       parse_proxies(proxy, options)
       parse_no_proxy_list
     end

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -81,8 +81,9 @@ module Faraday
     end
 
     def parse_no_proxy_list
+      @no_proxy ||= nil
       proxy_list = ENV['NO_PROXY'] || ENV['no_proxy']
-      @no_proxy = proxy_list.split(',') rescue false
+      @no_proxy = proxy_list.split(',') unless proxy_list.nil?
     end
 
     def proxy_for(uri)

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -2,37 +2,38 @@ module Faraday
   # Uses Environment variables to set proxies on a per-connection basis.
   #
   # If a proxy is not explicitly set, the following environment variables
-  # are used (lower case instances are used in the absence of upper case equivalents).
+  # are used:
   #   HTTP_PROXY, HTTPS_PROXY, NO_PROXY
+  # (lower case instances are used in the absence of upper case equivalents)
   #
-  # The NO_PROXY list specifies a comma-separated list of domains 
+  # The NO_PROXY list specifies a comma-separated list of domains
   # (and optionally ports) for which the proxy should not be used.
   #
   # Examples:
-  # # uses environment variables
-  # Faraday.new do |conn|
-  #   conn.request :proxy
-  #   conn.adapter ..
-  # end
+  #   # uses environment variables
+  #   Faraday.new do |conn|
+  #     conn.request :proxy
+  #     conn.adapter ..
+  #   end
   #
-  # # ignores environment variables
-  # Faraday.new do |conn|
-  #   conn.request :proxy 'http://my.proxy.com', /
-  #                :user => 'dan', :password => '123' 
-  #   conn.adapter ..
-  # end
+  #   # ignores environment variables
+  #   Faraday.new do |conn|
+  #     conn.request :proxy 'http://my.proxy.com', /
+  #                  :user => 'dan', :password => '123'
+  #     conn.adapter ..
+  #   end
   class Request::Proxy < Faraday::Middleware
     def initialize(app, proxy_url=nil, options={})
       @proxies = {:http => nil, :https => nil}
       parse_proxy_options(proxy_url, options)
       super(app)
     end
-    
+
     def call(env)
       env[:request][:proxy] = proxy_for(env.url)
       @app.call(env)
     end
-    
+
     private
     def parse_proxy_options(proxy, options)
       if proxy.is_a?(Hash)

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -2,21 +2,6 @@ require File.expand_path('../helper', __FILE__)
 require 'minitest/mock'
 
 class TestConnection < Faraday::TestCase
-
-  def with_env(key, proxy)
-    old_value = ENV.fetch(key, false)
-    ENV[key] = proxy
-    begin
-      yield
-    ensure
-      if old_value == false
-        ENV.delete key
-      else
-        ENV[key] = old_value
-      end
-    end
-  end
-
   def test_initialize_parses_host_out_of_given_url
     conn = Faraday::Connection.new "http://sushi.com"
     assert_equal 'sushi.com', conn.host
@@ -281,42 +266,6 @@ class TestConnection < Faraday::TestCase
 
     conn.proxy 'http://proxy.com'
     assert conn.builder.handlers.include?(Faraday::Request::Proxy)
-  end
-
-  def test_proxy_accepts_env_without_scheme
-    with_env 'http_proxy', "localhost:8888" do
-      uri = Faraday::Connection.new.proxy[:uri]
-      assert_equal 'localhost', uri.host
-      assert_equal 8888, uri.port
-    end
-  end
-
-  def test_no_proxy_from_env
-    with_env 'http_proxy', nil do
-      conn = Faraday::Connection.new
-      assert_equal nil, conn.proxy
-    end
-  end
-
-  def test_no_proxy_from_blank_env
-    with_env 'http_proxy', '' do
-      conn = Faraday::Connection.new
-      assert_equal nil, conn.proxy
-    end
-  end
-
-  def test_proxy_doesnt_accept_uppercase_env
-    with_env 'HTTP_PROXY', "http://localhost:8888/" do
-      conn = Faraday::Connection.new
-      assert_nil conn.proxy
-    end
-  end
-
-  def test_proxy_requires_uri
-    conn = Faraday::Connection.new
-    assert_raises ArgumentError do
-      conn.proxy :uri => :bad_uri, :user => 'rick'
-    end
   end
 
   def test_dups_connection_object

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -9,7 +9,6 @@ class EnvTest < Faraday::TestCase
     @conn.options.timeout      = 3
     @conn.options.open_timeout = 5
     @conn.ssl.verify           = false
-    @conn.proxy 'http://proxy.com'
   end
 
   def test_request_create_stores_method
@@ -63,11 +62,6 @@ class EnvTest < Faraday::TestCase
   def test_request_create_stores_ssl_options
     env = make_env
     assert_equal false, env.ssl.verify
-  end
-
-  def test_request_create_stores_proxy_options
-    env = make_env
-    assert_equal 'proxy.com', env.request.proxy.host
   end
 
   private

--- a/test/proxy_middleware_test.rb
+++ b/test/proxy_middleware_test.rb
@@ -117,6 +117,23 @@ class ProxyMiddlewareTest < Faraday::TestCase
     assert_equal 'pass',      proxy_options.password
   end
 
+  def test_http_proxy_with_encoded_username_and_password
+    conn = connection { |b| b.request :proxy, 
+      {
+        :uri => 'http://proxy.com', 
+        :user => '%27username%27',
+        :password => '%27password%27' 
+      }
+    }
+    response = conn.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'proxy.com', proxy_options.uri.host
+    assert_equal "'username'",  proxy_options.user
+    assert_equal "'password'",      proxy_options.password
+  end
+
   def test_upper_case_env_trumps_lower_case
     with_env 'http_proxy' => 'http://proxy.com', 'HTTP_PROXY' => 'http://upper.proxy.com' do
       response = connection { |b| b.request :proxy }.get('/test')

--- a/test/proxy_middleware_test.rb
+++ b/test/proxy_middleware_test.rb
@@ -1,32 +1,43 @@
 require File.expand_path('../helper', __FILE__)
 
 class ProxyMiddlewareTest < Faraday::TestCase
-  def setup
-    # clear any proxy environment variables
-    @backup_envs = {}
-    proxy_envs = %w{http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY}
-    proxy_envs.each {|key| @backup_envs[key] = ENV.delete(key) }
-  end
-  
-  def teardown
-    # ...and put them back again
-    @backup_envs.each {|key, value| ENV[key] = value }
+  def with_env(new_env)
+    old_env = {}
+
+    new_env.each do |key, value|
+      old_env[key] = ENV.fetch(key, false)
+      ENV[key] = value
+    end
+
+    begin
+      yield
+    ensure
+      old_env.each do |key, value|
+        if value == false
+          ENV.delete key
+        else
+          ENV[key] = value
+        end
+      end
+    end
   end
 
   def connection(url='http://example.com')
     Faraday.new(url) do |builder|
       yield builder
       builder.adapter :test do |stub|
-        stub.get('/test') {[ 200, {}, 'shrimp' ]}
+        stub.get('/test') {[ 200, {}, '' ]}
       end
     end
   end
 
   def test_no_proxy_set_by_default
-    response = connection{ |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => nil, 'http_proxy' => nil do
+      response = connection{ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    assert_nil proxy_options
+      assert_nil proxy_options
+    end
   end
 
   def test_raise_when_non_http_or_https_proxy_passed_in
@@ -35,32 +46,35 @@ class ProxyMiddlewareTest < Faraday::TestCase
   end
 
   def test_http_proxy_in_env_is_set
-    ENV['http_proxy'] = 'http://proxy.com'
-    response = connection { |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => nil, 'http_proxy' => 'http://proxy.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    refute_nil proxy_options
-    assert_equal 'http://proxy.com', proxy_options.uri.to_s
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
   end
 
   def test_http_proxy_with_username_and_password
-    ENV['http_proxy'] = 'http://username:pass@proxy.com'
-    response = connection { |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => nil, 'http_proxy' => 'http://username:pass@proxy.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    refute_nil proxy_options
-    assert_equal 'proxy.com', proxy_options.uri.host
-    assert_equal 'username',  proxy_options.user
-    assert_equal 'pass',      proxy_options.password
+      refute_nil proxy_options
+      assert_equal 'proxy.com', proxy_options.uri.host
+      assert_equal 'username',  proxy_options.user
+      assert_equal 'pass',      proxy_options.password
+    end
   end
 
   def test_http_proxy_in_env_is_set_in_upper_case
-    ENV['HTTP_PROXY'] = 'http://proxy.com'
-    response = connection { |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'http_proxy' => nil do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    refute_nil proxy_options
-    assert_equal 'http://proxy.com', proxy_options.uri.to_s
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
   end
 
   def test_http_proxy_set_explicitly
@@ -86,107 +100,107 @@ class ProxyMiddlewareTest < Faraday::TestCase
   end
 
   def test_upper_case_env_trumps_lower_case
-    ENV['http_proxy'] = 'http://proxy.com'
-    ENV['HTTP_PROXY'] = 'http://upper.proxy.com'
-    response = connection { |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'http_proxy' => 'http://proxy.com', 'HTTP_PROXY' => 'http://upper.proxy.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    refute_nil proxy_options
-    assert_equal 'http://upper.proxy.com', proxy_options.uri.to_s
+      refute_nil proxy_options
+      assert_equal 'http://upper.proxy.com', proxy_options.uri.to_s
+    end
   end
 
   def test_explicit_proxy_trumps_env
-    ENV['HTTP_PROXY'] = 'http://env.proxy.com'
-    conn = connection { |b| b.request :proxy, 'http://ex.proxy.com' }
-    response = conn.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => 'http://env.proxy.com' do
+      conn = connection { |b| b.request :proxy, 'http://ex.proxy.com' }
+      response = conn.get('/test')
+      proxy_options = response.env.request.proxy
 
-    refute_nil proxy_options
-    assert_equal 'http://ex.proxy.com', proxy_options.uri.to_s
+      refute_nil proxy_options
+      assert_equal 'http://ex.proxy.com', proxy_options.uri.to_s
+    end
   end
 
   def test_proxy_set_and_url_in_no_proxy_list_removes_proxy
-    ENV['http_proxy'] = 'http://proxy.com'
-    ENV['no_proxy']   = 'example.com'
-    response = connection { |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    assert_nil proxy_options
+      assert_nil proxy_options
+    end
   end
 
   def test_proxy_set_and_url_not_in_no_proxy_list_sets_proxy
-    ENV['http_proxy'] = 'http://proxy.com'
-    ENV['no_proxy']   = 'example2.com'
-    response = connection { |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example2.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    refute_nil proxy_options
-    assert_equal 'http://proxy.com', proxy_options.uri.to_s
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
   end
 
   def test_proxy_set_in_multi_element_no_proxy_list
-    ENV['http_proxy'] = 'http://proxy.com'
-    ENV['no_proxy']   = 'example0.com,example.com,example1.com'
-    response = connection { |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example0.com,example.com,example1.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    assert_nil proxy_options
+      assert_nil proxy_options
+    end
   end
 
   def test_proxy_ignored_when_ports_match_in_no_proxy_list
-    ENV['http_proxy'] = 'http://proxy.com'
-    ENV['no_proxy']   = 'example.com:7171'
-    response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example.com:7171' do
+      response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    assert_nil proxy_options
+      assert_nil proxy_options
+    end
   end
 
   def test_proxy_ignored_when_port_is_not_set_in_no_proxy_list
-    ENV['http_proxy'] = 'http://proxy.com'
-    ENV['no_proxy']   = 'example.com'
-    response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example.com' do
+      response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    assert_nil proxy_options
+      assert_nil proxy_options
+    end
   end
 
   def test_proxy_set_when_ports_mismatch_in_no_proxy_list
-    ENV['http_proxy'] = 'http://proxy.com'
-    ENV['no_proxy']   = 'example.com:3000'
-    response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example.com:3000' do
+      response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    refute_nil proxy_options
-    assert_equal 'http://proxy.com', proxy_options.uri.to_s
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
   end
 
   def test_https_proxy_set_given_https_url
-    ENV['https_proxy'] = 'https://ssl.proxy.com'
-    response = connection('https://example.com'){ |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
+    with_env 'HTTPS_PROXY' => 'https://ssl.proxy.com' do
+      response = connection('https://example.com'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    refute_nil proxy_options
-    assert_equal 'https://ssl.proxy.com', proxy_options.uri.to_s
+      refute_nil proxy_options
+      assert_equal 'https://ssl.proxy.com', proxy_options.uri.to_s
+    end
   end
 
   def test_https_ignored_given_match_in_no_proxy_list
-    ENV['https_proxy'] = 'https://ssl.proxy.com'
-    ENV['no_proxy'] = 'example.com'
+    with_env 'HTTPS_PROXY' => 'https://ssl.proxy.com', 'NO_PROXY' => 'example.com' do
+      response = connection('https://example.com'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    response = connection('https://example.com'){ |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
-
-    assert_nil proxy_options
+      assert_nil proxy_options
+    end
   end
 
   def test_https_ignored_when_http_url_requested
-    ENV['https_proxy'] = 'https://ssl.proxy.com'
+    with_env 'http_proxy' => nil, 'HTTP_PROXY' => nil, 'HTTPS_PROXY' => 'https://ssl.proxy.com' do
+      response = connection('http://example.com'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
 
-    response = connection('http://example.com'){ |b| b.request :proxy }.get('/test')
-    proxy_options = response.env.request.proxy
-
-    assert_nil proxy_options
+      assert_nil proxy_options
+    end
   end
-
 end

--- a/test/proxy_middleware_test.rb
+++ b/test/proxy_middleware_test.rb
@@ -99,6 +99,24 @@ class ProxyMiddlewareTest < Faraday::TestCase
     assert_equal 'pass',      proxy_options.password
   end
 
+  # this is to allow connection#proxy to behave as before
+  def test_http_proxy_set_via_hash
+    conn = connection { |b| b.request :proxy, 
+      {
+        :uri => 'http://proxy.com', 
+        :user => 'username',
+        :password => 'pass' 
+      }
+    }
+    response = conn.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'proxy.com', proxy_options.uri.host
+    assert_equal 'username',  proxy_options.user
+    assert_equal 'pass',      proxy_options.password
+  end
+
   def test_upper_case_env_trumps_lower_case
     with_env 'http_proxy' => 'http://proxy.com', 'HTTP_PROXY' => 'http://upper.proxy.com' do
       response = connection { |b| b.request :proxy }.get('/test')

--- a/test/proxy_middleware_test.rb
+++ b/test/proxy_middleware_test.rb
@@ -35,7 +35,6 @@ class ProxyMiddlewareTest < Faraday::TestCase
     with_env 'HTTP_PROXY' => nil, 'http_proxy' => nil do
       response = connection{ |b| b.request :proxy }.get('/test')
       proxy_options = response.env.request.proxy
-      # assert proxy_options.is_a?(Faraday::ProxyOptions)
 
       assert_nil proxy_options
     end

--- a/test/proxy_middleware_test.rb
+++ b/test/proxy_middleware_test.rb
@@ -35,6 +35,7 @@ class ProxyMiddlewareTest < Faraday::TestCase
     with_env 'HTTP_PROXY' => nil, 'http_proxy' => nil do
       response = connection{ |b| b.request :proxy }.get('/test')
       proxy_options = response.env.request.proxy
+      # assert proxy_options.is_a?(Faraday::ProxyOptions)
 
       assert_nil proxy_options
     end
@@ -169,6 +170,16 @@ class ProxyMiddlewareTest < Faraday::TestCase
   def test_proxy_set_when_ports_mismatch_in_no_proxy_list
     with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example.com:3000' do
       response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
+  end
+
+  def test_proxy_set_when_url_is_nil
+    with_env 'HTTP_PROXY' => 'http://proxy.com' do
+      response = connection(nil){ |b| b.request :proxy }.get('/test')
       proxy_options = response.env.request.proxy
 
       refute_nil proxy_options

--- a/test/proxy_middleware_test.rb
+++ b/test/proxy_middleware_test.rb
@@ -1,0 +1,192 @@
+require File.expand_path('../helper', __FILE__)
+
+class ProxyMiddlewareTest < Faraday::TestCase
+  def setup
+    # clear any proxy environment variables
+    @backup_envs = {}
+    proxy_envs = %w{http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY}
+    proxy_envs.each {|key| @backup_envs[key] = ENV.delete(key) }
+  end
+  
+  def teardown
+    # ...and put them back again
+    @backup_envs.each {|key, value| ENV[key] = value }
+  end
+
+  def connection(url='http://example.com')
+    Faraday.new(url) do |builder|
+      yield builder
+      builder.adapter :test do |stub|
+        stub.get('/test') {[ 200, {}, 'shrimp' ]}
+      end
+    end
+  end
+
+  def test_no_proxy_set_by_default
+    response = connection{ |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    assert_nil proxy_options
+  end
+
+  def test_raise_when_non_http_or_https_proxy_passed_in
+    conn = connection('http://example.com'){ |b| b.request :proxy, 'ftp://example.com'}
+    assert_raises TypeError do conn.get('/test') end
+  end
+
+  def test_http_proxy_in_env_is_set
+    ENV['http_proxy'] = 'http://proxy.com'
+    response = connection { |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'http://proxy.com', proxy_options.uri.to_s
+  end
+
+  def test_http_proxy_with_username_and_password
+    ENV['http_proxy'] = 'http://username:pass@proxy.com'
+    response = connection { |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'proxy.com', proxy_options.uri.host
+    assert_equal 'username',  proxy_options.user
+    assert_equal 'pass',      proxy_options.password
+  end
+
+  def test_http_proxy_in_env_is_set_in_upper_case
+    ENV['HTTP_PROXY'] = 'http://proxy.com'
+    response = connection { |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'http://proxy.com', proxy_options.uri.to_s
+  end
+
+  def test_http_proxy_set_explicitly
+    conn = connection { |b| b.request :proxy, 'http://proxy.com' }
+    response = conn.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'http://proxy.com', proxy_options.uri.to_s
+  end
+
+  def test_http_proxy_set_explicitly_with_username_and_password
+    conn = connection { |b| b.request :proxy, 'http://proxy.com', 
+                                      :user => 'username',
+                                      :password => 'pass' }
+    response = conn.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'proxy.com', proxy_options.uri.host
+    assert_equal 'username',  proxy_options.user
+    assert_equal 'pass',      proxy_options.password
+  end
+
+  def test_upper_case_env_trumps_lower_case
+    ENV['http_proxy'] = 'http://proxy.com'
+    ENV['HTTP_PROXY'] = 'http://upper.proxy.com'
+    response = connection { |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'http://upper.proxy.com', proxy_options.uri.to_s
+  end
+
+  def test_explicit_proxy_trumps_env
+    ENV['HTTP_PROXY'] = 'http://env.proxy.com'
+    conn = connection { |b| b.request :proxy, 'http://ex.proxy.com' }
+    response = conn.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'http://ex.proxy.com', proxy_options.uri.to_s
+  end
+
+  def test_proxy_set_and_url_in_no_proxy_list_removes_proxy
+    ENV['http_proxy'] = 'http://proxy.com'
+    ENV['no_proxy']   = 'example.com'
+    response = connection { |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    assert_nil proxy_options
+  end
+
+  def test_proxy_set_and_url_not_in_no_proxy_list_sets_proxy
+    ENV['http_proxy'] = 'http://proxy.com'
+    ENV['no_proxy']   = 'example2.com'
+    response = connection { |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'http://proxy.com', proxy_options.uri.to_s
+  end
+
+  def test_proxy_set_in_multi_element_no_proxy_list
+    ENV['http_proxy'] = 'http://proxy.com'
+    ENV['no_proxy']   = 'example0.com,example.com,example1.com'
+    response = connection { |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    assert_nil proxy_options
+  end
+
+  def test_proxy_ignored_when_ports_match_in_no_proxy_list
+    ENV['http_proxy'] = 'http://proxy.com'
+    ENV['no_proxy']   = 'example.com:7171'
+    response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    assert_nil proxy_options
+  end
+
+  def test_proxy_ignored_when_port_is_not_set_in_no_proxy_list
+    ENV['http_proxy'] = 'http://proxy.com'
+    ENV['no_proxy']   = 'example.com'
+    response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    assert_nil proxy_options
+  end
+
+  def test_proxy_set_when_ports_mismatch_in_no_proxy_list
+    ENV['http_proxy'] = 'http://proxy.com'
+    ENV['no_proxy']   = 'example.com:3000'
+    response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'http://proxy.com', proxy_options.uri.to_s
+  end
+
+  def test_https_proxy_set_given_https_url
+    ENV['https_proxy'] = 'https://ssl.proxy.com'
+    response = connection('https://example.com'){ |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'https://ssl.proxy.com', proxy_options.uri.to_s
+  end
+
+  def test_https_ignored_given_match_in_no_proxy_list
+    ENV['https_proxy'] = 'https://ssl.proxy.com'
+    ENV['no_proxy'] = 'example.com'
+
+    response = connection('https://example.com'){ |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    assert_nil proxy_options
+  end
+
+  def test_https_ignored_when_http_url_requested
+    ENV['https_proxy'] = 'https://ssl.proxy.com'
+
+    response = connection('http://example.com'){ |b| b.request :proxy }.get('/test')
+    proxy_options = response.env.request.proxy
+
+    assert_nil proxy_options
+  end
+
+end


### PR DESCRIPTION
Faraday currently supports the `http_proxy` environment variable and sets it as a default proxy if another is not explicitly set when a connection is created.

The `no_proxy` environment variable contains a comma-separated list of domains for which the proxy is not required[1]. If the requested URL matches an entry in this list, the default proxy should not be used.

This patch adds support for the `no_proxy` behaviour.

[1] This is already supported in a large number of existing ruby projects, e.g. [RubyGems](http://docs.rubygems.org/read/chapter/13#page51)
