### PR TITLE
Preserve and separate request and response bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ end
 ## GET ##
 
 response = conn.get '/nigiri/sake.json'     # GET http://sushi.com/nigiri/sake.json
-response.body
+response.response_body
 
 conn.get '/nigiri', { :name => 'Maguro' }   # GET http://sushi.com/nigiri?name=Maguro
 
@@ -45,7 +45,7 @@ conn.post '/nigiri', { :name => 'Maguro' }  # POST "name=maguro" to http://sushi
 conn.post do |req|
   req.url '/nigiri'
   req.headers['Content-Type'] = 'application/json'
-  req.body = '{ "name": "Unagi" }'
+  req.request_body = '{ "name": "Unagi" }'
 end
 
 ## Per-request options ##
@@ -127,12 +127,12 @@ later, response. Some keys are:
 # request phase
 :method - :get, :post, ...
 :url    - URI for the current request; also contains GET parameters
-:body   - POST parameters for :post/:put requests
+:request_body   - POST parameters for :post/:put requests
 :request_headers
 
 # response phase
 :status - HTTP response status code, such as 200
-:body   - the response body
+:response_body   - the response body
 :response_headers
 ```
 
@@ -157,11 +157,11 @@ end
 stubs.get('/uni') {[ 200, {}, 'urchin' ]}
 
 resp = test.get '/tamago'
-resp.body # => 'egg'
+resp.response_body # => 'egg'
 resp = test.get '/ebi'
-resp.body # => 'shrimp'
+resp.response_body # => 'shrimp'
 resp = test.get '/uni'
-resp.body # => 'urchin'
+resp.response_body # => 'urchin'
 resp = test.get '/else' #=> raises "no such stub" error
 
 # If you like, you can treat your stubs as mocks by verifying that all of

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -36,7 +36,7 @@ module Faraday
 
     def save_response(env, status, body, headers = nil)
       env.status = status
-      env.body = body
+      env.response_body = body
       env.response_headers = Utils::Headers.new.tap do |response_headers|
         response_headers.update headers unless headers.nil?
         yield(response_headers) if block_given?

--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -26,7 +26,7 @@ module Faraday
         end
 
         def read_body(env)
-          body = env[:body]
+          body = env[:request_body]
           body.respond_to?(:read) ? body.read : body
         end
 

--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -73,7 +73,7 @@ module Faraday
 
       # TODO: support streaming requests
       def read_body(env)
-        env[:body].respond_to?(:read) ? env[:body].read : env[:body]
+        env[:request_body].respond_to?(:read) ? env[:request_body].read : env[:request_body]
       end
     end
   end

--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -28,10 +28,10 @@ module Faraday
 
         # TODO Don't stream yet.
         # https://github.com/nahi/httpclient/pull/90
-        env[:body] = env[:body].read if env[:body].respond_to? :read
+        env[:request_body] = env[:request_body].read if env[:request_body].respond_to? :read
 
         resp = client.request env[:method], env[:url],
-          :body   => env[:body],
+          :body   => env[:request_body],
           :header => env[:request_headers]
 
         save_response env, resp.status, resp.body, resp.headers

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -59,21 +59,21 @@ module Faraday
       def create_request(env)
         request = Net::HTTPGenericRequest.new \
           env[:method].to_s.upcase,    # request method
-          !!env[:body],                # is there request body
+          !!env[:request_body],        # is there request body
           :head != env[:method],       # is there response body
           env[:url].request_uri,       # request uri path
           env[:request_headers]        # request headers
 
-        if env[:body].respond_to?(:read)
-          request.body_stream = env[:body]
+        if env[:request_body].respond_to?(:read)
+          request.body_stream = env[:request_body]
         else
-          request.body = env[:body]
+          request.body = env[:request_body]
         end
         request
       end
 
       def perform_request(http, env)
-        if :get == env[:method] and !env[:body]
+        if :get == env[:method] and !env[:request_body]
           # prefer `get` to `request` because the former handles gzip (ruby 1.9)
           http.get env[:url].request_uri, env[:request_headers]
         else

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -12,7 +12,7 @@ module Faraday
         super
 
         # TODO: support streaming requests
-        env[:body] = env[:body].read if env[:body].respond_to? :read
+        env[:request_body] = env[:request_body].read if env[:request_body].respond_to? :read
 
         session = @session ||= create_session
 
@@ -29,7 +29,7 @@ module Faraday
         end
 
         response = begin
-          data = env[:body] ? env[:body].to_s : nil
+          data = env[:request_body] ? env[:request_body].to_s : nil
           session.request(env[:method], env[:url].to_s, env[:request_headers], :data => data)
         rescue Errno::ECONNREFUSED, ::Patron::ConnectionFailed
           raise Error::ConnectionFailed, $!

--- a/lib/faraday/adapter/rack.rb
+++ b/lib/faraday/adapter/rack.rb
@@ -29,7 +29,7 @@ module Faraday
         super
         rack_env = {
           :method => env[:method],
-          :input  => env[:body].respond_to?(:read) ? env[:body].read : env[:body],
+          :input  => env[:request_body].respond_to?(:rread) ? env[:request_body].read : env[:request_body],
           'rack.url_scheme' => env[:url].scheme
         }
 

--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -27,7 +27,7 @@ module Faraday
 
       # TODO: support streaming requests
       def read_body(env)
-        env[:body] = env[:body].read if env[:body].respond_to? :read
+        env[:request_body] = env[:request_body].read if env[:request_body].respond_to? :read
       end
 
       def request(env)
@@ -38,7 +38,7 @@ module Faraday
 
         req = ::Typhoeus::Request.new env[:url].to_s,
           :method  => method,
-          :body    => env[:body],
+          :body    => env[:request_body],
           :headers => env[:request_headers],
           :disable_ssl_peer_verification => (env[:ssl] && env[:ssl].disable?)
 

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -123,7 +123,7 @@ module Faraday
     #   conn.get '/twitter/tweet/_search' do |req|
     #     req.headers[:content_type] = 'application/json'
     #     req.params[:routing] = 'kimchy'
-    #     req.body = JSON.generate(:query => {...})
+    #     req.request_body = JSON.generate(:query => {...})
     #   end
     #
     # Yields a Faraday::Response for further request customizations.
@@ -370,7 +370,7 @@ module Faraday
       request = build_request(method) do |req|
         req.url(url)                if url
         req.headers.update(headers) if headers
-        req.body = body             if body
+        req.request_body = body     if body
         yield(req) if block_given?
       end
 

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -251,7 +251,7 @@ module Faraday
     end
   end
 
-  class Env < Options.new(:method, :body, :url, :request, :request_headers,
+  class Env < Options.new(:method, :request_body, :response_body, :url, :request, :request_headers,
     :ssl, :parallel_manager, :params, :response, :response_headers, :status)
 
     ContentLength = 'Content-Length'.freeze
@@ -294,13 +294,13 @@ module Faraday
 
     # Public
     def needs_body?
-      !body && MethodsWithBodies.include?(method)
+      !request_body && MethodsWithBodies.include?(method)
     end
 
     # Public
     def clear_body
       request_headers[ContentLength] = '0'
-      self.body = ''
+      self.request_body = ''
     end
 
     # Public

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -172,7 +172,8 @@ module Faraday
 
     # ENV Keys
     # :method - a symbolized request method (:get, :post)
-    # :body   - the request body that will eventually be converted to a string.
+    # :request_body - the request body that will eventually be converted to a string.
+    # :response_body - the response body
     # :url    - URI instance for the current request.
     # :status           - HTTP response status code
     # :request_headers  - hash of HTTP Headers to be sent to the server
@@ -187,7 +188,7 @@ module Faraday
     #     :password   - Proxy server password
     # :ssl - Hash of options for configuring SSL requests.
     def build_env(connection, request)
-      Env.new(request.method, request.body,
+      Env.new(request.method, request.request_body, nil,
         connection.build_exclusive_url(request.path, request.params),
         request.options, request.headers, connection.ssl,
         connection.parallel_manager)

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -6,10 +6,10 @@ module Faraday
   #     req.headers['b'] = '2' # Header
   #     req.params['c']  = '3' # GET Param
   #     req['b']         = '2' # also Header
-  #     req.body = 'abc'
+  #     req.request_body = 'abc'
   #   end
   #
-  class Request < Struct.new(:method, :path, :params, :headers, :body, :options)
+  class Request < Struct.new(:method, :path, :params, :headers, :request_body, :options)
     extend MiddlewareRegistry
 
     register_middleware File.expand_path('../request', __FILE__),
@@ -69,7 +69,8 @@ module Faraday
 
     # ENV Keys
     # :method - a symbolized request method (:get, :post)
-    # :body   - the request body that will eventually be converted to a string.
+    # :request_body - the request body that will eventually be converted to a string.
+    # :response_body - the response body
     # :url    - URI instance for the current request.
     # :status           - HTTP response status code
     # :request_headers  - hash of HTTP Headers to be sent to the server
@@ -84,7 +85,7 @@ module Faraday
     #     :password   - Proxy server password
     # :ssl - Hash of options for configuring SSL requests.
     def to_env(connection)
-      Env.new(method, body, connection.build_exclusive_url(path, params),
+      Env.new(method, request_body, nil, connection.build_exclusive_url(path, params),
         options, headers, connection.ssl, connection.parallel_manager)
     end
   end

--- a/lib/faraday/request/multipart.rb
+++ b/lib/faraday/request/multipart.rb
@@ -9,15 +9,15 @@ module Faraday
       match_content_type(env) do |params|
         env.request.boundary ||= DEFAULT_BOUNDARY
         env.request_headers[CONTENT_TYPE] += "; boundary=#{env.request.boundary}"
-        env.body = create_multipart(env, params)
+        env.request_body = create_multipart(env, params)
       end
       @app.call env
     end
 
     def process_request?(env)
       type = request_type(env)
-      env.body.respond_to?(:each_key) and !env.body.empty? and (
-        (type.empty? and has_multipart?(env.body)) or
+      env.request_body.respond_to?(:each_key) and !env.request_body.empty? and (
+        (type.empty? and has_multipart?(env.request_body)) or
         type == self.class.mime_type
       )
     end

--- a/lib/faraday/request/url_encoded.rb
+++ b/lib/faraday/request/url_encoded.rb
@@ -10,7 +10,7 @@ module Faraday
     def call(env)
       match_content_type(env) do |data|
         params = Faraday::Utils::ParamsHash[data]
-        env.body = params.to_query(env.params_encoder)
+        env.request_body = params.to_query(env.params_encoder)
       end
       @app.call env
     end
@@ -18,13 +18,13 @@ module Faraday
     def match_content_type(env)
       if process_request?(env)
         env.request_headers[CONTENT_TYPE] ||= self.class.mime_type
-        yield(env.body) unless env.body.respond_to?(:to_str)
+        yield(env.request_body) unless env.request_body.respond_to?(:to_str)
       end
     end
 
     def process_request?(env)
       type = request_type(env)
-      env.body and (type.empty? or type == self.class.mime_type)
+      env.request_body and (type.empty? or type == self.class.mime_type)
     end
 
     def request_type(env)

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -13,7 +13,7 @@ module Faraday
       # Override this to modify the environment after the response has finished.
       # Calls the `parse` method if defined
       def on_complete(env)
-        env.body = parse(env.body) if respond_to?(:parse) && env.parse_body?
+        env.response_body = parse(env.response_body) if respond_to?(:parse) && env.parse_body?
       end
     end
 
@@ -42,8 +42,8 @@ module Faraday
     end
     def_delegator :headers, :[]
 
-    def body
-      finished? ? env.body : nil
+    def response_body
+      finished? ? env.response_body : nil
     end
 
     def finished?
@@ -73,7 +73,7 @@ module Faraday
     # because @on_complete_callbacks cannot be marshalled
     def marshal_dump
       !finished? ? nil : {
-        :status => @env.status, :body => @env.body,
+        :status => @env.status, :response_body => @env.response_body,
         :response_headers => @env.response_headers
       }
     end

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -15,7 +15,7 @@ module Faraday
     end
 
     def response_values(env)
-      {:status => env.status, :headers => env.response_headers, :body => env.body}
+      {:status => env.status, :headers => env.response_headers, :request_body => env.request_body}
     end
   end
 end

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -31,12 +31,12 @@ module Adapters
           resp1 = connection.get('echo?a=1')
           resp2 = connection.get('echo?b=2')
           assert connection.in_parallel?
-          assert_nil resp1.body
-          assert_nil resp2.body
+          assert_nil resp1.response_body
+          assert_nil resp2.response_body
         end
         assert !connection.in_parallel?
-        assert_equal 'get ?{"a"=>"1"}', resp1.body
-        assert_equal 'get ?{"b"=>"2"}', resp2.body
+        assert_equal 'get ?{"a"=>"1"}', resp1.response_body
+        assert_equal 'get ?{"b"=>"2"}', resp2.response_body
       end
     end
 
@@ -47,7 +47,7 @@ module Adapters
 
         err = capture_warnings do
           connection.in_parallel do
-            response = connection.get('echo').body
+            response = connection.get('echo').response_body
           end
         end
         assert response
@@ -59,7 +59,7 @@ module Adapters
     module Compression
       def test_GET_handles_compression
         res = get('echo_header', :name => 'accept-encoding')
-        assert_match(/gzip;.+\bdeflate\b/, res.body)
+        assert_match(/gzip;.+\bdeflate\b/, res.response_body)
       end
     end
 
@@ -79,11 +79,11 @@ module Adapters
       def_delegators :create_connection, :get, :head, :put, :post, :patch, :delete, :run_request
 
       def test_GET_retrieves_the_response_body
-        assert_equal 'get', get('echo').body
+        assert_equal 'get', get('echo').response_body
       end
 
       def test_GET_send_url_encoded_params
-        assert_equal %(get ?{"name"=>"zack"}), get('echo', :name => 'zack').body
+        assert_equal %(get ?{"name"=>"zack"}), get('echo', :name => 'zack').response_body
       end
 
       def test_GET_retrieves_the_response_headers
@@ -98,28 +98,28 @@ module Adapters
 
       def test_GET_with_body
         response = get('echo') do |req|
-          req.body = {'bodyrock' => true}
+          req.request_body = {'bodyrock' => true}
         end
-        assert_equal %(get {"bodyrock"=>"true"}), response.body
+        assert_equal %(get {"bodyrock"=>"true"}), response.response_body
       end
 
       def test_GET_sends_user_agent
         response = get('echo_header', {:name => 'user-agent'}, :user_agent => 'Agent Faraday')
-        assert_equal 'Agent Faraday', response.body
+        assert_equal 'Agent Faraday', response.response_body
       end
 
       def test_GET_ssl
         expected = self.class.ssl_mode?.to_s
-        assert_equal expected, get('ssl').body
+        assert_equal expected, get('ssl').response_body
       end
 
       def test_POST_send_url_encoded_params
-        assert_equal %(post {"name"=>"zack"}), post('echo', :name => 'zack').body
+        assert_equal %(post {"name"=>"zack"}), post('echo', :name => 'zack').response_body
       end
 
       def test_POST_send_url_encoded_nested_params
         resp = post('echo', 'name' => {'first' => 'zack'})
-        assert_equal %(post {"name"=>{"first"=>"zack"}}), resp.body
+        assert_equal %(post {"name"=>{"first"=>"zack"}}), resp.response_body
       end
 
       def test_POST_retrieves_the_response_headers
@@ -128,18 +128,18 @@ module Adapters
 
       def test_POST_sends_files
         resp = post('file') do |req|
-          req.body = {'uploaded_file' => Faraday::UploadIO.new(__FILE__, 'text/x-ruby')}
+          req.request_body = {'uploaded_file' => Faraday::UploadIO.new(__FILE__, 'text/x-ruby')}
         end
-        assert_equal "file integration.rb text/x-ruby #{File.size(__FILE__)}", resp.body
+        assert_equal "file integration.rb text/x-ruby #{File.size(__FILE__)}", resp.response_body
       end
 
       def test_PUT_send_url_encoded_params
-        assert_equal %(put {"name"=>"zack"}), put('echo', :name => 'zack').body
+        assert_equal %(put {"name"=>"zack"}), put('echo', :name => 'zack').response_body
       end
 
       def test_PUT_send_url_encoded_nested_params
         resp = put('echo', 'name' => {'first' => 'zack'})
-        assert_equal %(put {"name"=>{"first"=>"zack"}}), resp.body
+        assert_equal %(put {"name"=>{"first"=>"zack"}}), resp.response_body
       end
 
       def test_PUT_retrieves_the_response_headers
@@ -147,16 +147,16 @@ module Adapters
       end
 
       def test_PATCH_send_url_encoded_params
-        assert_equal %(patch {"name"=>"zack"}), patch('echo', :name => 'zack').body
+        assert_equal %(patch {"name"=>"zack"}), patch('echo', :name => 'zack').response_body
       end
 
       def test_OPTIONS
         resp = run_request(:options, 'echo', nil, {})
-        assert_equal 'options', resp.body
+        assert_equal 'options', resp.response_body
       end
 
       def test_HEAD_retrieves_no_response_body
-        assert_equal '', head('echo').body
+        assert_equal '', head('echo').response_body
       end
 
       def test_HEAD_retrieves_the_response_headers
@@ -168,7 +168,7 @@ module Adapters
       end
 
       def test_DELETE_retrieves_the_body
-        assert_equal %(delete), delete('echo').body
+        assert_equal %(delete), delete('echo').response_body
       end
 
       def test_timeout
@@ -189,7 +189,7 @@ module Adapters
         conn = create_connection(:proxy => proxy_uri)
 
         res = conn.get '/echo'
-        assert_equal 'get', res.body
+        assert_equal 'get', res.response_body
 
         unless self.class.ssl_mode?
           # proxy can't append "Via" header for HTTPS responses
@@ -214,7 +214,7 @@ module Adapters
 
       def test_empty_body_response_represented_as_blank_string
         response = get('204')
-        assert_equal '', response.body
+        assert_equal '', response.response_body
       end
 
       def adapter

--- a/test/adapters/logger_test.rb
+++ b/test/adapters/logger_test.rb
@@ -19,7 +19,7 @@ module Adapters
     end
 
     def test_still_returns_output
-      assert_equal 'hello', @resp.body
+      assert_equal 'hello', @resp.response_body
     end
 
     def test_logs_method_and_url

--- a/test/adapters/test_middleware_test.rb
+++ b/test/adapters/test_middleware_test.rb
@@ -21,22 +21,22 @@ module Adapters
     end
 
     def test_middleware_with_simple_path_sets_body
-      assert_equal 'hello', @resp.body
+      assert_equal 'hello', @resp.response_body
     end
 
     def test_middleware_can_be_called_several_times
-      assert_equal 'hello', @conn.get("/hello").body
+      assert_equal 'hello', @conn.get("/hello").response_body
     end
 
     def test_middleware_with_get_params
       @stubs.get('/param?a=1') { [200, {}, 'a'] }
-      assert_equal 'a', @conn.get('/param?a=1').body
+      assert_equal 'a', @conn.get('/param?a=1').response_body
     end
 
     def test_middleware_ignores_unspecified_get_params
       @stubs.get('/optional?a=1') { [200, {}, 'a'] }
-      assert_equal 'a', @conn.get('/optional?a=1&b=1').body
-      assert_equal 'a', @conn.get('/optional?a=1').body
+      assert_equal 'a', @conn.get('/optional?a=1&b=1').response_body
+      assert_equal 'a', @conn.get('/optional?a=1').response_body
       assert_raises Faraday::Adapter::Test::Stubs::NotFound do
         @conn.get('/optional')
       end
@@ -45,15 +45,15 @@ module Adapters
     def test_middleware_with_http_headers
       @stubs.get('/yo', { 'X-HELLO' => 'hello' }) { [200, {}, 'a'] }
       @stubs.get('/yo') { [200, {}, 'b'] }
-      assert_equal 'a', @conn.get('/yo') { |env| env.headers['X-HELLO'] = 'hello' }.body
-      assert_equal 'b', @conn.get('/yo').body
+      assert_equal 'a', @conn.get('/yo') { |env| env.headers['X-HELLO'] = 'hello' }.response_body
+      assert_equal 'b', @conn.get('/yo').response_body
     end
 
     def test_middleware_allow_different_outcomes_for_the_same_request
       @stubs.get('/hello') { [200, {'Content-Type' => 'text/html'}, 'hello'] }
       @stubs.get('/hello') { [200, {'Content-Type' => 'text/html'}, 'world'] }
-      assert_equal 'hello', @conn.get("/hello").body
-      assert_equal 'world', @conn.get("/hello").body
+      assert_equal 'hello', @conn.get("/hello").response_body
+      assert_equal 'world', @conn.get("/hello").response_body
     end
 
     def test_yields_env_to_stubs
@@ -66,7 +66,7 @@ module Adapters
       end
 
       @conn.headers['Accept'] = 'text/plain'
-      assert_equal 'a', @conn.get('http://foo.com/hello?a=1').body
+      assert_equal 'a', @conn.get('http://foo.com/hello?a=1').response_body
     end
 
     def test_parses_params_with_default_encoder
@@ -75,7 +75,7 @@ module Adapters
         [200, {}, 'a']
       end
 
-      assert_equal 'a', @conn.get('http://foo.com/hello?a[b]=1').body
+      assert_equal 'a', @conn.get('http://foo.com/hello?a[b]=1').response_body
     end
 
     def test_parses_params_with_nested_encoder
@@ -85,7 +85,7 @@ module Adapters
       end
 
       @conn.options.params_encoder = Faraday::NestedParamsEncoder
-      assert_equal 'a', @conn.get('http://foo.com/hello?a[b]=1').body
+      assert_equal 'a', @conn.get('http://foo.com/hello?a[b]=1').response_body
     end
 
     def test_parses_params_with_flat_encoder
@@ -95,7 +95,7 @@ module Adapters
       end
 
       @conn.options.params_encoder = Faraday::FlatParamsEncoder
-      assert_equal 'a', @conn.get('http://foo.com/hello?a[b]=1').body
+      assert_equal 'a', @conn.get('http://foo.com/hello?a[b]=1').response_body
     end
 
     def test_raises_an_error_if_no_stub_is_found_for_request

--- a/test/authentication_middleware_test.rb
+++ b/test/authentication_middleware_test.rb
@@ -14,52 +14,52 @@ class AuthenticationMiddlewareTest < Faraday::TestCase
 
   def test_basic_middleware_adds_basic_header
     response = conn { |b| b.request :basic_auth, 'aladdin', 'opensesame' }.get('/auth-echo')
-    assert_equal 'Basic YWxhZGRpbjpvcGVuc2VzYW1l', response.body
+    assert_equal 'Basic YWxhZGRpbjpvcGVuc2VzYW1l', response.response_body
   end
 
   def test_basic_middleware_adds_basic_header_correctly_with_long_values
     response = conn { |b| b.request :basic_auth, 'A' * 255, '' }.get('/auth-echo')
-    assert_equal "Basic #{'QUFB' * 85}Og==", response.body
+    assert_equal "Basic #{'QUFB' * 85}Og==", response.response_body
   end
 
   def test_basic_middleware_does_not_interfere_with_existing_authorization
     response = conn { |b| b.request :basic_auth, 'aladdin', 'opensesame' }.
       get('/auth-echo', nil, :authorization => 'Token token="bar"')
-    assert_equal 'Token token="bar"', response.body
+    assert_equal 'Token token="bar"', response.response_body
   end
 
   def test_token_middleware_adds_token_header
     response = conn { |b| b.request :token_auth, 'quux' }.get('/auth-echo')
-    assert_equal 'Token token="quux"', response.body
+    assert_equal 'Token token="quux"', response.response_body
   end
 
   def test_token_middleware_includes_other_values_if_provided
     response = conn { |b|
       b.request :token_auth, 'baz', :foo => 42
     }.get('/auth-echo')
-    assert_match(/^Token /, response.body)
-    assert_match(/token="baz"/, response.body)
-    assert_match(/foo="42"/, response.body)
+    assert_match(/^Token /, response.response_body)
+    assert_match(/token="baz"/, response.response_body)
+    assert_match(/foo="42"/, response.response_body)
   end
 
   def test_token_middleware_does_not_interfere_with_existing_authorization
     response = conn { |b| b.request :token_auth, 'quux' }.
       get('/auth-echo', nil, :authorization => 'Token token="bar"')
-    assert_equal 'Token token="bar"', response.body
+    assert_equal 'Token token="bar"', response.response_body
   end
 
   def test_authorization_middleware_with_string
     response = conn { |b|
       b.request :authorization, 'custom', 'abc def'
     }.get('/auth-echo')
-    assert_match(/^custom abc def$/, response.body)
+    assert_match(/^custom abc def$/, response.response_body)
   end
 
   def test_authorization_middleware_with_hash
     response = conn { |b|
       b.request :authorization, 'baz', :foo => 42
     }.get('/auth-echo')
-    assert_match(/^baz /, response.body)
-    assert_match(/foo="42"/, response.body)
+    assert_match(/^baz /, response.response_body)
+    assert_match(/foo="42"/, response.response_body)
   end
 end

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -35,9 +35,9 @@ class EnvTest < Faraday::TestCase
 
   def test_request_create_stores_body
     env = make_env do |req|
-      req.body = 'hi'
+      req.request_body = 'hi'
     end
-    assert_equal 'hi', env.body
+    assert_equal 'hi', env.request_body
   end
 
   def test_global_request_options
@@ -151,7 +151,7 @@ end
 class ResponseTest < Faraday::TestCase
   def setup
     @env = Faraday::Env.from \
-      :status => 404, :body => 'yikes',
+      :status => 404, :response_body => 'yikes',
       :response_headers => {'Content-Type' => 'text/plain'}
     @response = Faraday::Response.new @env
   end
@@ -168,10 +168,10 @@ class ResponseTest < Faraday::TestCase
 
   def test_body_is_parsed_on_finish
     response = Faraday::Response.new
-    response.on_complete { |env| env[:body] = env[:body].upcase }
+    response.on_complete { |env| env[:response_body] = env[:response_body].upcase }
     response.finish(@env)
 
-    assert_equal "YIKES", response.body
+    assert_equal "YIKES", response.response_body
   end
 
   def test_not_success
@@ -183,7 +183,7 @@ class ResponseTest < Faraday::TestCase
   end
 
   def test_body
-    assert_equal 'yikes', @response.body
+    assert_equal 'yikes', @response.response_body
   end
 
   def test_headers
@@ -192,8 +192,8 @@ class ResponseTest < Faraday::TestCase
   end
 
   def test_apply_request
-    @response.apply_request :body => 'a=b', :method => :post
-    assert_equal 'yikes', @response.body
+    @response.apply_request :request_body => 'a=b', :method => :post
+    assert_equal 'yikes', @response.response_body
     assert_equal :post, @response.env[:method]
   end
 
@@ -204,7 +204,7 @@ class ResponseTest < Faraday::TestCase
 
     loaded = Marshal.load Marshal.dump(@response)
     assert_nil loaded.env[:params]
-    assert_equal %w[body response_headers status], loaded.env.keys.map { |k| k.to_s }.sort
+    assert_equal %w[response_body response_headers status], loaded.env.keys.map { |k| k.to_s }.sort
   end
 
   def test_hash
@@ -213,6 +213,6 @@ class ResponseTest < Faraday::TestCase
     assert_equal @env.to_hash, hash
     assert_equal hash[:status], @response.status
     assert_equal hash[:response_headers], @response.headers
-    assert_equal hash[:body], @response.body
+    assert_equal hash[:response_body], @response.response_body
   end
 end

--- a/test/middleware/instrumentation_test.rb
+++ b/test/middleware/instrumentation_test.rb
@@ -33,7 +33,7 @@ module Middleware
 
       faraday = conn
       res = faraday.get '/'
-      assert_equal 'ok', res.body
+      assert_equal 'ok', res.response_body
 
       assert_equal 1, @instrumenter.instrumentations.size
       name, env = @instrumenter.instrumentations.first
@@ -46,7 +46,7 @@ module Middleware
 
       faraday = conn :name => 'booya'
       res = faraday.get '/'
-      assert_equal 'ok', res.body
+      assert_equal 'ok', res.response_body
 
       assert_equal 1, @instrumenter.instrumentations.size
       name, env = @instrumenter.instrumentations.first

--- a/test/middleware_stack_test.rb
+++ b/test/middleware_stack_test.rb
@@ -161,7 +161,7 @@ class MiddlewareStackTest < Faraday::TestCase
   end
 
   def assert_handlers(list)
-    echoed_list = @conn.get('/').body.to_s.split(':')
+    echoed_list = @conn.get('/').response_body.to_s.split(':')
     echoed_list.shift if echoed_list.first == ''
     assert_equal list, echoed_list
   end

--- a/test/request_middleware_test.rb
+++ b/test/request_middleware_test.rb
@@ -11,7 +11,7 @@ class RequestMiddlewareTest < Faraday::TestCase
       b.adapter :test do |stub|
         stub.post('/echo') do |env|
           posted_as = env[:request_headers]['Content-Type']
-          [200, {'Content-Type' => posted_as}, env[:body]]
+          [200, {'Content-Type' => posted_as}, env[:request_body]]
         end
       end
     end
@@ -34,32 +34,32 @@ class RequestMiddlewareTest < Faraday::TestCase
   def test_does_nothing_without_payload
     response = @conn.post('/echo')
     assert_nil response.headers['Content-Type']
-    assert response.body.empty?
+    assert response.response_body.empty?
   end
 
   def test_ignores_custom_content_type
     response = @conn.post('/echo', { :some => 'data' }, 'content-type' => 'application/x-foo')
     assert_equal 'application/x-foo', response.headers['Content-Type']
-    assert_equal({ :some => 'data' }, response.body)
+    assert_equal({ :some => 'data' }, response.response_body)
   end
 
   def test_url_encoded_no_header
     response = @conn.post('/echo', { :fruit => %w[apples oranges] })
     assert_equal 'application/x-www-form-urlencoded', response.headers['Content-Type']
-    assert_equal 'fruit%5B%5D=apples&fruit%5B%5D=oranges', response.body
+    assert_equal 'fruit%5B%5D=apples&fruit%5B%5D=oranges', response.response_body
   end
 
   def test_url_encoded_with_header
     response = @conn.post('/echo', {'a'=>123}, 'content-type' => 'application/x-www-form-urlencoded')
     assert_equal 'application/x-www-form-urlencoded', response.headers['Content-Type']
-    assert_equal 'a=123', response.body
+    assert_equal 'a=123', response.response_body
   end
 
   def test_url_encoded_nested
     response = @conn.post('/echo', { :user => {:name => 'Mislav', :web => 'mislav.net'} })
     assert_equal 'application/x-www-form-urlencoded', response.headers['Content-Type']
     expected = { 'user' => {'name' => 'Mislav', 'web' => 'mislav.net'} }
-    assert_equal expected, Faraday::Utils.parse_nested_query(response.body)
+    assert_equal expected, Faraday::Utils.parse_nested_query(response.response_body)
   end
 
   def test_url_encoded_non_nested
@@ -68,14 +68,14 @@ class RequestMiddlewareTest < Faraday::TestCase
     end
     assert_equal 'application/x-www-form-urlencoded', response.headers['Content-Type']
     expected = { 'dimensions' => ['date', 'location'] }
-    assert_equal expected, Faraday::Utils.parse_query(response.body)
-    assert_equal 'dimensions=date&dimensions=location', response.body
+    assert_equal expected, Faraday::Utils.parse_query(response.response_body)
+    assert_equal 'dimensions=date&dimensions=location', response.response_body
   end
 
   def test_url_encoded_unicode
     err = capture_warnings {
       response = @conn.post('/echo', {:str => "eé cç aã aâ"})
-      assert_equal "str=e%C3%A9+c%C3%A7+a%C3%A3+a%C3%A2", response.body
+      assert_equal "str=e%C3%A9+c%C3%A7+a%C3%A3+a%C3%A2", response.response_body
     }
     assert err.empty?, "stderr did include: #{err}"
   end
@@ -84,7 +84,7 @@ class RequestMiddlewareTest < Faraday::TestCase
     with_utf8 do
       err = capture_warnings {
         response = @conn.post('/echo', {:str => "eé cç aã aâ"})
-        assert_equal "str=e%C3%A9+c%C3%A7+a%C3%A3+a%C3%A2", response.body
+        assert_equal "str=e%C3%A9+c%C3%A7+a%C3%A3+a%C3%A2", response.response_body
       }
       assert err.empty?, "stderr did include: #{err}"
     end
@@ -92,7 +92,7 @@ class RequestMiddlewareTest < Faraday::TestCase
 
   def test_url_encoded_nested_keys
     response = @conn.post('/echo', {'a'=>{'b'=>{'c'=>['d']}}})
-    assert_equal "a%5Bb%5D%5Bc%5D%5B%5D=d", response.body
+    assert_equal "a%5Bb%5D%5Bc%5D%5B%5D=d", response.response_body
   end
 
   def test_multipart
@@ -105,11 +105,11 @@ class RequestMiddlewareTest < Faraday::TestCase
     payload = {:a => 1, :b => {:c => Faraday::UploadIO.new(__FILE__, 'text/x-ruby'), :d => 2}}
     response = @conn.post('/echo', payload)
 
-    assert_kind_of Faraday::CompositeReadIO, response.body
+    assert_kind_of Faraday::CompositeReadIO, response.response_body
     assert_equal "multipart/form-data; boundary=%s" % Faraday::Request::Multipart::DEFAULT_BOUNDARY,
       response.headers['Content-Type']
 
-    response.body.send(:ios).map{|io| io.read}.each do |io|
+    response.response_body.send(:ios).map{|io| io.read}.each do |io|
       if re = regexes.detect { |r| io =~ r }
         regexes.delete re
       end
@@ -127,11 +127,11 @@ class RequestMiddlewareTest < Faraday::TestCase
     payload = {:a => 1, :b =>[{:c => Faraday::UploadIO.new(__FILE__, 'text/x-ruby'), :d => 2}]}
     response = @conn.post('/echo', payload)
 
-    assert_kind_of Faraday::CompositeReadIO, response.body
+    assert_kind_of Faraday::CompositeReadIO, response.response_body
     assert_equal "multipart/form-data; boundary=%s" % Faraday::Request::Multipart::DEFAULT_BOUNDARY,
       response.headers['Content-Type']
 
-    response.body.send(:ios).map{|io| io.read}.each do |io|
+    response.response_body.send(:ios).map{|io| io.read}.each do |io|
       if re = regexes.detect { |r| io =~ r }
         regexes.delete re
       end

--- a/test/response_middleware_test.rb
+++ b/test/response_middleware_test.rb
@@ -40,7 +40,7 @@ class ResponseMiddlewareTest < Faraday::TestCase
 
   def test_upcase
     @conn.builder.insert(0, ResponseUpcaser)
-    assert_equal '<BODY></BODY>', @conn.get('ok').body
+    assert_equal '<BODY></BODY>', @conn.get('ok').response_body
   end
 end
 
@@ -63,10 +63,10 @@ class ResponseNoBodyMiddleWareTest < Faraday::TestCase
   end
 
   def test_204
-    assert_equal nil, @conn.get('no_content').body
+    assert_equal nil, @conn.get('no_content').response_body
   end
 
   def test_304
-    assert_equal nil, @conn.get('not_modified').body
+    assert_equal nil, @conn.get('not_modified').response_body
   end
 end


### PR DESCRIPTION
The body attribute would be set with the body from the response once a
request was completed. The other attributes of the request (url,
headers, etc.) are not clobbered because they don't share the same keys.

In the case of the headers, the work had already been done to separate
them out into separate attributes (response_headers vs.
request_headers). This does similar work.

Fixes #297

Depends on #389 since this breaks untested functionality in the Retry middleware. Once that has been merged, then this pull request needs to be modified so that the small amount of work from https://github.com/Nitrodist/faraday/commit/3348e99f8c0e94881848879f3b7b0a3794bea14a goes into it as well.