### PR TITLE
Include wrapped exception/reponse in ClientErrors

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -29,7 +29,17 @@ module Faraday
     end
 
     def inspect
-      %(#<#{self.class}>)
+      inner = ''
+      if @wrapped_exception
+        inner << " wrapped=#{@wrapped_exception.inspect}"
+      end
+      if @response
+        inner << " response=#{@response.inspect}"
+      end
+      if inner.empty?
+        inner << " #{super}"
+      end
+      %(#<#{self.class}#{inner}>)
     end
   end
 


### PR DESCRIPTION
The Exception#inspect method documentation states that it will "Return
this exception's class and message", so by default if you want to
quickly inspect an Exception you can just call #inspect.

    exc = NotImplementedError.new("That's no fork!")
    exc.inspect #=> => "#<NotImplementedError: That's no fork!>"

In contrast, Faraday::ClientError only prints the exception class, which
varies from the base class method documentation and makes inspecting the
exception a bit harder.

    exc = Faraday::ClientError.new(NotImplementedError.new("That's no fork!"))
    exc.inspect #=> "#<Faraday::ClientError>"

This pull request updates the ClientError#inspect method to follow the
superclass documentation and provide more useful information to help
intrepid explorers debug their exceptions.

    exc = Faraday::ClientError.new(NotImplementedError.new("That's no fork!"))
    exc.inspect #=> #<Faraday::ClientError wrapped=#<NotImplementedError: That's no fork!>>