### PR TITLE
httpclient: Enable gzip compression

### DIFF
--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -10,6 +10,9 @@ module Faraday
       def call(env)
         super
 
+        # enable compression
+        client.transparent_gzip_decompression = true
+
         if req = env[:request]
           if proxy = req[:proxy]
             configure_proxy proxy

--- a/test/adapters/httpclient_test.rb
+++ b/test/adapters/httpclient_test.rb
@@ -17,5 +17,7 @@ module Adapters
         assert_equal host, conn.options[:bind][:host]
       end
     end
+
+    Integration.apply(self, :Compression)
   end
 end

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -59,7 +59,8 @@ module Adapters
     module Compression
       def test_GET_handles_compression
         res = get('echo_header', :name => 'accept-encoding')
-        assert_match(/gzip;.+\bdeflate\b/, res.body)
+        assert_match(/\bgzip\b/, res.body)
+        assert_match(/\bdeflate\b/, res.body)
       end
     end
 


### PR DESCRIPTION
Motivation: `httpclient` support gzip compression since late 2010 (see https://github.com/nahi/httpclient/issues/42).