### PR TITLE
Make Faraday easily swappable with Net::HTTP

### DIFF
--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -36,6 +36,7 @@ module Faraday
     def status
       finished? ? env.status : nil
     end
+    alias :code :status
 
     def headers
       finished? ? env.response_headers : {}


### PR DESCRIPTION
There're several occasions that I needed to use Faraday instead of Net::HTTP, and while being mostly compatible, I had to monkey patch it for providing the "code" method.