### PR TITLE
Fix default port numbers for Net::HTTP adapters

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -92,7 +92,7 @@ module Faraday
           Net::HTTP::Proxy(proxy[:uri].host, proxy[:uri].port, proxy[:user], proxy[:password])
         else
           Net::HTTP
-        end.new(env[:url].host, env[:url].port)
+        end.new(env[:url].host, env[:url].port || (env[:url].scheme == 'https' ? 443 : 80))
       end
 
       def configure_ssl(http, ssl)

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -1,4 +1,6 @@
 require File.expand_path('../integration', __FILE__)
+require 'ostruct'
+require 'uri'
 
 module Adapters
   class NetHttpTest < Faraday::TestCase
@@ -9,6 +11,35 @@ module Adapters
     behaviors << :Compression if RUBY_VERSION >= '1.9'
 
     Integration.apply(self, *behaviors)
+
+    def test_no_explicit_http_port_number
+      url = URI('http://example.com')
+      url.port = nil
+
+      adapter = Faraday::Adapter::NetHttp.new
+      http = adapter.net_http_connection(:url => url, :request => {})
+
+      assert_equal 80, http.port
+    end
+
+    def test_no_explicit_https_port_number
+      url = URI('https://example.com')
+      url.port = nil
+
+      adapter = Faraday::Adapter::NetHttp.new
+      http = adapter.net_http_connection(:url => url, :request => {})
+
+      assert_equal 443, http.port
+    end
+
+    def test_explicit_port_number
+      url = URI('https://example.com:1234')
+
+      adapter = Faraday::Adapter::NetHttp.new
+      http = adapter.net_http_connection(:url => url, :request => {})
+
+      assert_equal 1234, http.port
+    end
 
   end
 end


### PR DESCRIPTION
When Addressable::URI is used, the `port` property will be nil unless port was explicitly specified. This made Addressable unusable in HTTPS scenarios with Net::HTTP adapters, which would default to port 80 even when the scheme was "https".

Others adapters are not affected, as they get passed the full request URI and respect their scheme portion.

Closes #512, fixes #318