### PR TITLE
Update Utils::ParamsHash#update

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -126,7 +126,7 @@ module Faraday
       alias_method :key?, :include?
 
       def update(params)
-        params.each do |key, value|
+        params.try(:each) do |key, value|
           self[key] = value
         end
         self

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -126,9 +126,9 @@ module Faraday
       alias_method :key?, :include?
 
       def update(params)
-        params.try(:each) do |key, value|
+        params.each do |key, value|
           self[key] = value
-        end
+        end unless params.nil?
         self
       end
       alias_method :merge!, :update


### PR DESCRIPTION
Allowing for nil when setting params

There are situations where it makes sense to set request params with an object which may be nil or a hash. This may be just a preference, since you can always make sure you are not passing nil, but this would require an extra check sometimes which can be skipped.

If you deem this as a good idea, let me know.