### PR TITLE
:verify_callback ssl option for Net::HTTP adapter

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -106,6 +106,8 @@ module Faraday
         http.ca_path      = ssl[:ca_path]      if ssl[:ca_path]
         http.verify_depth = ssl[:verify_depth] if ssl[:verify_depth]
         http.ssl_version  = ssl[:version]      if ssl[:version]
+
+        http.verify_callback = ssl[:verify_callback] if ssl[:verify_callback]
       end
 
       def ssl_cert_store(ssl)

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -202,7 +202,7 @@ module Faraday
   end
 
   class SSLOptions < Options.new(:verify, :ca_file, :ca_path, :verify_mode,
-    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth, :version)
+    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth, :version, :verify_callback)
 
     def verify?
       verify != false


### PR DESCRIPTION
This option is useful for certificate pinning — https://stackoverflow.com/questions/22093042/implementing-https-certificate-pubkey-pinning-with-ruby
