### PR TITLE
Update options for TyphoeusAdapter

### DIFF
--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -40,7 +40,7 @@ module Faraday
           :method  => method,
           :body    => env[:body],
           :headers => env[:request_headers],
-          :disable_ssl_peer_verification => (env[:ssl] && env[:ssl].disable?)
+          :ssl_verifypeer => (env[:ssl] && env[:ssl].disable?)
 
         configure_ssl     req, env
         configure_proxy   req, env


### PR DESCRIPTION
I'm not sure if this is the correct way to fix the problem I'm having. Faraday specifies a particularly old version of Typheous. I have other gems that are depending on more recent versions of Typheous. In combination, when I have a more recent version of Typhoeus loaded, my specs start to fail because Faraday uses the TypheousAdapter and is making requests to typhoeus using the old option key. 

This change does not break any existing tests, so I'm not sure what i can do about breaking changes. This change _does_ fix my issue. 