### PR TITLE
  Allow setting idle_timeout for net-http-persistent adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,11 @@ bundler_args: --without development --path vendor/bundle --jobs=3 --retry=3
 cache: bundler
 
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
-  - jruby-18mode
   - jruby-19mode
   - jruby-20mode
   - jruby-21mode
@@ -22,7 +20,6 @@ matrix:
   allow_failures:
     # "A fatal error has been detected by the Java Runtime Environment:
     #  Internal Error (sharedRuntime.cpp:843)"
-    - rvm: jruby-18mode
     - rvm: jruby-19mode
     - rvm: jruby-20mode
     - rvm: jruby-21mode

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -23,6 +23,10 @@ module Faraday
       end
 
       def perform_request(http, env)
+        # see: http://docs.seattlerb.org/net-http-persistent/Net/HTTP/Persistent.html#attribute-i-idle_timeout
+        req = env[:request]
+        http.idle_timeout = req[:idle_timeout] if req[:idle_timeout]
+
         http.request env[:url], create_request(env)
       rescue Net::HTTP::Persistent::Error => error
         if error.message.include? 'Timeout'

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -56,8 +56,8 @@ module Faraday
         # HAX: helps but doesn't work completely
         # https://github.com/toland/patron/issues/34
         ::Patron::Request::VALID_ACTIONS.tap do |actions|
-          actions << :patch unless actions.include? :patch
-          actions << :options unless actions.include? :options
+          actions << 'PATCH' unless actions.include? 'PATCH'
+          actions << 'OPTIONS' unless actions.include? 'OPTIONS'
         end
       end
 

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -189,7 +189,7 @@ module Faraday
   end
 
   class RequestOptions < Options.new(:params_encoder, :proxy, :bind,
-    :timeout, :open_timeout, :boundary,
+    :timeout, :open_timeout, :idle_timeout, :boundary,
     :oauth)
 
     def []=(key, value)

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -8,6 +8,7 @@ class EnvTest < Faraday::TestCase
 
     @conn.options.timeout      = 3
     @conn.options.open_timeout = 5
+    @conn.options.idle_timeout = 7
     @conn.ssl.verify           = false
     @conn.proxy 'http://proxy.com'
   end
@@ -44,15 +45,18 @@ class EnvTest < Faraday::TestCase
     env = make_env
     assert_equal 3, env.request.timeout
     assert_equal 5, env.request.open_timeout
+    assert_equal 7, env.request.idle_timeout
   end
 
   def test_per_request_options
     env = make_env do |req|
       req.options.timeout = 10
+      req.options.idle_timeout = 8
       req.options.boundary = 'boo'
       req.options.oauth[:consumer_secret] = 'xyz'
     end
     assert_equal 10, env.request.timeout
+    assert_equal 8, env.request.idle_timeout
     assert_equal 5, env.request.open_timeout
     assert_equal 'boo', env.request.boundary
 


### PR DESCRIPTION
Just brought https://github.com/lostisland/faraday/pull/470 up to date