### PR TITLE
resolve nil params value encode issue

### DIFF
--- a/lib/faraday/parameters.rb
+++ b/lib/faraday/parameters.rb
@@ -51,13 +51,11 @@ module Faraday
             buffer << "#{to_query.call(new_parent, val)}&"
           end
           return buffer.chop
+        elsif value.nil?
+          return parent
         else
-          if value == nil
-            return parent
-          else
-            encoded_value = escape(value)
-            return "#{parent}=#{encoded_value}"
-          end
+          encoded_value = escape(value)
+          return "#{parent}=#{encoded_value}"
         end
       end
 

--- a/lib/faraday/parameters.rb
+++ b/lib/faraday/parameters.rb
@@ -52,8 +52,12 @@ module Faraday
           end
           return buffer.chop
         else
-          encoded_value = escape(value)
-          return "#{parent}=#{encoded_value}"
+          if value == nil
+            return parent
+          else
+            encoded_value = escape(value)
+            return "#{parent}=#{encoded_value}"
+          end
         end
       end
 

--- a/test/parameters_test.rb
+++ b/test/parameters_test.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../helper', __FILE__)
+
+module Parameters
+  class NestedParamsEncoderTest < Faraday::TestCase
+    def test_decode_common_query
+      params = Faraday::NestedParamsEncoder.decode("foo1=bar1&foo2=bar2")
+      assert_equal 'bar1', params["foo1"]
+      assert_equal 'bar2', params["foo2"]
+    end
+
+    def test_encode_common_params
+      params = {"foo1" => "bar1", "foo2" => "bar2"}
+      assert_equal "foo1=bar1&foo2=bar2", Faraday::NestedParamsEncoder.encode(params)
+    end
+
+    def test_decode_blank_string_query
+      params = Faraday::NestedParamsEncoder.decode("blank=&foo=bar")
+      assert_equal '', params["blank"]
+      assert_equal 'bar', params["foo"]
+    end
+
+    def test_encode_blank_string_params
+      params = {"blank" => "", "foo" => "bar"}
+      assert_equal "blank=&foo=bar", Faraday::NestedParamsEncoder.encode(params)
+    end
+
+    def test_decode_nil_string_query
+      params = Faraday::NestedParamsEncoder.decode("foo=bar&nil")
+      assert_equal nil, params["nil"]
+      assert_equal 'bar', params["foo"]
+    end
+
+    def test_encode_nil_string_params
+      params = {"foo" => "bar", "nil" => nil}
+      assert_equal "foo=bar&nil", Faraday::NestedParamsEncoder.encode(params)
+    end
+  end
+end


### PR DESCRIPTION
we are using a third party service which utilize nil query params as route control, however, Faraday encode the nil params to a blank string, for example:

Faraday.get("http://example.com/uri?param1&params2")

the url will be parsed as:

http://example.com/uri?param1=&params2=