### PR TITLE
make env a hash again

### DIFF
--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -187,10 +187,7 @@ module Faraday
     #     :password   - Proxy server password
     # :ssl - Hash of options for configuring SSL requests.
     def build_env(connection, request)
-      Env.new(request.method, request.body,
-        connection.build_exclusive_url(request.path, request.params),
-        request.options, request.headers, connection.ssl,
-        connection.parallel_manager)
+      Env.build(connection, request)
     end
 
     private

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -80,9 +80,7 @@ module Faraday
     #     :password   - Proxy server password
     # :ssl - Hash of options for configuring SSL requests.
     def to_env(connection)
-      Env.new(method, body, connection.build_exclusive_url(path, params),
-        options, headers, connection.ssl, connection.parallel_manager)
+      Env.build(connection, self)
     end
   end
 end
-


### PR DESCRIPTION
Env being a struct is what caused the breakage with the middleware.  It prevented them from setting arbitrary keys on the Env without some extra work.  This turns it back into a Hash.  Do we like this approach?
1. Should we wrap Env as a hash instead of extending it?
2. I don't like `hash_accessor`, and would rather remove all uses of method accessors on Env in the codebase.

I think with this, we can push out a new rc for 0.9.0 and actually ship.

/cc @mislav @sferik 
