### PR TITLE
Add trailing slash back to url_prefix if perform an empty get()

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -322,6 +322,7 @@ module Faraday
     # Returns the new String path prefix.
     def path_prefix=(value)
       url_prefix.path = if value
+        @raw_base_has_trailing_slash = value =~ /\/$/
         value = value.chomp '/'
         value = '/' + value unless value[0,1] == '/'
         value
@@ -394,7 +395,7 @@ module Faraday
     def build_exclusive_url(url, params = nil)
       url = nil if url.respond_to?(:empty?) and url.empty?
       base = url_prefix
-      if url and base.path and base.path !~ /\/$/
+      if (url and base.path and base.path !~ /\/$/) or (url.nil? and base.path and @raw_base_has_trailing_slash)
         base = base.dup
         base.path = base.path + '/'  # ensure trailing slash
       end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -177,6 +177,20 @@ class TestConnection < Faraday::TestCase
     assert_equal "/nigiri", uri.path
   end
 
+  def test_build_url_add_ending_slash_given_nil_url_but_given_url_prefix_has_ending_slash
+    conn = Faraday::Connection.new
+    conn.url_prefix = "http://sushi.com/nigiri/"
+    uri = conn.build_url(nil)
+    assert_equal "/nigiri/", uri.path
+  end
+
+  def test_build_url_add_ending_slash_given_empty_url_but_given_url_prefix_has_ending_slash
+    conn = Faraday::Connection.new
+    conn.url_prefix = "http://sushi.com/nigiri/"
+    uri = conn.build_url('')
+    assert_equal "/nigiri/", uri.path
+  end
+
   def test_build_url_parses_url_params_into_query
     conn = Faraday::Connection.new
     uri = conn.build_url("http://sushi.com/sake.html", 'a[b]' => '1 + 2')


### PR DESCRIPTION
Hello, this PR attempt to fix #212.
