### PR TITLE
Get the default values for the instrumenter options

### DIFF
--- a/lib/faraday/request/instrumentation.rb
+++ b/lib/faraday/request/instrumentation.rb
@@ -24,7 +24,7 @@ module Faraday
     #   end
     def initialize(app, options = nil)
       super(app)
-      @name, @instrumenter = Options.from(options).values
+      @name, @instrumenter = Options.from(options).values_at(:name, :instrumenter)
     end
 
     def call(env)

--- a/test/middleware/instrumentation_test.rb
+++ b/test/middleware/instrumentation_test.rb
@@ -28,6 +28,19 @@ module Middleware
       assert_equal :boom, options(:instrumenter => :boom).instrumenter
     end
 
+    def test_instrumentation_with_default_name
+      assert_equal 0, @instrumenter.instrumentations.size
+
+      faraday = conn
+      res = faraday.get '/'
+      assert_equal 'ok', res.body
+
+      assert_equal 1, @instrumenter.instrumentations.size
+      name, env = @instrumenter.instrumentations.first
+      assert_equal 'request.faraday', name
+      assert_equal '/', env[:url].path
+    end
+
     def test_instrumentation
       assert_equal 0, @instrumenter.instrumentations.size
 


### PR DESCRIPTION
Before this pull request the default values were not being used since the values method on the Struct will not call the accessors.
