### PR TITLE
Env stored on middleware response has reference to the response

### DIFF
--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -151,8 +151,9 @@ module Faraday
         lock!
         to_app(lambda { |env|
           response = Response.new
-          response.finish(env) unless env.parallel?
           env.response = response
+          response.finish(env) unless env.parallel?
+          response
         })
       end
     end

--- a/test/middleware_stack_test.rb
+++ b/test/middleware_stack_test.rb
@@ -143,6 +143,15 @@ class MiddlewareStackTest < Faraday::TestCase
     assert_match "zomg/i_dont/exist", err.message
   end
 
+  def test_env_stored_on_middleware_response_has_reference_to_the_response
+    env = response = nil
+    build_stack Struct.new(:app) {
+      define_method(:call) { |e| env, response = e, app.call(e) }
+    }
+    @conn.get("/")
+    assert_same env.response, response.env.response
+  end
+
   private
 
   # make a stack with test adapter that reflects the order of middleware


### PR DESCRIPTION
Synopsis
--------

The `Env` that gets stored on the `Response` does not contain a reference to that response. This env is a copy of the env that was passed through the middleware stack. Thus if the env passed to `app.call` is used, it has the response, but if the one from the `Response` is used, then it does not. This happens when, for example, you invoke the `on_complete` hook on the response, after it has finished.


Fixes Longstanding VCR issue
----------------------------

Fixes https://github.com/vcr/vcr/issues/386

A longstanding issue in VCR's integration with v0.9.x It was worked around in this commit: https://github.com/vcr/vcr/pull/439 And is merged into master, but is not released. Merging this will fix the issue, without the changes to VCR needing to be released.

The old code, which is currently released, and gets its env from the Request can be seen [here](https://github.com/vcr/vcr/blob/cb9696c44dee4c0d39b4f531e72516f4bc57272f%5E/lib/vcr/middleware/faraday.rb#L99-105)


Fixes Faraday Issue
-------------------

Fixes https://github.com/lostisland/faraday/issues/441
which identifies this same problem.


Closes Faraday PR
-----------------

I'm going to recommend closing https://github.com/lostisland/faraday/pull/360/files as the issue was probably introduced [here](https://github.com/lostisland/faraday/commit/04a8514cba58f899183dbe2d5c7c4281d1e85f3f#diff-fc9726b31994223d11a212b5169100fdL68) when `Response#finish` changed from storing the `env` directly, to storing a copy:

```diff
- @env = env
+ @env = Env.from(env)
```

Presumably this behaviour is still desired, but the mentioned pull essentially undoes this by returning the same `env` from `Env.from` ([link](https://github.com/lostisland/faraday/pull/360/files#diff-32dfef617839b0b1d5f792c3d3da8420R275))

The commit that introduced the issue is probably good, but is called by the app in the middleware stack that creates the response, before it sets the rsponse onto the env. This means that the copy does not have the link to the response.

https://github.com/lostisland/faraday/blob/81f16593a0138ec58bb6f25e1c2804e91589662f/lib/faraday/rack_builder.rb#L152-155


Not sure about the test name/location
-------------------------------------

I had difficulty figuring out where to put this test, and what to name it. I eventually went with the test on the `middleware_stack_test.rb`, because it deals with the `RackBuilder`, but if there's a better place,
or a better name, let me know and I'll update it.


One other weird thing
---------------------

Depending on when the `Request#on_complete` callback is invoked, you're either getting the original env, or the copy:

https://github.com/lostisland/faraday/blob/81f16593a0138ec58bb6f25e1c2804e91589662f/lib/faraday/response.rb#L53-67