### PR TITLE
Remove extraneous call to_s in string interpolation.

### DIFF
--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -18,7 +18,7 @@ module Faraday
     def_delegators :@logger, :debug, :info, :warn, :error, :fatal
 
     def call(env)
-      info "#{env.method} #{env.url.to_s}"
+      info "#{env.method} #{env.url}"
       debug('request') { dump_headers env.request_headers }
       debug('request') { dump_body(env[:body]) } if env[:body] && log_body?(:request)
       super


### PR DESCRIPTION
For documentation purposes:

Ruby automatically calls `to_s` on the value returned in a string interpolation. As a result, the explicit call to `to_s` is unnecessary on Line 21 of `logger.rb`.