### PR TITLE
Fix interval_randomness data type

### DIFF
--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -42,7 +42,7 @@ module Faraday
       end
 
       def interval_randomness
-        (self[:interval_randomness] ||= 0).to_i
+        (self[:interval_randomness] ||= 0).to_f
       end
 
       def backoff_factor


### PR DESCRIPTION
I found `interval_randomness` was decimal number but it's converted to integer in the getter method.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/lostisland/faraday/405)
<!-- Reviewable:end -->
