### PR TITLE
Add missing SSL options key

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -202,7 +202,8 @@ module Faraday
   end
 
   class SSLOptions < Options.new(:verify, :ca_file, :ca_path, :verify_mode,
-    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth, :version)
+    :cert_store, :client_cert, :client_cert_passwd, :client_key, :certificate,
+    :private_key, :verify_depth, :version)
 
     def verify?
       verify != false


### PR DESCRIPTION
The Typhoeus adapter provides the ability for users to [pass in a client certificate password](https://github.com/typhoeus/typhoeus/pull/317) along with other SSL options. This patch allows that value to be passed through from Faraday to the adapter.

Without this, [the adapter is busted](https://github.com/typhoeus/typhoeus/issues/346) when used with 0.9.0.

See also:
- https://github.com/lostisland/faraday/issues/333
