### PR TITLE
Extend patrons VALID_ACTIONS by uppercased strings instead of symbols.

### DIFF
--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -56,8 +56,8 @@ module Faraday
         # HAX: helps but doesn't work completely
         # https://github.com/toland/patron/issues/34
         ::Patron::Request::VALID_ACTIONS.tap do |actions|
-          actions << :patch unless actions.include? :patch
-          actions << :options unless actions.include? :options
+          actions << 'PATCH' unless actions.include? 'PATCH'
+          actions << 'OPTIONS' unless actions.include? 'OPTIONS'
         end
       end
 


### PR DESCRIPTION
When I downloaded faraday and tried to run tests `Adapters::Patron#test_OPTIONS` failed with:

```
  1) Error:
Adapters::Patron#test_OPTIONS:
ArgumentError: Action must be one of GET, PUT, POST, DELETE, HEAD, COPY, patch, options
    /Users/edariedl/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/patron-0.4.20/lib/patron/request.rb:93:in `action='
    /Users/edariedl/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/patron-0.4.20/lib/patron/session.rb:210:in `block in build_request'
    /Users/edariedl/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/patron-0.4.20/lib/patron/session.rb:209:in `tap'
    /Users/edariedl/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/patron-0.4.20/lib/patron/session.rb:209:in `build_request'
    /Users/edariedl/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/patron-0.4.20/lib/patron/session.rb:200:in `request'
    /Users/edariedl/Public/repos/faraday/lib/faraday/adapter/patron.rb:33:in `call'
    /Users/edariedl/Public/repos/faraday/lib/faraday/response.rb:8:in `call'
    /Users/edariedl/Public/repos/faraday/lib/faraday/request/url_encoded.rb:15:in `call'
    /Users/edariedl/Public/repos/faraday/lib/faraday/request/multipart.rb:14:in `call'
    /Users/edariedl/Public/repos/faraday/lib/faraday/rack_builder.rb:139:in `build_response'
    /Users/edariedl/Public/repos/faraday/lib/faraday/connection.rb:377:in `run_request'
    /Users/edariedl/Public/repos/faraday/test/adapters/integration.rb:155:in `test_OPTIONS'
```

When action is checked in patron gem it is converted to string and upcased https://github.com/toland/patron/blob/master/lib/patron/request.rb#L92 and than compered with `VALIDATE_ACTIONS` array.