### PR TITLE
Set req.body example as standard json format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ conn.post '/nigiri', { :name => 'Maguro' }  # POST "name=maguro" to http://sushi
 conn.post do |req|
   req.url '/nigiri'
   req.headers['Content-Type'] = 'application/json'
-  req.body = '{ "name": "Unagi" }'
+  req.body = { name: 'Unagi' }.to_json
 end
 
 ## Per-request options ##


### PR DESCRIPTION
'{ "name": "Unagi" }' is not a standard json format. 

Rubyist may like pass a hash.to_json for this scenario.