### PR TITLE
Added method sort_params= to Faraday::Connection

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -349,7 +349,7 @@ module Faraday
 
       query_values = params.dup.merge_query(uri.query, options.params_encoder)
       query_values.update extra_params if extra_params
-      uri.query = query_values.empty? ? nil : query_values.to_query(options.params_encoder)
+      uri.query = query_values.empty? ? nil : query_values.to_query(options.params_encoder, @sort_params)
 
       uri
     end
@@ -389,6 +389,15 @@ module Faraday
       end
     end
 
+    # Indicates whether to sort parameters. By default parameters are sorted.
+    #
+    # conn = Faraday::Connection.new { ... }
+    # conn.sort_params = false
+    #
+    def sort_params=(value)
+      @sort_params = value
+    end
+
     # Internal: Build an absolute URL based on url_prefix.
     #
     # url    - A String or URI-like object
@@ -404,7 +413,7 @@ module Faraday
         base.path = base.path + '/'  # ensure trailing slash
       end
       uri = url ? base + url : base
-      uri.query = params.to_query(options.params_encoder) if params
+      uri.query = params.to_query(options.params_encoder, @sort_params) if params
       uri.query = nil if uri.query and uri.query.empty?
       uri
     end

--- a/lib/faraday/parameters.rb
+++ b/lib/faraday/parameters.rb
@@ -7,7 +7,7 @@ module Faraday
       def_delegators :'Faraday::Utils', :escape, :unescape
     end
 
-    def self.encode(params)
+    def self.encode(params, sort_params = true)
       return nil if params == nil
 
       if !params.is_a?(Array)
@@ -22,7 +22,9 @@ module Faraday
         end
         # Useful default for OAuth and caching.
         # Only to be used for non-Array inputs. Arrays should preserve order.
-        params.sort!
+        if sort_params
+          params.sort!
+        end
       end
 
       # Helper lambda
@@ -117,7 +119,7 @@ module Faraday
       def_delegators :'Faraday::Utils', :escape, :unescape
     end
 
-    def self.encode(params)
+    def self.encode(params, sort_params = true)
       return nil if params == nil
 
       if !params.is_a?(Array)
@@ -132,7 +134,9 @@ module Faraday
         end
         # Useful default for OAuth and caching.
         # Only to be used for non-Array inputs. Arrays should preserve order.
-        params.sort!
+        if sort_params
+          params.sort!
+        end
       end
 
       # The params have form [['key1', 'value1'], ['key2', 'value2']].

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -149,8 +149,8 @@ module Faraday
         self
       end
 
-      def to_query(encoder = nil)
-        (encoder || Utils.default_params_encoder).encode(self)
+      def to_query(encoder = nil, sort_params = true)
+        (encoder || Utils.default_params_encoder).encode(self, sort_params)
       end
 
       private


### PR DESCRIPTION
- The sort_params= method takes in a boolean which
  indicates whether to sort request parameters.
  By default Faraday sorts the paramerers.