### PR TITLE
NetHttp uses with_net_http_connection (#446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Faraday Changelog
 
+## v0.9.1
+
+* Refactor Net:HTTP adapter so that with_net_http_connection can be overridden to allow pooled connections. (@Ben-M)
+
 ## v0.9.0
 
 * Add HTTPClient adapter (@hakanensari)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ We will accept adapters that:
 2. if they have features not present in included adapters.
 
 We are pushing towards a 1.0 release, when we will have to follow [Semantic
-Versioning][semver].  If your patch includes changes to break compatiblitity,
+Versioning][semver].  If your patch includes changes to break compatibility,
 note that so we can add it to the [Changelog][].
 
 [semver]:    http://semver.org/

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -14,7 +14,7 @@ require 'forwardable'
 #   conn.get '/'
 #
 module Faraday
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 
   class << self
     # Public: Gets or sets the root path that Faraday is being loaded from.

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -8,7 +8,7 @@ module Faraday
     class NetHttpPersistent < NetHttp
       dependency 'net/http/persistent'
 
-      def net_http_connection(env)
+      def with_net_http_connection(env)
         if proxy = env[:request][:proxy]
           proxy_uri = ::URI::HTTP === proxy[:uri] ? proxy[:uri].dup : ::URI.parse(proxy[:uri].to_s)
           proxy_uri.user = proxy_uri.password = nil
@@ -18,7 +18,8 @@ module Faraday
             define_method(:password) { proxy[:password] }
           end if proxy[:user]
         end
-        Net::HTTP::Persistent.new 'Faraday', proxy_uri
+
+        yield Net::HTTP::Persistent.new 'Faraday', proxy_uri
       end
 
       def perform_request(http, env)


### PR DESCRIPTION
As discussed in #446 this switches Net:Http to use 'with_net_http_connection' internally, so that it can be overridden to allow for connection pooling.

Let me know if you'd prefer me to remove the version bump.