### PR TITLE
Add space after semicolon in multipart post

### DIFF
--- a/lib/faraday/request/multipart.rb
+++ b/lib/faraday/request/multipart.rb
@@ -8,7 +8,7 @@ module Faraday
     def call(env)
       match_content_type(env) do |params|
         env.request.boundary ||= DEFAULT_BOUNDARY
-        env.request_headers[CONTENT_TYPE] += ";boundary=#{env.request.boundary}"
+        env.request_headers[CONTENT_TYPE] += "; boundary=#{env.request.boundary}"
         env.body = create_multipart(env, params)
       end
       @app.call env

--- a/test/request_middleware_test.rb
+++ b/test/request_middleware_test.rb
@@ -106,7 +106,7 @@ class RequestMiddlewareTest < Faraday::TestCase
     response = @conn.post('/echo', payload)
 
     assert_kind_of Faraday::CompositeReadIO, response.body
-    assert_equal "multipart/form-data;boundary=%s" % Faraday::Request::Multipart::DEFAULT_BOUNDARY,
+    assert_equal "multipart/form-data; boundary=%s" % Faraday::Request::Multipart::DEFAULT_BOUNDARY,
       response.headers['Content-Type']
 
     response.body.send(:ios).map{|io| io.read}.each do |io|
@@ -116,7 +116,7 @@ class RequestMiddlewareTest < Faraday::TestCase
     end
     assert_equal [], regexes
   end
-  
+
   def test_multipart_with_arrays
     # assume params are out of order
     regexes = [
@@ -128,7 +128,7 @@ class RequestMiddlewareTest < Faraday::TestCase
     response = @conn.post('/echo', payload)
 
     assert_kind_of Faraday::CompositeReadIO, response.body
-    assert_equal "multipart/form-data;boundary=%s" % Faraday::Request::Multipart::DEFAULT_BOUNDARY,
+    assert_equal "multipart/form-data; boundary=%s" % Faraday::Request::Multipart::DEFAULT_BOUNDARY,
       response.headers['Content-Type']
 
     response.body.send(:ios).map{|io| io.read}.each do |io|
@@ -138,5 +138,5 @@ class RequestMiddlewareTest < Faraday::TestCase
     end
     assert_equal [], regexes
   end
-  
+
 end


### PR DESCRIPTION
Took me a while to figure out why multipart posting with Faraday vs Multipart-Post. 

**TL;DR** Some servers don't like it when headers don't have a space following semicolons in request headers.  My suggestion is to stick with convention in core Ruby libs and RFC examples to avoid issues. This PR does that for the multipart post part of Faraday.

---

Turns out that the Content-Type was being sent as "Content-Type: multipart/form-data;boundary=-----------RubyMultipartPost" without the space after the semicolon and before the boundary definition, whereas when using Multipart-post, there is a space because it uses set-content-type in [Net::HTTPHeader](http://ruby-doc.org/stdlib-1.9.3/libdoc/net/http/rdoc/Net/HTTPHeader.html#method-i-set_content_type), which sets a space. This was throwing off a service that I am using to upload photos to.

Not having the space is theoretically perfectly fine, as the [RFC spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html) does not specify that that there needs to be a space, although all the examples on the page do have the space in them. However, I think if there are no objections, it would be nice to follow convention set in the standard Ruby library (and thus Multipart-post), as well as RFC to avoid pesky servers throwing errors (like with [Exchange 2010](https://github.com/unwire/handsoap/pull/18))
