### PR TITLE
Fix ActiveSupport::SafeBuffer#gsub bug

### DIFF
--- a/lib/faraday/parameters.rb
+++ b/lib/faraday/parameters.rb
@@ -3,8 +3,8 @@ module Faraday
     ESCAPE_RE = /[^a-zA-Z0-9 .~_-]/
 
     def self.escape(s)
-      return s.to_s.gsub(ESCAPE_RE) {
-        '%' + $&.unpack('H2' * $&.bytesize).join('%').upcase
+      s.to_s.gsub(ESCAPE_RE) {|match|
+        '%' + match.unpack('H2' * match.bytesize).join('%').upcase
       }.tr(' ', '+')
     end
 


### PR DESCRIPTION
Escaping failed while encoding nested parameters. 

```
NoMethodError: undefined method `bytesize' for nil:NilClass
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:7:in `block in escape'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/core_ext/string/output_safety.rb:169:in `gsub'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/activesupport-3.2.13/lib/active_support/core_ext/string/output_safety.rb:169:in `gsub'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:6:in `escape'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:55:in `block in encode'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:44:in `call'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:44:in `block (2 levels) in encode'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:42:in `each'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:42:in `block in encode'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:64:in `call'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:64:in `block in encode'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:62:in `each'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/parameters.rb:62:in `encode'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/utils.rb:153:in `to_query'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/request/url_encoded.rb:13:in `block in call'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/request/url_encoded.rb:21:in `match_content_type'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/request/url_encoded.rb:11:in `call'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/rack_builder.rb:139:in `build_response'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/connection.rb:377:in `run_request'
    from /srv/motorlot/shared/bundle/ruby/2.0.0/gems/faraday-0.9.0/lib/faraday/connection.rb:177:in `post'
```
