### PR TITLE
remove net_http_persistent todo

### DIFF
--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -6,8 +6,6 @@ module Faraday
     class NetHttpPersistent < NetHttp
       dependency 'net/http/persistent'
 
-      # TODO: investigate is it safe to create a new Persistent instance for
-      # every request, or does it defy the purpose of persistent connections
       def net_http_connection(env)
         Net::HTTP::Persistent.new 'Faraday',
           env[:request][:proxy] ? env[:request][:proxy][:uri] : nil


### PR DESCRIPTION
From the docs: "Multiple Net::HTTP::Persistent objects will share the same set of connections."

http://docs.seattlerb.org/net-http-persistent/Net/HTTP/Persistent.html
