### PR TITLE
EMHttp and EMSynchrony  SSL validation host fix

### DIFF
--- a/lib/faraday/adapter/em_http_ssl_patch.rb
+++ b/lib/faraday/adapter/em_http_ssl_patch.rb
@@ -39,7 +39,7 @@ module EmHttpSslPatch
   end
 
   def host
-    parent.connopts.host
+    parent.uri.host
   end
 
   def certificate_store


### PR DESCRIPTION
Connection host might be already resolved so that SSL validation fails.
We should use host from request uri instead of connection host.

More details: https://github.com/igrigorik/em-http-request/issues/33