### PR TITLE
use URI#find_proxy for proxy detection from env

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -81,11 +81,8 @@ module Faraday
 
       @proxy = nil
       proxy(options.fetch(:proxy) {
-        uri = ENV['http_proxy']
-        if uri && !uri.empty?
-          uri = 'http://' + uri if uri !~ /^http/i
-          uri
-        end
+        uri = URI(url_prefix).find_proxy
+        uri.instance_of?(URI::Generic) ? URI("http://#{uri}") : uri
       })
 
       yield(self) if block_given?


### PR DESCRIPTION
Faraday rolls [its own proxy detection](https://github.com/lostisland/faraday/blob/df9d5c31c577e6bab53af3e4a6635bb8a738e863/lib/faraday/connection.rb#L83) which doesn't behave comprehensively, not taking into account  `no_proxy` or `https_proxy` environment variables. Net::HTTP [relies](https://github.com/ruby/ruby/blob/106075eac89ede7bcd71616ba78f1344892140a4/lib/net/http.rb#L1028) on [URI#find_proxy](http://ruby-doc.org/stdlib-2.1.2/libdoc/uri/rdoc/URI/Generic.html#method-i-find_proxy). This commits makes Faraday do the same.
