### PR TITLE
Don't set a default cert_store for Net::HTTP

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -98,22 +98,14 @@ module Faraday
       def configure_ssl(http, ssl)
         http.use_ssl      = true
         http.verify_mode  = ssl_verify_mode(ssl)
-        http.cert_store   = ssl_cert_store(ssl)
 
+        http.cert_store   = ssl[:cert_store]   if ssl[:cert_store]
         http.cert         = ssl[:client_cert]  if ssl[:client_cert]
         http.key          = ssl[:client_key]   if ssl[:client_key]
         http.ca_file      = ssl[:ca_file]      if ssl[:ca_file]
         http.ca_path      = ssl[:ca_path]      if ssl[:ca_path]
         http.verify_depth = ssl[:verify_depth] if ssl[:verify_depth]
         http.ssl_version  = ssl[:version]      if ssl[:version]
-      end
-
-      def ssl_cert_store(ssl)
-        return ssl[:cert_store] if ssl[:cert_store]
-        # Use the default cert store by default, i.e. system ca certs
-        cert_store = OpenSSL::X509::Store.new
-        cert_store.set_default_paths
-        cert_store
       end
 
       def ssl_verify_mode(ssl)

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -35,7 +35,6 @@ module Faraday
 
       def configure_ssl(http, ssl)
         http.verify_mode  = ssl_verify_mode(ssl)
-        http.cert_store   = ssl_cert_store(ssl)
 
         http.certificate  = ssl[:client_cert]  if ssl[:client_cert]
         http.private_key  = ssl[:client_key]   if ssl[:client_key]


### PR DESCRIPTION
When you set a `cert_store` for Net::HTTP, it overrides the `ca_file` and `ca_path` options. Since a default one is always set, you can't actually reconfigure Net::HTTP without doing it through the `cert_store` option.

Net::HTTP by default already does this: [Net::HTTP](https://github.com/ruby/ruby/blob/trunk/lib/net/http.rb#L897) uses [OpenSSL::SSL::SSLContext::DEFAULT_CERT_STORE](https://github.com/ruby/openssl/blob/master/lib/openssl/ssl.rb#L71) which calls `set_default_paths` and as part of `set_params` it sets `cert_store = DEFAULT_CERT_STORE`.

I tested this by setting an invalid `ca_file`, and it still worked until I removed the code which sets `cert_store` by default, and then it failed validation. I can't find the OpenSSL C code to specifically show that it prioritizes `cert_store` though.