### PR TITLE
Reset Faraday.default_connection when setting Faraday.default_adapter

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -81,6 +81,15 @@ module Faraday
       end
     end
 
+    # Public: Updates default adapter while resetting
+    # #default_connection.
+    #
+    # Returns the new default_adapter.
+    def default_adapter=(adapter)
+      @default_connection = nil
+      @default_adapter = adapter
+    end
+
     alias require_lib require_libs
 
   private


### PR DESCRIPTION
Currently Faraday.default_connection is memoized - this is fine and wonderful, unless you change Faraday.default_adapter after you have already initialized Faraday.default_connection. In this case, your Faraday::Connection instance has already been setup (which magically happens via method_missing if you call, e.g., Faraday.get "http://foobar.com/") and your changes to .default_adapter won't do anything.

``` ruby
irb(main):001:0> require 'faraday'
=> true
irb(main):002:0> Faraday.get("http://change.org/")
=> #<Faraday::Response:0x0000000284bd20 @env={:method=>:get, :body=>"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\"><html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=iso-8859-1\"><meta http-equiv=\"Content-Script-Type\" content=\"text/javascript\"><script type=\"text/javascript\">function setCookie(c_name, value, expiredays) { var exdate = new Date(); exdate.setDate(exdate.getDate()+expiredays); document.cookie = c_name + \"=\" + escape(value) + ((expiredays==null) ? \"\" : \";expires=\" + exdate.toGMTString()) + \";path=/\"; } function getHostUri() { var loc = document.location; return loc.toString(); } setCookie('YPF8827340282Jdskjhfiw_928937459182JAX666', '72.3.243.59', 10); setCookie('DOAReferrer', document.referrer, 10); location.href = getHostUri();</script></head><body><noscript>This site requires JavaScript and Cookies to be enabled. Please change your browser settings or upgrade your browser.</noscript></body></html>\n", :url=>#<URI::HTTP:0x00000002683268 URL:http://change.org/>, :request_headers=>{}, :parallel_manager=>nil, :request=>{:proxy=>nil}, :ssl=>{}, :status=>200, :response_headers=>{"server"=>"nginx/1.2.6", "date"=>"Mon, 06 May 2013 21:46:16 GMT", "content-type"=>"text/html", "transfer-encoding"=>"chunked", "connection"=>"close", "p3p"=>"CP=\"NON DSP COR ADMa OUR IND UNI COM NAV INT\"", "cache-control"=>"no-cache, no-store, must-revalidate", "pragma"=>"no-cache"}, :response=>#<Faraday::Response:0x0000000284bd20 ...>}, @on_complete_callbacks=[]>
irb(main):003:0> Faraday.default_adapter = :typhoeus
=> :typhoeus
irb(main):004:0> Faraday.get("http://change.org/")
=> #<Faraday::Response:0x00000002bc4498 @env={:method=>:get, :body=>"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\"><html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=iso-8859-1\"><meta http-equiv=\"Content-Script-Type\" content=\"text/javascript\"><script type=\"text/javascript\">function setCookie(c_name, value, expiredays) { var exdate = new Date(); exdate.setDate(exdate.getDate()+expiredays); document.cookie = c_name + \"=\" + escape(value) + ((expiredays==null) ? \"\" : \";expires=\" + exdate.toGMTString()) + \";path=/\"; } function getHostUri() { var loc = document.location; return loc.toString(); } setCookie('YPF8827340282Jdskjhfiw_928937459182JAX666', '72.3.243.59', 10); setCookie('DOAReferrer', document.referrer, 10); location.href = getHostUri();</script></head><body><noscript>This site requires JavaScript and Cookies to be enabled. Please change your browser settings or upgrade your browser.</noscript></body></html>\n", :url=>#<URI::HTTP:0x00000002bb6a50 URL:http://change.org/>, :request_headers=>{}, :parallel_manager=>nil, :request=>{:proxy=>nil}, :ssl=>{}, :status=>200, :response_headers=>{"server"=>"nginx/1.2.6", "date"=>"Mon, 06 May 2013 21:47:30 GMT", "content-type"=>"text/html", "transfer-encoding"=>"chunked", "connection"=>"close", "p3p"=>"CP=\"NON DSP COR ADMa OUR IND UNI COM NAV INT\"", "cache-control"=>"no-cache, no-store, must-revalidate", "pragma"=>"no-cache"}, :response=>#<Faraday::Response:0x00000002bc4498 ...>}, @on_complete_callbacks=[]>
irb(main):005:0> Faraday.default_connection
=> #<Faraday::Connection:0x00000001ff6580 @headers={}, @params={}, @options={}, @ssl={}, @parallel_manager=nil, @default_parallel_manager=nil, @builder=#<Faraday::Builder:0x00000001ff62b0 @handlers=[Faraday::Request::UrlEncoded, Faraday::Adapter::NetHttp]>, @url_prefix=#<URI::HTTP:0x00000002683b78 URL:http:/>, @proxy=nil, @app=#<Faraday::Request::UrlEncoded:0x00000002682d40 @app=#<Faraday::Adapter::NetHttp:0x00000002682d90 @app=#<Proc:0x00000002682e80@/data/change_main/shared/bundle/ruby/1.9.1/gems/faraday-0.8.4/lib/faraday/connection.rb:74 (lambda)>>>>
```

This pull request explicitly defines a Faraday.default_adapter= setter that clears Faraday.default_connection to handle this bug.

``` ruby
1.9.3-p0 :001 > require './lib/faraday'
 => true
1.9.3-p0 :002 > Faraday.default_connection
 => #<Faraday::Connection:0x007f99ba2592d8 @parallel_manager=nil, @headers={"User-Agent"=>"Faraday v0.9.0.pre"}, @params={}, @options=#<Faraday::RequestOptions (empty)>, @ssl=#<Faraday::SSLOptions (empty)>, @default_parallel_manager=nil, @builder=#<Faraday::RackBuilder:0x007f99ba2590d0 @handlers=[Faraday::Request::UrlEncoded, Faraday::Adapter::NetHttp]>, @url_prefix=#<URI::HTTP:0x007f99ba4ed080 URL:http:/>>
1.9.3-p0 :003 > Faraday.default_adapter = :typhoeus
 => :typhoeus
1.9.3-p0 :004 > Faraday.default_connection
 => #<Faraday::Connection:0x007f99ba509c08 @parallel_manager=nil, @headers={"User-Agent"=>"Faraday v0.9.0.pre"}, @params={}, @options=#<Faraday::RequestOptions (empty)>, @ssl=#<Faraday::SSLOptions (empty)>, @default_parallel_manager=nil, @builder=#<Faraday::RackBuilder:0x007f99ba509ac8 @handlers=[Faraday::Request::UrlEncoded, Faraday::Adapter::Typhoeus]>, @url_prefix=#<URI::HTTP:0x007f99ba668590 URL:http:/>>
```
