### PR TITLE
Do not reuse connection instance between requests with basic authentication parameters in URL.

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -420,7 +420,7 @@ module Faraday
     #
     # Returns a Faraday::Connection.
     def dup(url = nil)
-      self.class.new(build_exclusive_url(url), :headers => headers.dup, :params => params.dup, :builder => builder.dup, :ssl => ssl.dup)
+      self.class.new(build_exclusive_url(url), :headers => headers.dup, :params => params.dup, :builder => builder.clone, :ssl => ssl.dup)
     end
 
     # Internal: Yields username and password extracted from a URI if they both exist.

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -420,7 +420,7 @@ module Faraday
     #
     # Returns a Faraday::Connection.
     def dup(url = nil)
-      self.class.new(build_exclusive_url(url), :headers => headers.dup, :params => params.dup, :builder => builder.clone, :ssl => ssl.dup)
+      self.class.new(build_exclusive_url(url), :headers => headers.dup, :params => params.dup, :builder => builder.dup, :ssl => ssl.dup)
     end
 
     # Internal: Yields username and password extracted from a URI if they both exist.

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -120,6 +120,14 @@ module Adapters
         refute_equal 401, response.status
       end
 
+      def test_GET_passes_basic_auth_with_url_credentials
+        conn = create_connection
+        url = live_server_url(:userinfo => 'user:pass',
+                              :path => '/basic-auth/user/pass')
+        response = conn.get(url)
+        refute_equal 401, response.status
+      end
+
       def test_POST_send_url_encoded_params
         assert_equal %(post {"name"=>"zack"}), post('echo', :name => 'zack').body
       end
@@ -244,8 +252,7 @@ module Adapters
           end
         end
 
-        server = self.class.live_server
-        url = '%s://%s:%d' % [server.scheme, server.host, server.port]
+        url = live_server_url
 
         options[:ssl] ||= {}
         options[:ssl][:ca_file] ||= ENV['SSL_FILE']
@@ -255,6 +262,15 @@ module Adapters
           adapter_handler = conn.builder.handlers.last
           conn.builder.insert_before adapter_handler, Faraday::Response::RaiseError
         end
+      end
+
+      def live_server_url(options = {})
+        server = self.class.live_server
+        defaults = {:scheme => server.scheme,
+                    :host => server.host,
+                    :port => server.port}
+
+        URI::Generic.build(defaults.merge(options)).to_s
       end
     end
   end

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -113,6 +113,13 @@ module Adapters
         assert_equal expected, get('ssl').body
       end
 
+      def test_GET_passes_basic_auth_with_connection_credentials
+        conn = create_connection
+        conn.basic_auth('user', 'pass')
+        response = conn.get('basic-auth/user/pass')
+        refute_equal 401, response.status
+      end
+
       def test_POST_send_url_encoded_params
         assert_equal %(post {"name"=>"zack"}), post('echo', :name => 'zack').body
       end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -481,6 +481,24 @@ class TestRequestParams < Faraday::TestCase
     assert_query_equal %w[b=b], query
   end
 
+  def test_inherits_basic_auth
+    header_name = Faraday::Request::Authorization::KEY
+    conn = create_connection
+    conn.basic_auth('before', 'before')
+    get '?a=1' do |req|
+      assert_equal conn.headers[header_name], req.headers[header_name]
+    end
+  end
+
+  def test_overrides_basic_auth
+    header_name = Faraday::Request::Authorization::KEY
+    conn = create_connection
+    conn.basic_auth('before', 'before')
+    get 'http://after:after@domain.com' do |req|
+      refute_equal conn.headers[header_name], req.headers[header_name]
+    end
+  end
+
   def test_array_params_in_url
     with_default_params_encoder(nil) do
       create_connection 'http://a.co/page1?color[]=red&color[]=blue'

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -408,6 +408,8 @@ class TestRequestParams < Faraday::TestCase
       class << conn.builder
         undef app
         def app() lambda { |env| env } end
+        undef dup
+        def dup() clone end
       end
     end
   end

--- a/test/live_server.rb
+++ b/test/live_server.rb
@@ -56,6 +56,17 @@ class LiveServer < Sinatra::Base
     request.secure?.to_s
   end
 
+  get '/basic-auth/:user/:password' do
+    required_credentials = [params[:user], params[:password]]
+    auth = Rack::Auth::Basic::Request.new(request.env)
+
+    if auth.provided? && auth.basic? && auth.credentials == required_credentials
+      halt 200, "Authorized\n"
+    else
+      halt 401, "Not authorized\n"
+    end
+  end
+
   error do |e|
     "#{e.class}\n#{e.to_s}\n#{e.backtrace.join("\n")}"
   end


### PR DESCRIPTION
I think this should be the simplest solution for #343, considering this issue is more of an edge case than architectural problem. I wrote unit tests and added missing integration tests for described scenario.