### PR TITLE
Adding support for newer SSL options in the net/http adapter

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -100,6 +100,9 @@ module Faraday
         http.ca_path      = ssl[:ca_path]      if ssl[:ca_path]
         http.verify_depth = ssl[:verify_depth] if ssl[:verify_depth]
         http.ssl_version  = ssl[:version]      if ssl[:version]
+        http.ciphers      = ssl[:ciphers]      if ssl[:ciphers]
+        http.verify_callback = ssl[:verify_callback] if ssl[:verify_callback]
+        http.ssl_timeout  = ssl[:timeout]      if ssl[:timeout]
       end
 
       def ssl_cert_store(ssl)

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -202,7 +202,8 @@ module Faraday
   end
 
   class SSLOptions < Options.new(:verify, :ca_file, :ca_path, :verify_mode,
-    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth, :version)
+    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth, :version,
+    :ciphers, :verify_callback, :timeout)
 
     def verify?
       verify != false


### PR DESCRIPTION
In recent Rubies, net/http supports setting the list of ciphers, as well as an SSL timeout and a callback for additional server certificate verification. This PR adds support for those attributes to the net/http adapter.

Let me know if there are any changes you would like made. Thanks!