### PR TITLE
Treat URL query params as binary data

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -188,7 +188,11 @@ module Faraday
       }.tr(' ', '+')
     end
 
-    def unescape(s) CGI.unescape s.to_s.force_encoding(Encoding::BINARY) end
+    def unescape(s)
+      string = s.to_s
+      string.force_encoding(Encoding::BINARY) if RUBY_VERSION >= '1.9'
+      CGI.unescape string
+    end
 
     DEFAULT_SEP = /[&;] */n
 

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -188,7 +188,7 @@ module Faraday
       }.tr(' ', '+')
     end
 
-    def unescape(s) CGI.unescape s.to_s end
+    def unescape(s) CGI.unescape s.to_s.force_encoding(Encoding::BINARY) end
 
     DEFAULT_SEP = /[&;] */n
 

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -65,7 +65,8 @@ class TestUtils < Faraday::TestCase
   end
 
   def test_unescaping_and_escaping_invalid_byte_sequences
-    invalid_utf_sequence = "%A0".force_encoding(Encoding::UTF_8)
+    invalid_utf_sequence = "%A0"
+    invalid_utf_sequence.force_encoding(Encoding::UTF_8) if RUBY_VERSION >= "1.9"
     unescaped = Faraday::Utils.unescape(invalid_utf_sequence)
     assert_equal invalid_utf_sequence, Faraday::Utils.escape(unescaped)
   end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -63,5 +63,11 @@ class TestUtils < Faraday::TestCase
       Faraday::Utils.default_uri_parser = old_parser
     end
   end
+
+  def test_unescaping_and_escaping_invalid_byte_sequences
+    invalid_utf_sequence = "%A0".force_encoding(Encoding::UTF_8)
+    unescaped = Faraday::Utils.unescape(invalid_utf_sequence)
+    assert_equal invalid_utf_sequence, Faraday::Utils.escape(unescaped)
+  end
 end
 


### PR DESCRIPTION
If a url with non properly UTF-8 encoded characters as part of the query
is passed to a connection, an `invalid byte sequence` error is raised.
e.g. http://example.com/search?q=%A0

We should treat query strings as binary data to avoid having this issue

references https://github.com/lostisland/faraday/issues/476