### PR TITLE
Add ciphers (and a few other new SSL options) to the net/http adapter

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -100,9 +100,9 @@ module Faraday
         http.ca_path      = ssl[:ca_path]      if ssl[:ca_path]
         http.verify_depth = ssl[:verify_depth] if ssl[:verify_depth]
         http.ssl_version  = ssl[:version]      if ssl[:version]
-        http.ciphers      = ssl[:ciphers]      if ssl[:ciphers] && http.respond_to?(:ciphers=)
-        http.verify_callback = ssl[:verify_callback] if ssl[:verify_callback] && http.respond_to?(:verify_callback=)
-        http.ssl_timeout  = ssl[:timeout]      if ssl[:timeout] && http.respond_to?(:ssl_timeout=)
+        http.ciphers      = ssl[:ciphers]      if ssl[:ciphers]
+        http.verify_callback = ssl[:verify_callback] if ssl[:verify_callback]
+        http.ssl_timeout  = ssl[:timeout]      if ssl[:timeout]
       end
 
       def ssl_cert_store(ssl)


### PR DESCRIPTION
In recent Rubies, net/http supports setting the list of ciphers, as well as an SSL timeout and a callback for additional server certificate verification. This PR adds support for those attributes to the net/http adapter.

Let me know if there are any changes you would like made. Thanks!
