### PR TITLE
Env custom members should be copied by Env.from(env)

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -270,6 +270,17 @@ module Faraday
     def_delegators :request, :params_encoder
 
     # Public
+    def self.from(value)
+      env = super(value)
+      if value.kind_of?(self)
+        value.custom_members.each do |custom_key, custom_value|
+          env[custom_key] = custom_value
+        end
+      end
+      env
+    end
+
+    # Public
     def [](key)
       if in_member_set?(key)
         super(key)

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -70,6 +70,15 @@ class EnvTest < Faraday::TestCase
     assert_equal 'proxy.com', env.request.proxy.host
   end
 
+  def test_custom_headers_are_retained
+    env = make_env
+    env[:foo] = "custom 1"
+    env[:bar] = :custom_2
+    env2 = Faraday::Env.from(env)
+    assert_equal "custom 1", env2[:foo]
+    assert_equal :custom_2,  env2[:bar]
+  end
+
   private
 
   def make_env(method = :get, connection = @conn, &block)


### PR DESCRIPTION
Fixes lostisland/faraday#408.

If middleware or adapters add custom members to env, those members should be
retained.