### PR TITLE
ship only essential files

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -20,15 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
   spec.add_development_dependency 'bundler', '~> 1.0'
 
-  spec.files = %w(.document CHANGELOG.md CONTRIBUTING.md Gemfile LICENSE.md README.md Rakefile)
-  spec.files << "#{lib}.gemspec"
-  spec.files += Dir.glob("lib/**/*.rb")
-  spec.files += Dir.glob("test/**/*.{rb,txt}")
-  spec.files += Dir.glob("script/*")
-
-  dev_null    = File.exist?('/dev/null') ? '/dev/null' : 'NUL'
-  git_files   = `git ls-files -z 2>#{dev_null}`
-  spec.files &= git_files.split("\0") if $?.success?
-
-  spec.test_files = Dir.glob("test/**/*.rb")
+  spec.files = `git ls-files -z lib LICENSE.md README.md`.split("\0")
 end


### PR DESCRIPTION
 - install faster
 - less space used when putting into vendor/cache

@mislav 