### PR TITLE
Add an optional "origin" option to authorization middleware.

### DIFF
--- a/lib/faraday/request/authorization.rb
+++ b/lib/faraday/request/authorization.rb
@@ -33,6 +33,8 @@ module Faraday
           raise ArgumentError, "origin must be an absolute HTTP URL: #{origin.inspect}"
         uri += '/' if uri.path.empty?
         @origin = uri
+      else
+        @origin = nil
       end
       super(app)
     end

--- a/lib/faraday/request/authorization.rb
+++ b/lib/faraday/request/authorization.rb
@@ -25,17 +25,48 @@ module Faraday
       "#{type} #{values * comma}"
     end
 
-    def initialize(app, type, token)
+    def initialize(app, type, token, origin = nil)
       @header_value = self.class.header(type, token)
+      if origin
+        uri = URI(origin)
+        URI::HTTP === uri && uri.host or
+          raise ArgumentError, "origin must be an absolute HTTP URL: #{origin.inspect}"
+        uri += '/' if uri.path.empty?
+        @origin = uri
+      end
       super(app)
     end
 
     # Public
     def call(env)
-      unless env.request_headers[KEY]
+      if !env.request_headers[KEY] && under_origin?(env[:url])
         env.request_headers[KEY] = @header_value
       end
       @app.call(env)
+    end
+
+    private
+
+    def under_origin?(uri)
+      return true unless @origin
+
+      uri.scheme == @origin.scheme &&
+        uri.port == @origin.port &&
+        # DomainName(uri.host) == DomainName(@origin.host) &&
+        uri.host.casecmp(@origin.host) == 0 &&
+        path_match?(@origin.path, uri.path)
+    end
+
+    def path_match?(base_path, target_path)
+      # Implementation taken from http-cookie
+      base_path.start_with?('/') or return false
+      # RFC 6265 5.1.4
+      bsize = base_path.size
+      tsize = target_path.size
+      return bsize == 1 if tsize == 0 # treat empty target_path as "/"
+      return false unless target_path.start_with?(base_path)
+      return true if bsize == tsize || base_path.end_with?('/')
+      target_path[bsize] == ?/
     end
   end
 end

--- a/lib/faraday/request/authorization.rb
+++ b/lib/faraday/request/authorization.rb
@@ -31,7 +31,7 @@ module Faraday
         uri = URI(origin)
         URI::HTTP === uri && uri.host or
           raise ArgumentError, "origin must be an absolute HTTP URL: #{origin.inspect}"
-        uri += '/' if uri.path.empty?
+        uri.path = '/' if uri.path.empty?
         @origin = uri
       else
         @origin = nil


### PR DESCRIPTION
This allows user to specify an "origin" URL only to which site the
authentication credentials given are passed via request header.

```
conn = Faraday.new { |faraday|
  faraday.request :url_encoded
  faraday.request :basic_auth, 'user', 'password1', 'http://example.org/private/'
  faraday.request :basic_auth, 'user', 'password2', 'http://example.net/'
}
```