### PR TITLE
Remove request/timeout from autoloads, since it has been removed

### DIFF
--- a/lib/faraday/autoload.rb
+++ b/lib/faraday/autoload.rb
@@ -69,7 +69,6 @@ module Faraday
       :UrlEncoded => 'url_encoded',
       :Multipart => 'multipart',
       :Retry => 'retry',
-      :Timeout => 'timeout',
       :Authorization => 'authorization',
       :BasicAuthentication => 'basic_authentication',
       :TokenAuthentication => 'token_authentication',


### PR DESCRIPTION
request/timeout.rb was removed in 43343e971f4bb9366daa1188272389166396a5c0
