### PR TITLE
Honour request.options.params_encoder

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -396,7 +396,7 @@ module Faraday
     #          of the resulting url (default: nil).
     #
     # Returns the resulting URI instance.
-    def build_exclusive_url(url = nil, params = nil)
+    def build_exclusive_url(url = nil, params = nil, params_encoder = nil)
       url = nil if url.respond_to?(:empty?) and url.empty?
       base = url_prefix
       if url and base.path and base.path !~ /\/$/
@@ -404,7 +404,7 @@ module Faraday
         base.path = base.path + '/'  # ensure trailing slash
       end
       uri = url ? base + url : base
-      uri.query = params.to_query(options.params_encoder) if params
+      uri.query = params.to_query(params_encoder || options.params_encoder) if params
       uri.query = nil if uri.query and uri.query.empty?
       uri
     end

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -188,7 +188,7 @@ module Faraday
     # :ssl - Hash of options for configuring SSL requests.
     def build_env(connection, request)
       Env.new(request.method, request.body,
-        connection.build_exclusive_url(request.path, request.params),
+        connection.build_exclusive_url(request.path, request.params, request.options.params_encoder),
         request.options, request.headers, connection.ssl,
         connection.parallel_manager)
     end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -517,6 +517,24 @@ class TestRequestParams < Faraday::TestCase
     end
   end
 
+  class FooBarEncoder
+    def self.encode(params)
+      "foo=bar"
+    end
+
+    def self.decode(param_string)
+      {"foo" => "bar"} 
+    end
+  end
+
+  def test_params_with_connection_options
+    create_connection 'http://a.co/page1', :params => {:color => 'blue'}
+    query = get do |req|
+      req.options.params_encoder = FooBarEncoder
+    end
+    assert_equal "foo=bar", query
+  end
+
   def get(*args)
     env = @conn.get(*args) do |req|
       yield(req) if block_given?


### PR DESCRIPTION
Fixes https://github.com/lostisland/faraday/issues/465

When setting up a new request, `build_exclusive_url` only uses the global `params_encoder` setting which means request-specific settings are completely ignored.