### PR TITLE
Add Response#redirect? to check for HTTP 3xx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Faraday Changelog
 
+## Unreleased
+
+* Add `Response#redirect?` to check for HTTP status codes in 3xx (@nathanl)
+
 ## v0.9.1
 
 * Refactor Net:HTTP adapter so that with_net_http_connection can be overridden to allow pooled connections. (@Ben-M)

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -257,6 +257,7 @@ module Faraday
     ContentLength = 'Content-Length'.freeze
     StatusesWithoutBody = Set.new [204, 304]
     SuccessfulStatuses = 200..299
+    RedirectStatuses = 300..399
 
     # A Set of HTTP verbs that typically send a body.  If no body is set for
     # these requests, the Content-Length header is set to 0.
@@ -290,6 +291,11 @@ module Faraday
     # Public
     def success?
       SuccessfulStatuses.include?(status)
+    end
+
+    # Public
+    def redirect?
+      RedirectStatuses.include?(status)
     end
 
     # Public

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -70,6 +70,10 @@ module Faraday
       finished? && env.success?
     end
 
+    def redirect?
+      finished? && env.redirect?
+    end
+
     # because @on_complete_callbacks cannot be marshalled
     def marshal_dump
       !finished? ? nil : {

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -178,6 +178,10 @@ class ResponseTest < Faraday::TestCase
     assert !@response.success?
   end
 
+  def test_not_redirect
+    assert !@response.redirect?
+  end
+
   def test_status
     assert_equal 404, @response.status
   end


### PR DESCRIPTION
Added only the sort of test that currently exists for `success?` in an effort to conform to the project's current approach. I could add a test where `redirect?` is true if you like.