### PR TITLE
Make excon adapter compatible with 0.44 excon version

### DIFF
--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -41,6 +41,7 @@ module Faraday
           if req[:proxy]
             opts[:proxy] = {
               :host     => req[:proxy][:uri].host,
+              :hostname => req[:proxy][:uri].hostname,
               :port     => req[:proxy][:uri].port,
               :scheme   => req[:proxy][:uri].scheme,
               :user     => req[:proxy][:user],


### PR DESCRIPTION
Now it always use 127.0.0.1 as proxy host