### PR TITLE
Faraday::Response::Logger: Update tests

### DIFF
--- a/test/adapters/logger_test.rb
+++ b/test/adapters/logger_test.rb
@@ -12,7 +12,6 @@ module Adapters
         b.adapter :test do |stubs|
           stubs.get('/hello') { [200, {'Content-Type' => 'text/html'}, 'hello'] }
           stubs.post('/ohai') { [200, {'Content-Type' => 'text/html'}, 'fred'] }
-          stubs.get('/ohno') { [200, {'Content-Type' => 'text/html'}, 'wilma'] }
           stubs.post('/ohyes') { [200, {'Content-Type' => 'text/html'}, 'pebbles'] }
           stubs.get('/rubbles') { [200, {'Content-Type' => 'application/json'}, rubbles] }
         end
@@ -54,16 +53,18 @@ module Adapters
       refute_match %(fred), @io.string
     end
 
-    def test_log_request_body
+    def test_log_only_request_body
       app = conn(@logger, :bodies => { :request => true })
       app.post '/ohyes', 'name=Tamago', :accept => 'text/html'
       assert_match %(name=Tamago), @io.string
+      refute_match %(pebbles), @io.string
     end
 
-    def test_log_response_body
+    def test_log_only_response_body
       app = conn(@logger, :bodies => { :response => true })
-      app.get '/ohno', :accept => 'text/html'
-      assert_match %(wilma), @io.string
+      app.post '/ohyes', 'name=Hamachi', :accept => 'text/html'
+      assert_match %(pebbles), @io.string
+      refute_match %(name=Hamachi), @io.string
     end
 
     def test_log_request_and_response_body


### PR DESCRIPTION
Looking through the tests for the `Faraday::Response::Logger` I saw that
the tests do not test that only the request/response body are logged when
the logger `:bodies` option is a hash.

Tests updated to use `refutes_match` when either the request/response
bodies are not whitelisted setup options.