### PR TITLE
strict_base64 required for HTTP Auth to IIS servers.

### DIFF
--- a/lib/faraday/request/basic_authentication.rb
+++ b/lib/faraday/request/basic_authentication.rb
@@ -4,7 +4,7 @@ module Faraday
   class Request::BasicAuthentication < Request.load_middleware(:authorization)
     # Public
     def self.header(login, pass)
-      value = Base64.encode64([login, pass].join(':'))
+      value = Base64.strict_encode64([login, pass].join(':'))
       value.gsub!("\n", '')
       super(:Basic, value)
     end


### PR DESCRIPTION
Loosely related to #256.

Base64#encode64 inserts a \n every 60 characters.  A base64-encoded string with newlines confuses IIS completely and cannot be used for HTTP Authentication.

Base64#strict_encode64 was introduced in Ruby 1.9, so there would be a dependency there.
