### PR TITLE
Instrument the number of retries

### DIFF
--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -107,7 +107,10 @@ module Faraday
       request_body = env[:body]
       begin
         env[:body] = request_body # after failure env[:body] is set to the response body
-        @app.call(env)
+        @app.call(env).on_complete do |response_env|
+          # add the number of retries to the env:
+          response_env[:retries] = @options.max - retries
+        end
       rescue @errmatch => exception
         if retries > 0 && retry_request?(env, exception)
           retries -= 1

--- a/test/middleware/retry_test.rb
+++ b/test/middleware/retry_test.rb
@@ -173,5 +173,19 @@ module Middleware
       assert_equal 2, @times_called
     end
 
+    def test_adds_info_to_env
+      @explode = lambda do |n|
+        if n <= 2
+          puts "raise!"
+          raise Errno::ETIMEDOUT
+        else
+          [200, {}, ""]
+        end
+      end
+
+      response = conn.get("/unstable")
+      assert_equal 2, response.env[:retries]
+    end
+
   end
 end


### PR DESCRIPTION
Adds an entry in the response env for the number of retries that were performed before the request succeeded.
