### PR TITLE
Add Manticore adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :test do
   gem 'simplecov'
   gem 'sinatra', '~> 1.3'
   gem 'typhoeus', '~> 0.3.3', :platforms => [:ruby_18, :ruby_19, :ruby_20, :ruby_21]
+  gem 'manticore', '~> 0.4', :platforms => [:jruby]
 end
 
 gemspec

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -14,7 +14,8 @@ module Faraday
       :em_http => [:EMHttp, 'em_http'],
       :excon => [:Excon, 'excon'],
       :rack => [:Rack, 'rack'],
-      :httpclient => [:HTTPClient, 'httpclient']
+      :httpclient => [:HTTPClient, 'httpclient'],
+      :manticore => [:Manticore, 'manticore']
 
     # Public: This module marks an Adapter as supporting parallel requests.
     module Parallelism

--- a/lib/faraday/adapter/manticore.rb
+++ b/lib/faraday/adapter/manticore.rb
@@ -1,0 +1,90 @@
+module Faraday
+  class Adapter
+    class Manticore < Faraday::Adapter
+      dependency { require 'manticore' }
+
+      class ParallelManager
+        def client=(client)
+          @client ||= client
+        end
+
+        def run
+          @client.execute! if @client
+        end
+      end
+
+      self.supports_parallel = true
+      def self.setup_parallel_manager(options = {})
+        ParallelManager.new
+      end
+
+      def client(env)
+        @client ||= begin
+          opts = {}
+          opts[:ssl] = env[:ssl].to_hash if env[:ssl]
+          ::Manticore::Client.new(opts)
+        end
+      end
+
+      def call(env)
+        super
+
+        opts = {}
+        if env.key? :request_headers
+          opts[:headers] = env[:request_headers]
+          opts[:headers].reject! {|k, _| k.downcase == "content-length" }  # Manticore computes Content-Length
+        end
+        body = read_body(env)
+        opts[:body] = body if body
+
+        if req = env[:request]
+          opts[:request_timeout] = opts[:connect_timeout] = opts[:socket_timeout] = req[:timeout] if req.key?(:timeout)
+          opts[:connect_timeout] = opts[:socket_timeout] = req[:open_timeout] if req.key?(:open_timeout)
+          if prx = req[:proxy]
+            opts[:proxy] = {
+              :url      => prx[:uri].to_s,
+              :user     => prx[:user],
+              :password => prx[:password]
+            }
+          end
+        end
+
+        cl = client(env)
+        if parallel?(env)
+          env[:parallel_manager].client = cl
+          cl = cl.async
+        end
+
+        last_exception = nil
+
+        req = cl.send(env[:method].to_s.downcase, env[:url].to_s, opts)
+        req.on_success do |response|
+          save_response(env, response.code, response.body || "", response.headers)
+          env[:response].finish(env) if parallel?(env)
+        end
+
+        req.on_failure do |err|
+          case err
+          when ::Manticore::Timeout
+            raise TimeoutError, err
+          when ::Manticore::SocketException, ::Java::JavaUtilConcurrent::ExecutionException
+            raise ConnectionFailed, err
+          else
+            raise err
+          end
+        end
+
+        req.call unless parallel?(env)
+        @app.call env
+      end
+
+      def parallel?(env)
+        !env[:parallel_manager].nil?
+      end
+
+      def read_body(env)
+        env[:body].respond_to?(:read) ? env[:body].read : env[:body]
+      end
+    end
+  end
+end

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -181,7 +181,7 @@ module Adapters
 
       def test_connection_error
         assert_raises Faraday::Error::ConnectionFailed do
-          get 'http://localhost:4'
+          create_connection.get 'http://localhost:4'
         end
       end
 

--- a/test/adapters/manticore_test.rb
+++ b/test/adapters/manticore_test.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../integration', __FILE__)
+
+module Adapters
+  class ManticoreTest < Faraday::TestCase
+
+    def adapter() :manticore end
+
+    behaviors = [:Parallel, :Compression]
+    Integration.apply(self, *behaviors) if jruby?
+  end
+end


### PR DESCRIPTION
This adds an adapter for [Manticore](https://github.com/cheald/manticore), a high-performance JRuby-only HTTP client.

I can distribute the adapter with Manticore directly, but I figured I'd try this first, since this makes it much easier to make sure that the adapter doesn't break with Faraday changes; by testing it with the Faraday test suite, it'll be easier to make sure things work as intended in the future.

Parallel requests are supported and work well. Compression is supported. SSL is supported, but it takes different keys than Faraday's defaults, since Manticore can't currently read PEM certificates (it prefers JKS and PKCS12). Streaming reads are easily supported once Faraday's interface for streaming is implemented.