### PR TITLE
Add proper support for parsing `a[][b]=c` nested queries

### DIFF
--- a/lib/faraday/parameters.rb
+++ b/lib/faraday/parameters.rb
@@ -46,6 +46,8 @@ module Faraday
             buffer << "#{to_query.call(new_parent, val)}&"
           end
           return buffer.chop
+        elsif value.nil?
+          return parent
         else
           encoded_value = escape(value)
           return "#{parent}=#{encoded_value}"

--- a/lib/faraday/parameters.rb
+++ b/lib/faraday/parameters.rb
@@ -71,6 +71,7 @@ module Faraday
           end
         end
         # Numeric keys implies an array
+        # FIXME: this is not compatible with Rack::Utils.parse_nested_query
         if hash != {} && hash.keys.all? { |key| key =~ /^\d+$/ }
           hash.sort.inject([]) do |accu, (_, value)|
             accu << value; accu

--- a/test/parameters_test.rb
+++ b/test/parameters_test.rb
@@ -69,6 +69,12 @@ class TestParameters < Faraday::TestCase
     assert_equal expected, Faraday::NestedParamsEncoder.decode(query)
   end
 
+  def test_decode_nested_array_mixed_types
+    query = "a[][one]=1&a[]=2&a[]=&a[]"
+    expected = Rack::Utils.parse_nested_query(query)
+    assert_equal expected, Faraday::NestedParamsEncoder.decode(query)
+  end
+
   def test_decode_nested_ignores_invalid_array
     query = "[][a]=1&b=2"
     expected = {"a" => "1", "b" => "2"}

--- a/test/parameters_test.rb
+++ b/test/parameters_test.rb
@@ -56,7 +56,7 @@ class TestParameters < Faraday::TestCase
   end
 
   def test_encode_nil_nested
-    assert_equal "a=", Faraday::NestedParamsEncoder.encode("a" => nil)
+    assert_equal "a", Faraday::NestedParamsEncoder.encode("a" => nil)
   end
 
   def test_encode_nil_flat

--- a/test/parameters_test.rb
+++ b/test/parameters_test.rb
@@ -104,8 +104,9 @@ class TestParameters < Faraday::TestCase
   end
 
   def test_encode_rack_compat_nested
-    params = { :a => [{:one => "1", :two => "2"}] }
+    params = { :a => [{:one => "1", :two => "2"}, "3", ""] }
     expected = Rack::Utils.build_nested_query(params)
-    assert_equal expected, Faraday::Utils.unescape(Faraday::NestedParamsEncoder.encode(params))
+    assert_equal expected.split("&").sort,
+      Faraday::Utils.unescape(Faraday::NestedParamsEncoder.encode(params)).split("&").sort
   end
 end


### PR DESCRIPTION
```rb
decode("a[][b]=1&a[][c]=2&a[][b]=3")

before => {"a"=>{"b"=>"3", "c"=>"2"}}
after  => {"a"=>[{"b"=>"1", "c"=>"2"}, {"b"=>"3"}]}
```

This matches behavior of Rack::Utils.parse_nested_query which Rails adopts.

Fixes #428, fixes #345