### PR TITLE
[excon] pass client side cert information to excon connection

### DIFF
--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -16,6 +16,10 @@ module Faraday
           opts[:ssl_verify_peer] = !!ssl.fetch(:verify, true)
           opts[:ssl_ca_path] = ssl[:ca_path] if ssl[:ca_path]
           opts[:ssl_ca_file] = ssl[:ca_file] if ssl[:ca_file]
+          opts[:client_cert] = ssl[:client_cert] if ssl[:client_cert]
+          opts[:client_key]  = ssl[:client_key]  if ssl[:client_key]
+          opts[:certificate] = ssl[:certificate] if ssl[:certificate]
+          opts[:private_key] = ssl[:private_key] if ssl[:private_key]
 
           # https://github.com/geemus/excon/issues/106
           # https://github.com/jruby/jruby-ossl/issues/19


### PR DESCRIPTION
Excon supports client side SSL authentication, but the Faraday implementation does not.  This fixes that.
