### PR TITLE
Allow specifying methods that bypass :retry_if on Request::Retry

### DIFF
--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -22,7 +22,8 @@ module Faraday
 
     IDEMPOTENT_METHODS = [:delete, :get, :head, :options, :put]
 
-    class Options < Faraday::Options.new(:max, :interval, :interval_randomness, :backoff_factor, :exceptions, :retry_if)
+    class Options < Faraday::Options.new(:max, :interval, :interval_randomness, :backoff_factor,
+                                         :exceptions, :methods, :retry_if)
       DEFAULT_CHECK = lambda { |env,exception| false }
 
       def self.from(value)
@@ -54,6 +55,10 @@ module Faraday
                                      Error::TimeoutError])
       end
 
+      def methods
+        Array(self[:methods] ||= Faraday::Request::Retry::IDEMPOTENT_METHODS)
+      end
+
       def retry_if
         self[:retry_if] ||= DEFAULT_CHECK
       end
@@ -75,6 +80,9 @@ module Faraday
     #                       given as Class, Module, or String. (default:
     #                       [Errno::ETIMEDOUT, Timeout::Error,
     #                       Error::TimeoutError])
+    # methods             - A list of HTTP methods to retry without calling retry_if.  Pass
+    #                       an empty Array to call retry_if for all exceptions.
+    #                       (defaults to the idempotent HTTP methods in IDEMPOTENT_METHODS)
     # retry_if            - block that will receive the env object and the exception raised
     #                       and should decide if the code should retry still the action or
     #                       not independent of the retry count. This would be useful
@@ -133,7 +141,7 @@ module Faraday
     private
 
     def retry_request?(env, exception)
-      IDEMPOTENT_METHODS.include?(env[:method]) || @options.retry_if.call(env, exception)
+      @options.methods.include?(env[:method]) || @options.retry_if.call(env, exception)
     end
 
   end

--- a/test/middleware/retry_test.rb
+++ b/test/middleware/retry_test.rb
@@ -126,7 +126,7 @@ module Middleware
       assert_equal 1, @times_called
     end
 
-    def test_should_not_call_retry_if_for_idempotent_methods
+    def test_should_not_call_retry_if_for_idempotent_methods_if_methods_unspecified
       @explode = lambda {|n| raise Errno::ETIMEDOUT }
       check = lambda { |env,exception| raise "this should have never been called" }
       assert_raises(Errno::ETIMEDOUT) {
@@ -135,12 +135,30 @@ module Middleware
       assert_equal 3, @times_called
     end
 
-    def test_should_not_retry_for_non_idempotent_method
+    def test_should_not_retry_for_non_idempotent_method_if_methods_unspecified
       @explode = lambda {|n| raise Errno::ETIMEDOUT }
       assert_raises(Errno::ETIMEDOUT) {
         conn.post("/unstable")
       }
       assert_equal 1, @times_called
+    end
+
+    def test_should_not_call_retry_if_for_specified_methods
+      @explode = lambda {|n| raise Errno::ETIMEDOUT }
+      check = lambda { |env,exception| raise "this should have never been called" }
+      assert_raises(Errno::ETIMEDOUT) {
+        conn(:retry_if => check, :methods => [:post]).post("/unstable")
+      }
+      assert_equal 3, @times_called
+    end
+
+    def test_should_call_retry_if_for_empty_method_list
+      @explode = lambda {|n| raise Errno::ETIMEDOUT }
+      check = lambda { |env,exception| @times_called < 2 }
+      assert_raises(Errno::ETIMEDOUT) {
+        conn(:retry_if => check, :methods => []).get("/unstable")
+      }
+      assert_equal 2, @times_called
     end
 
   end


### PR DESCRIPTION
This expands the `IDEMPOTENT_METHODS` functionality to allow speifying the
methods that will be retried without calling `:retry_if`.  The new `:methods` option
to `Request::Retry` allows `:retry_if` to be called for every HTTP method, a user-
specified set of HTTP methods, or never.

It's likely that `:retry_if`, `IDEMPOTENT_METHODS`, and `:methods` could be
combined into a simpler API (such as by changing the `:retry_if` default value to
check for an idempotent method), but this separate approach preserves the
existing behavior if `:methods` is not specified.

Tests and documentation are included in the pull request; I ran the tests against
Ruby 2.1.3 and Ruby 1.8.7.