### PR TITLE
Pass client side cert information to excon

### DIFF
--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -16,6 +16,8 @@ module Faraday
           opts[:ssl_verify_peer] = !!ssl.fetch(:verify, true)
           opts[:ssl_ca_path] = ssl[:ca_path] if ssl[:ca_path]
           opts[:ssl_ca_file] = ssl[:ca_file] if ssl[:ca_file]
+          opts[:client_cert] = ssl[:client_cert] if ssl[:client_cert]
+          opts[:client_key]  = ssl[:client_key]  if ssl[:client_key]
 
           # https://github.com/geemus/excon/issues/106
           # https://github.com/jruby/jruby-ossl/issues/19


### PR DESCRIPTION
Added support to excon for pulling out :client_cert and :client_key from the ssl hash and passing it to the connection.
