### PR TITLE
Treat connection timeouts as connection failures in net-http adapter.

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -25,6 +25,7 @@ module Faraday
       ]
 
       NET_HTTP_EXCEPTIONS << OpenSSL::SSL::SSLError if defined?(OpenSSL)
+      NET_HTTP_EXCEPTIONS << Net::OpenTimeout if defined?(Net::OpenTimeout)
 
       def call(env)
         super


### PR DESCRIPTION
This PR treats `Net::OpenTimeout` on newer 2.x versions of Ruby as a connection
failure, without changing the behavior on older versions of Ruby.  This allows one
to distinguish between `:open_timeout` connection timeouts and `:timeout` request
timeouts.
