### PR TITLE
fix: map headers only when not falsy

### DIFF
--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -33,7 +33,7 @@ module Faraday
     private
 
     def dump_headers(headers)
-      headers.map { |k, v| "#{k}: #{v.inspect}" }.join("\n")
+      headers.map { |k, v| "#{k}: #{v.inspect}" }.join("\n") if headers
     end
 
     def dump_body(body)


### PR DESCRIPTION
tried the `faraday.response :logger`, failed to me cause headers was nil. 