### PR TITLE
Document resolution for issue #182

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ stack and default adapter (see [Faraday::RackBuilder#initialize](https://github.
 response = Faraday.get 'http://sushi.com/nigiri/sake.json'
 ```
 
+## Requests with duplicate parameters ##
+
+Sometimes you need to send the same URL parameter multiple times with different values. This requires manually setting the
+parameter encoder and can be done on a per connection basis.
+
+```ruby
+conn.options.params_encoder = Faraday::FlatParamsEncoder
+conn.get do |req|
+  req.params['roll'] = ['california', 'philadelphia']
+end
+# GET 'http://sushi.com?roll=california&roll=philadelphia'
+```
+
 ## Advanced middleware usage
 
 The order in which middleware is stacked is important. Like with Rack, the


### PR DESCRIPTION
This PR explains sending duplicate URL parameters as reported in https://github.com/lostisland/faraday/issues/182

The issue was fixed a while back but I had to dig through source code to figure out how to use it. I thought I'd contribute to the README to make it clearer for other users.