### PR TITLE
Add additional SSL options to net::http and net::http::persistant

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -106,6 +106,9 @@ module Faraday
         http.ca_path      = ssl[:ca_path]      if ssl[:ca_path]
         http.verify_depth = ssl[:verify_depth] if ssl[:verify_depth]
         http.ssl_version  = ssl[:version]      if ssl[:version]
+        http.ciphers      = ssl[:ciphers]      if ssl[:ciphers]
+        http.verify_callback = ssl[:verify_callback] if ssl[:verify_callback]
+        http.ssl_timeout  = ssl[:timeout]      if ssl[:timeout]
       end
 
       def ssl_cert_store(ssl)

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -42,7 +42,12 @@ module Faraday
         http.certificate  = ssl[:client_cert]  if ssl[:client_cert]
         http.private_key  = ssl[:client_key]   if ssl[:client_key]
         http.ca_file      = ssl[:ca_file]      if ssl[:ca_file]
+        http.ca_path      = ssl[:ca_path]      if ssl[:ca_path]
+        http.verify_depth = ssl[:verify_depth] if ssl[:verify_depth]
         http.ssl_version  = ssl[:version]      if ssl[:version]
+        http.ciphers      = ssl[:ciphers]      if ssl[:ciphers]
+        http.verify_callback = ssl[:verify_callback] if ssl[:verify_callback]
+        http.ssl_timeout  = ssl[:ssl_timeout]  if ssl[:ssl_timeout]
       end
     end
   end

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -202,7 +202,8 @@ module Faraday
   end
 
   class SSLOptions < Options.new(:verify, :ca_file, :ca_path, :verify_mode,
-    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth, :version)
+    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth, :version,
+    :ciphers, :verify_callback, :timeout)
 
     def verify?
       verify != false


### PR DESCRIPTION
Replaces PR #339 .

* Add  support for `ciphers`, `verify_depth`, and `ssl_timeout` to net::http and net::http::persistant.
* Also add adding `ca_path` and `verify_depth` to net::http::persistant. The underlying library supports these options, just like net::http.

Not touching the other adapters due to limited experience with some of the underlying libraries, or due to inconsistencies with what is supposed to be passed or supported. The libcurl-based HTTP client libraries expect file paths for the client certificate and client private key instead of their corresponding OpenSSL::X509::Certificate or OpenSSL::PKey::* objects, plus replicating the Ruby OpenSSL `verify_callback` API may require significant effort or patching of the client libraries.