### PR TITLE
Allows passing of adapter specific ssl options

### DIFF
--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -20,6 +20,11 @@ module Faraday
           opts[:client_key]  = ssl[:client_key]  if ssl[:client_key]
           opts[:certificate] = ssl[:certificate] if ssl[:certificate]
           opts[:private_key] = ssl[:private_key] if ssl[:private_key]
+          opts[:ssl_version] = ssl[:version] if ssl[:version]
+
+          if ( adapter_specific = ssl[:adapter_specific] )
+            opts[:client_key_pass] = adapter_specific[:client_key_pass] if adapter_specific[:client_key_pass]
+          end
 
           # https://github.com/geemus/excon/issues/106
           # https://github.com/jruby/jruby-ossl/issues/19

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -202,7 +202,7 @@ module Faraday
   end
 
   class SSLOptions < Options.new(:verify, :ca_file, :ca_path, :verify_mode,
-    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth, :version)
+    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth, :version, :adapter_specific)
 
     def verify?
       verify != false


### PR DESCRIPTION
Running SSL=yes script/test
Gives: 494 runs, 837 assertions, 1 failures, 21 errors, 0 skips

This PR does not cause these failures as they already exist in master.

Added ssl option for excon client_key_pass using a new key in SSLOptions called adapter_specific.
