### PR TITLE
Fix ActiveSupport::SafeBuffer#gsub bug again

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -162,8 +162,8 @@ module Faraday
     ESCAPE_RE = /[^a-zA-Z0-9 .~_-]/
 
     def escape(s)
-      s.to_s.gsub(ESCAPE_RE) {
-        '%' + $&.unpack('H2' * $&.bytesize).join('%').upcase
+      s.to_s.gsub(ESCAPE_RE) {|match|
+        '%' + match.unpack('H2' * match.bytesize).join('%').upcase
       }.tr(' ', '+')
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -81,3 +81,24 @@ module Faraday
     end
   end
 end
+
+# The essential part of ActiveSupport::SafeBuffer to demonstrate
+# how it blows up when passed to Faraday::Utils.escape
+# rails/rails@ed738f7
+class FakeSafeBuffer < String
+  UNSAFE_STRING_METHODS = %w(gsub)
+
+  def to_s
+    self
+  end
+
+  UNSAFE_STRING_METHODS.each do |unsafe_method|
+    if 'String'.respond_to?(unsafe_method)
+      class_eval <<-EOT, __FILE__, __LINE__ + 1
+        def #{unsafe_method}(*args, &block)       # def capitalize(*args, &block)
+          to_str.#{unsafe_method}(*args, &block)  #   to_str.capitalize(*args, &block)
+        end                                       # end
+      EOT
+    end
+  end
+end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -9,6 +9,11 @@ class TestUtils < Faraday::TestCase
     Faraday::Utils.default_uri_parser = nil
   end
 
+  def test_escaping_safe_buffer
+    str = FakeSafeBuffer.new('$32,000.00')
+    assert_equal '%2432%2C000.00', Faraday::Utils.escape(str)
+  end
+
   def test_parses_with_default
     assert_equal %(#<Method: Kernel.URI>), Faraday::Utils.default_uri_parser.to_s
     uri = normalize(@url)


### PR DESCRIPTION
#93 was previously fixed in #94, but was deleted in 8806c4ff, then put back in without the block argument in 4e14ce583. #93 needs to be fixed again.

I wish I knew how to write a test for this without introducing ActiveSupport as a dependency. I'll be happy to add it if you don't mind the development dependency.
