### PR TITLE
By default, retry only HTTP methods known to be idempotent, user can optionally configure other methods - fixes #298

### DIFF
--- a/test/middleware/retry_test.rb
+++ b/test/middleware/retry_test.rb
@@ -10,35 +10,37 @@ module Middleware
       Faraday.new do |b|
         b.request :retry, *retry_args
         b.adapter :test do |stub|
-          stub.post('/unstable') {
-            @times_called += 1
-            @explode.call @times_called
-          }
+          ['get', 'post'].each do |method|
+            stub.send(method, '/unstable') {
+              @times_called += 1
+              @explode.call @times_called
+            }
+          end
         end
       end
     end
 
     def test_unhandled_error
       @explode = lambda {|n| raise "boom!" }
-      assert_raises(RuntimeError) { conn.post("/unstable") }
+      assert_raises(RuntimeError) { conn.get("/unstable") }
       assert_equal 1, @times_called
     end
 
     def test_handled_error
       @explode = lambda {|n| raise Errno::ETIMEDOUT }
-      assert_raises(Errno::ETIMEDOUT) { conn.post("/unstable") }
+      assert_raises(Errno::ETIMEDOUT) { conn.get("/unstable") }
       assert_equal 3, @times_called
     end
 
     def test_legacy_max_retries
       @explode = lambda {|n| raise Errno::ETIMEDOUT }
-      assert_raises(Errno::ETIMEDOUT) { conn(1).post("/unstable") }
+      assert_raises(Errno::ETIMEDOUT) { conn(1).get("/unstable") }
       assert_equal 2, @times_called
     end
 
     def test_new_max_retries
       @explode = lambda {|n| raise Errno::ETIMEDOUT }
-      assert_raises(Errno::ETIMEDOUT) { conn(:max => 3).post("/unstable") }
+      assert_raises(Errno::ETIMEDOUT) { conn(:max => 3).get("/unstable") }
       assert_equal 4, @times_called
     end
 
@@ -46,7 +48,7 @@ module Middleware
       @explode = lambda {|n| raise Errno::ETIMEDOUT }
       started  = Time.now
       assert_raises(Errno::ETIMEDOUT) {
-        conn(:max => 2, :interval => 0.1).post("/unstable")
+        conn(:max => 2, :interval => 0.1).get("/unstable")
       }
       assert_in_delta 0.2, Time.now - started, 0.04
     end
@@ -70,7 +72,7 @@ module Middleware
       retry_middleware.sleep_amount_retries = [2, 1]
 
       assert_raises(Errno::ETIMEDOUT) {
-        retry_middleware.call({})
+        retry_middleware.call({:method => :get})
       }
 
       assert_empty retry_middleware.sleep_amount_retries
@@ -101,25 +103,42 @@ module Middleware
     def test_custom_exceptions
       @explode = lambda {|n| raise "boom!" }
       assert_raises(RuntimeError) {
-        conn(:exceptions => StandardError).post("/unstable")
+        conn(:exceptions => StandardError).get("/unstable")
       }
       assert_equal 3, @times_called
     end
 
     def test_should_stop_retrying_if_block_returns_false_checking_env
-      @explode = lambda {|n| raise Errno::ECONNREFUSED }
+      @explode = lambda {|n| raise Errno::ETIMEDOUT }
       check = lambda { |env,exception| env[:method] != :post }
-      assert_raises(Errno::ECONNREFUSED) {
+      assert_raises(Errno::ETIMEDOUT) {
         conn(:retry_if => check).post("/unstable")
       }
       assert_equal 1, @times_called
     end
 
     def test_should_stop_retrying_if_block_returns_false_checking_exception
-      @explode = lambda {|n| raise Errno::ECONNREFUSED }
-      check = lambda { |env,exception| !exception.kind_of?(Errno::ECONNREFUSED) }
-      assert_raises(Errno::ECONNREFUSED) {
+      @explode = lambda {|n| raise Errno::ETIMEDOUT }
+      check = lambda { |env,exception| !exception.kind_of?(Errno::ETIMEDOUT) }
+      assert_raises(Errno::ETIMEDOUT) {
         conn(:retry_if => check).post("/unstable")
+      }
+      assert_equal 1, @times_called
+    end
+
+    def test_should_not_call_retry_if_for_idempotent_methods
+      @explode = lambda {|n| raise Errno::ETIMEDOUT }
+      check = lambda { |env,exception| raise "this should have never been called" }
+      assert_raises(Errno::ETIMEDOUT) {
+        conn(:retry_if => check).get("/unstable")
+      }
+      assert_equal 3, @times_called
+    end
+
+    def test_should_not_retry_for_non_idempotent_method
+      @explode = lambda {|n| raise Errno::ETIMEDOUT }
+      assert_raises(Errno::ETIMEDOUT) {
+        conn.post("/unstable")
       }
       assert_equal 1, @times_called
     end


### PR DESCRIPTION
This changes the default at the retry middleware to retry only on methods known to be idempotent, other methods (`POST`, `PATCH`) will not be retried by default but the user can do so by sending in a `:retryable_methods` option when creating the connection.

Fixes #298.
