### PR TITLE
Don't rebuild Env if you already have one

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -269,6 +269,15 @@ module Faraday
 
     def_delegators :request, :params_encoder
 
+    def self.from(value)
+      case value
+      when Env
+        value
+      else
+        super(value)
+      end
+    end
+
     # Public
     def [](key)
       if in_member_set?(key)

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -201,6 +201,21 @@ class OptionsTest < Faraday::TestCase
     assert_equal :get, e.method
   end
 
+  def test_env_from_hash
+    e = Faraday::Env.from({ :method => :get })
+    assert_equal :get, e.method
+  end
+
+  def test_env_from_env
+    e = Faraday::Env.from({ :method => :get })
+    e[:custom] = :boom
+
+    env = Faraday::Env.from(e)
+    assert_equal env.method, e.method
+    assert_equal env[:custom], e[:custom]
+    assert_equal env.object_id, e.object_id
+  end
+
   def test_env_access_symbol_non_member
     e = Faraday::Env.new
     assert_nil e[:custom]


### PR DESCRIPTION
Save the Env :recycle::earth_americas: 

A small patch to help fixing caching middleware in https://github.com/lostisland/faraday_middleware/pull/74 by allowing `Faraday::Env.from` to reuse an `Env` instance if provided.

---
@technoweenie @mislav 