### PR TITLE
Update VALID_ACTIONS in Patron adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'minitest', '>= 5.0.5'
   gem 'net-http-persistent', '>= 2.9.4'
-  gem 'patron', '>= 0.4.2', :platforms => :ruby
+  gem 'patron', '>= 0.4.20', :platforms => :ruby
   gem 'rack-test', '>= 0.6', :require => 'rack/test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]
   gem 'simplecov'

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -56,8 +56,8 @@ module Faraday
         # HAX: helps but doesn't work completely
         # https://github.com/toland/patron/issues/34
         ::Patron::Request::VALID_ACTIONS.tap do |actions|
-          actions << :patch unless actions.include? :patch
-          actions << :options unless actions.include? :options
+          actions << "PATCH" unless actions.include? "PATCH"
+          actions << "OPTIONS" unless actions.include? "OPTIONS"
         end
       end
 

--- a/test/adapters/patron_test.rb
+++ b/test/adapters/patron_test.rb
@@ -14,7 +14,7 @@ module Adapters
 
       # no support for SSL peer verification
       undef :test_GET_ssl_fails_with_bad_cert if ssl_mode?
-    end unless jruby?
+    end  unless RUBY_VERSION < '1.9' or jruby?
 
   end
 end


### PR DESCRIPTION
When running the tests, I get the following error:

```
1) Error:
Adapters::Patron#test_OPTIONS:
ArgumentError: Action must be one of GET, PUT, POST, DELETE, HEAD, COPY, patch, options
    /Users/benhanzl/.rvm/gems/ruby-2.2.0@faraday/gems/patron-0.4.20/lib/patron/request.rb:93:in `action='
    /Users/benhanzl/.rvm/gems/ruby-2.2.0@faraday/gems/patron-0.4.20/lib/patron/session.rb:210:in `block in build_request'
    /Users/benhanzl/.rvm/gems/ruby-2.2.0@faraday/gems/patron-0.4.20/lib/patron/session.rb:209:in `tap'
    /Users/benhanzl/.rvm/gems/ruby-2.2.0@faraday/gems/patron-0.4.20/lib/patron/session.rb:209:in `build_request'
    /Users/benhanzl/.rvm/gems/ruby-2.2.0@faraday/gems/patron-0.4.20/lib/patron/session.rb:200:in `request'
    /Users/benhanzl/code/faraday/lib/faraday/adapter/patron.rb:33:in `call'
    /Users/benhanzl/code/faraday/lib/faraday/response.rb:8:in `call'
    /Users/benhanzl/code/faraday/lib/faraday/request/url_encoded.rb:15:in `call'
    /Users/benhanzl/code/faraday/lib/faraday/request/multipart.rb:14:in `call'
    /Users/benhanzl/code/faraday/lib/faraday/rack_builder.rb:139:in `build_response'
    /Users/benhanzl/code/faraday/lib/faraday/connection.rb:377:in `run_request'
    /Users/benhanzl/code/faraday/test/adapters/integration.rb:155:in `test_OPTIONS'
```

Since the last build on Travis-CI, a new version of the Patron gem has been released. The breaking change is that they now use [uppercase strings](https://github.com/toland/patron/compare/v0.4.18...v0.4.20#diff-6a69cf7f78fed8289d7504e87c55fa23R35), instead of lowercase symbols, for validating the allowed actions.

I have updated the HAX in the Patron adapter to use the strings instead of the symbols and updated the Gemfile to require the latest version of the gem. If you would like to keep the dependency on the older version of Patron, I could instead add both the symbol and the string, but I thought this was cleaner.