### PR TITLE
Update ENV Keys docs to use `options` rather than `request`

### DIFF
--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -68,21 +68,21 @@ module Faraday
     end
 
     # ENV Keys
-    # :method - a symbolized request method (:get, :post)
-    # :body   - the request body that will eventually be converted to a string.
-    # :url    - URI instance for the current request.
+    # :method           - a symbolized request method (:get, :post)
+    # :body             - the request body that will eventually be converted to a string.
+    # :url              - URI instance for the current request.
     # :status           - HTTP response status code
     # :request_headers  - hash of HTTP Headers to be sent to the server
     # :response_headers - Hash of HTTP headers from the server
     # :parallel_manager - sent if the connection is in parallel mode
-    # :request - Hash of options for configuring the request.
-    #   :timeout      - open/read timeout Integer in seconds
-    #   :open_timeout - read timeout Integer in seconds
-    #   :proxy        - Hash of proxy options
-    #     :uri        - Proxy Server URI
-    #     :user       - Proxy server username
-    #     :password   - Proxy server password
-    # :ssl - Hash of options for configuring SSL requests.
+    # :options          - Hash of options for configuring the request.
+    #   :timeout        - open/read timeout Integer in seconds
+    #   :open_timeout   - read timeout Integer in seconds
+    #   :proxy          - Hash of proxy options
+    #     :uri          - Proxy Server URI
+    #     :user         - Proxy server username
+    #     :password     - Proxy server password
+    # :ssl              - Hash of options for configuring SSL requests.
     def to_env(connection)
       Env.new(method, body, connection.build_exclusive_url(path, params),
         options, headers, connection.ssl, connection.parallel_manager)


### PR DESCRIPTION
The documentation for the ENV key isn’t `request`. Rather it is `options`. Since this isn’t very well documented for proxy settings it was unclear how to implement proxy settings. Changing to `options` makes it clear as it can be mapped back to the documentation for `timeout` as well.