### PR TITLE
Fix up the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ Faraday supports these adapters:
 * [EventMachine][]
 * [HTTPClient][]
 
-[net_http]: http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html
-[net_http_persistent]: https://github.com/drbrain/net-http-persistent
-
 It also includes a Rack adapter for hitting loaded Rack applications through
 Rack::Test, and a Test adapter for stubbing requests by hand.
 
@@ -213,12 +210,14 @@ of a major release, support for that Ruby version may be dropped.
 Copyright (c) 2009-2013 [Rick Olson](mailto:technoweenie@gmail.com), Zack Hobson.
 See [LICENSE][] for details.
 
-[travis]:    http://travis-ci.org/lostisland/faraday
-[excon]:     https://github.com/geemus/excon#readme
-[typhoeus]:  https://github.com/typhoeus/typhoeus#readme
-[patron]:    http://toland.github.com/patron/
-[eventmachine]: https://github.com/igrigorik/em-http-request#readme
-[httpclient]: https://github.com/nahi/httpclient
-[jruby]:     http://jruby.org/
-[rubinius]:  http://rubini.us/
-[license]:   LICENSE.md
+[net_http]:            http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html
+[net_http_persistent]: https://github.com/drbrain/net-http-persistent
+[travis]:              http://travis-ci.org/lostisland/faraday
+[excon]:               https://github.com/geemus/excon#readme
+[typhoeus]:            https://github.com/typhoeus/typhoeus#readme
+[patron]:              http://toland.github.com/patron/
+[eventmachine]:        https://github.com/igrigorik/em-http-request#readme
+[httpclient]:          https://github.com/nahi/httpclient
+[jruby]:               http://jruby.org/
+[rubinius]:            http://rubini.us/
+[license]:             LICENSE.md

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ processing the request/response cycle.
 
 Faraday supports these adapters:
 
-* [`Net::HTTP`][net_http] _(the default adapter)_
+* [`Net::HTTP`][net_http] _(default)_
 * [`Net::HTTP::Persistent`][net_http_persistent]
 * [Excon][]
 * [Typhoeus][]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ processing the request/response cycle.
 
 Faraday supports these adapters:
 
-* Net::HTTP
+* [`Net::HTTP`][]
+* [`Net::HTTP::Persistent`][]
 * [Excon][]
 * [Typhoeus][]
 * [Patron][]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Faraday
 
 Faraday is an HTTP client lib that provides a common interface over many
-adapters (such as `Net::HTTP`, the default adapter) and embraces the concept of Rack middleware when
+adapters (such as `Net::HTTP`) and embraces the concept of Rack middleware when
 processing the request/response cycle.
 
 Faraday supports these adapters:
 
-* [`Net::HTTP`][net_http]
+* [`Net::HTTP`][net_http] _(the default adapter)_
 * [`Net::HTTP::Persistent`][net_http_persistent]
 * [Excon][]
 * [Typhoeus][]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ processing the request/response cycle.
 Faraday supports these adapters:
 
 * [`Net::HTTP`][net_http]
-* [`Net::HTTP::Persistent`][net_http_persistent]
+* [`Net::HTTP::Persistent`][net_http_persistent] _(experimental)_
 * [Excon][]
 * [Typhoeus][]
 * [Patron][]

--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@ processing the request/response cycle.
 
 Faraday supports these adapters:
 
-* [`Net::HTTP`][]
-* [`Net::HTTP::Persistent`][]
+* [`Net::HTTP`][net_http]
+* [`Net::HTTP::Persistent`][net_http_persistent]
 * [Excon][]
 * [Typhoeus][]
 * [Patron][]
 * [EventMachine][]
 * [HTTPClient][]
+
+[net_http]: http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html
+[net_http_persistent]: https://github.com/drbrain/net-http-persistent
 
 It also includes a Rack adapter for hitting loaded Rack applications through
 Rack::Test, and a Test adapter for stubbing requests by hand.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ processing the request/response cycle.
 Faraday supports these adapters:
 
 * [`Net::HTTP`][net_http]
-* [`Net::HTTP::Persistent`][net_http_persistent] _(experimental)_
+* [`Net::HTTP::Persistent`][net_http_persistent]
 * [Excon][]
 * [Typhoeus][]
 * [Patron][]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Faraday
 
 Faraday is an HTTP client lib that provides a common interface over many
-adapters (such as Net::HTTP) and embraces the concept of Rack middleware when
+adapters (such as `Net::HTTP`, the default adapter) and embraces the concept of Rack middleware when
 processing the request/response cycle.
 
 Faraday supports these adapters:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ processing the request/response cycle.
 Faraday supports these adapters:
 
 * [Net::HTTP][net_http] _(default)_
-* [Net::HTTP::Persistent][net_http_persistent]
+* [Net::HTTP::Persistent][persistent]
 * [Excon][]
 * [Typhoeus][]
 * [Patron][]
@@ -210,14 +210,14 @@ of a major release, support for that Ruby version may be dropped.
 Copyright (c) 2009-2013 [Rick Olson](mailto:technoweenie@gmail.com), Zack Hobson.
 See [LICENSE][] for details.
 
-[net_http]:            http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html
-[net_http_persistent]: https://github.com/drbrain/net-http-persistent
-[travis]:              http://travis-ci.org/lostisland/faraday
-[excon]:               https://github.com/geemus/excon#readme
-[typhoeus]:            https://github.com/typhoeus/typhoeus#readme
-[patron]:              http://toland.github.com/patron/
-[eventmachine]:        https://github.com/igrigorik/em-http-request#readme
-[httpclient]:          https://github.com/nahi/httpclient
-[jruby]:               http://jruby.org/
-[rubinius]:            http://rubini.us/
-[license]:             LICENSE.md
+[net_http]:     http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html
+[persistent]:   https://github.com/drbrain/net-http-persistent
+[travis]:       http://travis-ci.org/lostisland/faraday
+[excon]:        https://github.com/geemus/excon#readme
+[typhoeus]:     https://github.com/typhoeus/typhoeus#readme
+[patron]:       http://toland.github.com/patron/
+[eventmachine]: https://github.com/igrigorik/em-http-request#readme
+[httpclient]:   https://github.com/nahi/httpclient
+[jruby]:        http://jruby.org/
+[rubinius]:     http://rubini.us/
+[license]:      LICENSE.md

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Faraday
 
 Faraday is an HTTP client lib that provides a common interface over many
-adapters (such as `Net::HTTP`) and embraces the concept of Rack middleware when
+adapters (such as Net::HTTP) and embraces the concept of Rack middleware when
 processing the request/response cycle.
 
 Faraday supports these adapters:
 
-* [`Net::HTTP`][net_http] _(default)_
-* [`Net::HTTP::Persistent`][net_http_persistent]
+* [Net::HTTP][net_http] _(default)_
+* [Net::HTTP::Persistent][net_http_persistent]
 * [Excon][]
 * [Typhoeus][]
 * [Patron][]

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -4,7 +4,6 @@
 
 module Faraday
   class Adapter
-    # Experimental adapter for net-http-persistent
     class NetHttpPersistent < NetHttp
       dependency 'net/http/persistent'
 


### PR DESCRIPTION
@technoweenie, @mislav _et al._ - the main purpose of this PR is to add `Net::HTTP::Persistent` to the list of available adapters, as per the changes in #123, and to make further improvements to the README file started in ffa01e25:

* mark `Net::HTTP` as the default adapter
* add `Net::HTTP:Persistent` as an available but experimental adapter
* add docu hyperlinks for both `Net::HTTP` and `Net::HTTP::Persistent`

Hope these changes meet your approval... thanks!