### PR TITLE
Raise Unauthorized error for 401 and Dont raise error for 422

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -35,11 +35,12 @@ module Faraday
 
   class ConnectionFailed < ClientError;   end
   class ResourceNotFound < ClientError;   end
+  class UnprocessableEntity < ClientError;   end
   class ParsingError     < ClientError;   end
   class TimeoutError < ClientError; end
 
   [:MissingDependency, :ClientError, :ConnectionFailed, :ResourceNotFound,
-   :ParsingError, :TimeoutError].each do |const|
+   :ParsingError, :TimeoutError, :UnprocessableEntity].each do |const|
     Error.const_set(const, Faraday.const_get(const))
   end
 end

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -35,13 +35,12 @@ module Faraday
 
   class ConnectionFailed < ClientError;   end
   class ResourceNotFound < ClientError;   end
-  class UnprocessableEntity < ClientError;   end
   class ParsingError     < ClientError;   end
   class TimeoutError < ClientError; end
   class Unauthorized < ClientError; end
 
   [:MissingDependency, :ClientError, :ConnectionFailed, :ResourceNotFound,
-   :ParsingError, :TimeoutError, :UnprocessableEntity, :Unauthorized].each do |const|
+   :ParsingError, :TimeoutError, :Unauthorized].each do |const|
     Error.const_set(const, Faraday.const_get(const))
   end
 end

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -38,9 +38,10 @@ module Faraday
   class UnprocessableEntity < ClientError;   end
   class ParsingError     < ClientError;   end
   class TimeoutError < ClientError; end
+  class Unauthorized < ClientError; end
 
   [:MissingDependency, :ClientError, :ConnectionFailed, :ResourceNotFound,
-   :ParsingError, :TimeoutError, :UnprocessableEntity].each do |const|
+   :ParsingError, :TimeoutError, :UnprocessableEntity, :Unauthorized].each do |const|
     Error.const_set(const, Faraday.const_get(const))
   end
 end

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -9,7 +9,7 @@ module Faraday
       when 404
         raise Faraday::Error::ResourceNotFound, response_values(env)
       when 422
-        #raise Faraday::Error::UnprocessableEntity, response_values(env)
+        # dont raise error for 422        
       when ClientErrorStatuses
         raise Faraday::Error::ClientError, response_values(env)
       end

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -7,7 +7,7 @@ module Faraday
       when 404
         raise Faraday::Error::ResourceNotFound, response_values(env)
       when 422
-        raise Faraday::Error::UnprocessableEntity, response_values(env)
+        #raise Faraday::Error::UnprocessableEntity, response_values(env)
       when ClientErrorStatuses
         raise Faraday::Error::ClientError, response_values(env)
       end

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -4,6 +4,8 @@ module Faraday
 
     def on_complete(env)
       case env[:status]
+      when 401
+        raise Faraday::Error::Unauthorized, response_values(env)
       when 404
         raise Faraday::Error::ResourceNotFound, response_values(env)
       when 422

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -6,6 +6,8 @@ module Faraday
       case env[:status]
       when 404
         raise Faraday::Error::ResourceNotFound, response_values(env)
+      when 422
+        raise Faraday::Error::UnprocessableEntity, response_values(env)
       when ClientErrorStatuses
         raise Faraday::Error::ClientError, response_values(env)
       end


### PR DESCRIPTION
Raises Unauthorized error when HTTP 401 is received.
Don't raise error for 422. 422 can be easily handled by the parent application.