### PR TITLE
em_synchrony adapter does not properly report EventMachine::HttpClient errors

### DIFF
--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -52,6 +52,10 @@ module Faraday
             client = block.call
           end
 
+          if e = client.error
+            raise e
+          end
+
           save_response(env, client.response_header.status, client.response) do |resp_headers|
             client.response_header.each do |name, value|
               resp_headers[name.to_sym] = value


### PR DESCRIPTION
This fix raises an exception when EventMachine::HttpClient assigns an error (such as Errno::ECONNREFUSED).  This fixes the problem that the response status is merely set to 0 on connection errors.  The adapter should now be compatible with the others, which raise Faraday::Error::ConnectionFailed.
