### PR TITLE
Update link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,7 @@ We will accept middleware that:
 
 1. is useful to a broader audience, but can be implemented relatively
    simple; and
-2. which isn't already present in the [faraday_middleware](https://github.com/lostisland/faraday_middleware/wiki)
-   project.
+2. which isn't already present in the [faraday_middleware][] project.
 
 We will accept adapters that:
 


### PR DESCRIPTION
The current link in CONTRIBUTING.md goes to https://github.com/pengwynn/faraday_middleware/wiki
