### PR TITLE
Add SOCKS support with socksify

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -89,7 +89,13 @@ module Faraday
 
       def net_http_connection(env)
         if proxy = env[:request][:proxy]
-          Net::HTTP::Proxy(proxy[:uri].host, proxy[:uri].port, proxy[:user], proxy[:password])
+          if proxy[:uri].scheme.start_with?('socks')
+            require 'socksify'
+            require 'socksify/http'
+            Net::HTTP::SOCKSProxy(proxy[:uri].host, proxy[:uri].port)
+          else
+            Net::HTTP::Proxy(proxy[:uri].host, proxy[:uri].port, proxy[:user], proxy[:password])
+          end
         else
           Net::HTTP
         end.new(env[:url].host, env[:url].port)


### PR DESCRIPTION
Use a SOCKS (SOCKS5) connection with Faraday, using the socksify gem.