### PR TITLE
Faraday::Utils::Headers#replace has side-effects

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -81,6 +81,7 @@ module Faraday
 
       def replace(other)
         clear
+        @names.clear
         self.update other
         self
       end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -41,6 +41,15 @@ class TestUtils < Faraday::TestCase
     end
   end
 
+  def test_replace_header_hash
+    headers = Faraday::Utils::Headers.new('authorization' => 't0ps3cr3t!')
+    assert headers.include?('authorization')
+
+    headers.replace({'content-type' => 'text/plain'})
+
+    assert !headers.include?('authorization')
+  end
+
   def normalize(url)
     Faraday::Utils::URI(url)
   end


### PR DESCRIPTION
The headers hash contains some local state inside the @names instance variable as a means of doing case-insensitive hashes. This has the side-effect that one has to remember to perform mirror operations on the @names hash in addition to the object itself(Headers).

A case in point is the replace method – which did not clear out the @names hash which was causing side-effects by not performing a mirror operation (clear) on the @names hash.