### PR TITLE
Fix for issue with string keys in connection options

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -18,7 +18,7 @@ module Faraday
     # Public
     def update(obj)
       obj.each do |key, value|
-        if sub_options = self.class.options_for(key)
+        if sub_options = self.class.options_for(key.to_sym)
           value = sub_options.from(value) if value
         elsif Hash === value
           hash = {}

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -158,6 +158,15 @@ class OptionsTest < Faraday::TestCase
     assert_nil options.b
   end
 
+  def test_from_hash_with_string_keys_with_sub_object
+    options = ParentOptions.from 'a' => 1, 'c' => {'sub' => 1}
+    assert_kind_of ParentOptions, options
+    assert_equal 1, options.a
+    assert_kind_of SubOptions, options.c
+    assert_equal 1, options.c.sub
+    assert_nil options.b
+  end
+
   def test_invalid_key
     assert_raises NoMethodError do
       ParentOptions.from :invalid => 1


### PR DESCRIPTION
Hi!
Here is small fix for *Issue with a string keys in Faraday::Connection options #444*