### PR TITLE
Support 'Expect' header with '100-continue' value (currently only used by Net:HTTP)

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -35,6 +35,7 @@ module Faraday
           req = env[:request]
           http.read_timeout = http.open_timeout = req[:timeout] if req[:timeout]
           http.open_timeout = req[:open_timeout]                if req[:open_timeout]
+          http.continue_timeout = req[:continue_timeout]        if req[:continue_timeout]
 
           begin
             http_response = perform_request(http, env)

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -189,7 +189,7 @@ module Faraday
   end
 
   class RequestOptions < Options.new(:params_encoder, :proxy, :bind,
-    :timeout, :open_timeout, :boundary,
+    :timeout, :open_timeout, :boundary,:continue_timeout,
     :oauth)
 
     def []=(key, value)

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -8,6 +8,7 @@ class EnvTest < Faraday::TestCase
 
     @conn.options.timeout      = 3
     @conn.options.open_timeout = 5
+    @conn.options.continue_timeout = 7
     @conn.ssl.verify           = false
     @conn.proxy 'http://proxy.com'
   end
@@ -44,16 +45,19 @@ class EnvTest < Faraday::TestCase
     env = make_env
     assert_equal 3, env.request.timeout
     assert_equal 5, env.request.open_timeout
+    assert_equal 7, env.request.continue_timeout
   end
 
   def test_per_request_options
     env = make_env do |req|
       req.options.timeout = 10
+      req.options.continue_timeout = 8
       req.options.boundary = 'boo'
       req.options.oauth[:consumer_secret] = 'xyz'
     end
     assert_equal 10, env.request.timeout
     assert_equal 5, env.request.open_timeout
+    assert_equal 8, env.request.continue_timeout
     assert_equal 'boo', env.request.boundary
 
     oauth_expected = {:consumer_secret => 'xyz', :consumer_key => 'anonymous'}


### PR DESCRIPTION
HTTP supports the 'Expect' header to allow verification of a specific request before actually sending the body data.
Example of practical use : http://stackoverflow.com/questions/14281628/ssl-renegotiation-with-client-certificate-causes-server-buffer-overflow

This is supported by Net::HTTP, however is not enabled by default. The time to wait for the '100-continue' response is configured by setting the 'continue_timeout' parameter  (default = nil)
See http://docs.ruby-lang.org/en/2.0.0/Net/HTTP.html#attribute-i-continue_timeout

However, faraday does not support configuring such a parameter, hence the merge request

Most-likely a similar timeout parameter would be required for other HTTP adapters supporting the Expect header.