### PR TITLE
Clarify block definition of connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Rack::Test, and a Test adapter for stubbing requests by hand.
 ## Usage
 
 ```ruby
+## CREATE CONNECTION ##
+
+# Use default request encoding and adapter middleware:
+conn = Faraday.new(:url => 'http://sushi.com')
+
+# To explicitly set the request encoding and/or other middlewares to use, define with a block.
+# Note: A connection defined with a block will not use any of the default middlewares that you get
+#       without a block, so you MUST define a request encoding and adapter explicitly.
+#       (defaults are explicitly used below)
+
 conn = Faraday.new(:url => 'http://sushi.com') do |faraday|
   faraday.request  :url_encoded             # form-encode POST params
   faraday.response :logger                  # log requests to STDOUT


### PR DESCRIPTION
Just adding or removing an empty block from the call to `Faraday.new` changes the behavior.  This should be documented.