### PR TITLE
ApiAuth support

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -14,7 +14,8 @@ module Faraday
       :em_http => [:EMHttp, 'em_http'],
       :excon => [:Excon, 'excon'],
       :rack => [:Rack, 'rack'],
-      :httpclient => [:HTTPClient, 'httpclient']
+      :httpclient => [:HTTPClient, 'httpclient'],
+      :api_auth => [:ApiAuth, 'api_auth']
 
     # Public: This module marks an Adapter as supporting parallel requests.
     module Parallelism

--- a/lib/faraday/adapter/api_auth.rb
+++ b/lib/faraday/adapter/api_auth.rb
@@ -1,0 +1,64 @@
+module Faraday
+  class Adapter
+    class ApiAuth < Faraday::Adapter
+      dependency 'api-auth'
+
+      # possible => data
+      #  verify_mode
+
+      # TODO documentation
+      def initialize(app, access_id, secret_key, data = {})
+        super(app)
+
+        @access_id  = access_id
+        @secret_key = secret_key
+      end
+
+      # TODO documentation
+      def call(env)
+        super
+
+        http_response = request(env[:url], env[:method], env[:body])
+
+        save_response(env, http_response.code.to_i, http_response.body || '') do |response_headers|
+          http_response.each_header do |key, value|
+            response_headers[key] = value
+          end
+        end
+
+        @app.call(env)
+      end
+
+      private
+
+      # TODO documentation
+      def request(uri, method, data = {})
+        http    = Net::HTTP.new(uri.host, uri.port)
+        request = request_for_http_method(method, uri)
+
+        data.present? ? request.set_form_data(data) : request['Content-Length'] = 0
+
+        signed_request = ::ApiAuth.sign!(request, @access_id, @secret_key)
+        http.use_ssl     = uri.scheme.eql?('https')
+        http.verify_mode = false
+
+        http.request(signed_request)
+      end
+
+      # TODO documentation
+      def request_for_http_method(method, uri)
+        case method
+          when :post
+            Net::HTTP::Post.new(uri.request_uri)
+          when :put
+            Net::HTTP::Put.new(uri.request_uri)
+          when :get
+            Net::HTTP::Get.new(uri.request_uri)
+          when :delete
+            Net::HTTP::Delete.new(uri.request_uri)
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
hey guys,

I wasn't able to sign a Faraday request using ApiAuth, I created a new adapter for that, not sure if that's the best place but I don't have access to the request object from a Faraday Middleware.

Usage:

```ruby
connection = Faraday.new(url: 'url') do |faraday|
  faraday.adapter :api_auth, 'key', 'secret'
end
```

what do you think? maybe there is a cleaner way of doing the same

Thanks

