### PR TITLE
Fix response not changing with parallel requests

### DIFF
--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -61,8 +61,8 @@ module Faraday
 
     def finish(env)
       raise "response already finished" if finished?
-      @env = Env.from(env)
       @on_complete_callbacks.each { |callback| callback.call(env) }
+      @env = Env.from(env)
       return self
     end
 

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -166,6 +166,14 @@ class ResponseTest < Faraday::TestCase
     end
   end
 
+  def test_body_is_parsed_on_finish
+    response = Faraday::Response.new
+    response.on_complete { |env| env[:body] = env[:body].upcase }
+    response.finish(@env)
+
+    assert_equal "YIKES", response.body
+  end
+
   def test_not_success
     assert !@response.success?
   end


### PR DESCRIPTION
If we're doing parallel requests, and we're using for example `FaradayMiddleware::ParseJson`, then the responses' body would not be JSON-parsed.

``` ruby
require "faraday"
require "typhoeus/adapters/faraday"

connection = Faraday.new(url) do |b|
  b.response :json
  b.adapter :typhoeus
end

response = nil

connection.in_parallel do
  response = connection.get "/path"
end

response.body # JSON in string format
```

This is because response's `@env` would not be changed by the "on complete" callbacks, since `#finish` only changes the local `env`, and only after we initialized `@env`.
