### PR TITLE
Remove remnant `require_libs` call from `Faraday::Utils`

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -1,5 +1,4 @@
 require 'thread'
-Faraday.require_libs 'parameters'
 
 module Faraday
   module Utils


### PR DESCRIPTION
Removes a call to `Faraday.require_libs` from `Faraday::Utils` which looks like it should have been removed in 1e5284c5adbe07561a44d2119e6415eb3390701f.

The `parameters.rb` file is already required in `lib/faraday.rb`.