### PR TITLE
Fix port number as 443 if url is https.

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -91,6 +91,7 @@ module Faraday
         if proxy = env[:request][:proxy]
           Net::HTTP::Proxy(proxy[:uri].host, proxy[:uri].port, proxy[:user], proxy[:password])
         else
+          env[:url].port = 443 if env[:url].scheme == 'https'
           Net::HTTP
         end.new(env[:url].host, env[:url].port)
       end


### PR DESCRIPTION
This patch fixes SSL_connect error when accessing url via https.

Is seems that supermarket.chef.io prohibited access via http recently.
This patch works fine with 2.0.18 version of berkshelf.