### PR TITLE
Options#fetch returns the default when the value is nil or false.

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -48,8 +48,9 @@ module Faraday
 
     # Public
     def fetch(key, default = nil)
-      send(key) || send("#{key}=", default ||
-        (block_given? ? Proc.new.call : nil))
+      return send(key) if keys.include?(key)
+
+      send("#{key}=", default || (block_given? ? Proc.new.call : nil))
     end
 
     # Public

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -164,4 +164,10 @@ class OptionsTest < Faraday::TestCase
     e["custom"] = :boom
     assert_equal :boom, e["custom"]
   end
+
+  def test_env_fetch_ignores_false
+    ssl = Faraday::SSLOptions.new
+    ssl.verify = false
+    assert !ssl.fetch(:verify, true)
+  end
 end


### PR DESCRIPTION
This makes it possible to turn off SSL cert verification with the net/http adapter because this line hit the bug: https://github.com/lostisland/faraday/blob/master/lib/faraday/adapter/net_http.rb#L114
