### PR TITLE
More helpful Logger error on missing adapter

### DIFF
--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -25,6 +25,11 @@ module Faraday
     end
 
     def on_complete(env)
+      # Not ideal, but better than a cryptic error: https://github.com/lostisland/faraday/issues/317
+      if env.status.nil?
+        raise 'Response data is empty! Did you forget to explicitly specify an adapter?'
+      end
+
       info('Status') { env.status.to_s }
       debug('response') { dump_headers env.response_headers }
       debug('response') { dump_body env[:body] } if env[:body] && log_body?(:response)

--- a/test/adapters/logger_test.rb
+++ b/test/adapters/logger_test.rb
@@ -78,5 +78,17 @@ module Adapters
       app.get '/rubbles', nil, :accept => 'text/html'
       assert_match %([\"Barney\", \"Betty\", \"Bam Bam\"]\n), @io.string
     end
+
+    def test_helpful_error_on_missing_adapter
+      app = Faraday.new do |b|
+        b.response :logger, @logger
+      end
+
+      error = assert_raises do
+        app.get '/test'
+      end
+
+      assert_match /specify an adapter/, error.message
+    end
   end
 end


### PR DESCRIPTION
The current error message has confused people.

As discussed in #317, there are better longer-term solutions, but no one has implemented those yet, so maybe good could be better than perfect here?

I'll add a note in #121 to revert this (if it's merged) if the proper fix is implemented.

I'm sure this isn't the best way to catch this error – please do suggest improvements and I'll do my best.

cc @mislav 