### PR TITLE
Make Headers#fetch case-insensitive, like []

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -45,6 +45,10 @@ module Faraday
         super k, v
       end
 
+      def fetch(k, *args)
+        super(@names[k.downcase]) {|key| super(k, *args)}
+      end
+
       def delete(k)
         k = KeyMap[k]
         if k = @names[k.downcase]

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -98,6 +98,16 @@ class HeadersTest < Faraday::TestCase
     assert_equal 'application/xml', @headers['content-type']
   end
 
+  def test_fetch_key
+    @headers['Content-Type'] = 'application/json'
+    assert_equal 'application/json', @headers.fetch('Content-Type')
+    assert_equal 'application/json', @headers.fetch('CONTENT-TYPE')
+    assert_equal 'default', @headers.fetch('invalid', 'default')
+    assert_equal 'invalid key', @headers.fetch('invalid') {|el| "#{el} key"}
+    fetch_error = RUBY_VERSION =~ /1.8/ ? IndexError : KeyError
+    assert_raises(fetch_error) { @headers.fetch('invalid') }
+  end
+
   def test_delete_key
     @headers['Content-Type'] = 'application/json'
     assert_equal 1, @headers.size


### PR DESCRIPTION
Faraday::Utils::Headers extend the behavior of Ruby's Hash by
making the [] operator working without being case sensitive.

This commit provides the same behavior for the .fetch operator.

For instance, given `@headers['Content-Type'] = 'application/json'`,
it is now possible obtain the content type in all of these cases:

```
@headers['Content-Type']
@headers.fetch 'Content-Type'
@headers['content-type']
@headers.fetch 'content-type'
```

The tests in the commit ensure that all the cases of Ruby's Hash
work as expected
