### PR TITLE
Adds reason phrase support

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -34,9 +34,10 @@ module Faraday
       env.clear_body if env.needs_body?
     end
 
-    def save_response(env, status, body, headers = nil)
+    def save_response(env, status, body, headers = nil, reason_phrase = "")
       env.status = status
       env.body = body
+      env.reason_phrase = reason_phrase.to_s.strip
       env.response_headers = Utils::Headers.new.tap do |response_headers|
         response_headers.update headers unless headers.nil?
         yield(response_headers) if block_given?

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -34,10 +34,10 @@ module Faraday
       env.clear_body if env.needs_body?
     end
 
-    def save_response(env, status, body, headers = nil, reason_phrase = "")
+    def save_response(env, status, body, headers = nil, reason_phrase = nil)
       env.status = status
       env.body = body
-      env.reason_phrase = reason_phrase.to_s.strip
+      env.reason_phrase = reason_phrase && reason_phrase.to_s.strip
       env.response_headers = Utils::Headers.new.tap do |response_headers|
         response_headers.update headers unless headers.nil?
         yield(response_headers) if block_given?

--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -140,7 +140,9 @@ module Faraday
       def perform_single_request(env)
         req = EventMachine::HttpRequest.new(env[:url], connection_config(env))
         req.setup_request(env[:method], request_config(env)).callback { |client|
-          save_response(env, client.response_header.status, client.response) do |resp_headers|
+          status = client.response_header.status
+          reason = client.response_header.http_reason
+          save_response(env, status, client.response, nil, reason) do |resp_headers|
             client.response_header.each do |name, value|
               resp_headers[name.to_sym] = value
             end

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -54,7 +54,9 @@ module Faraday
 
           raise client.error if client.error
 
-          save_response(env, client.response_header.status, client.response) do |resp_headers|
+          status = client.response_header.status
+          reason = client.response_header.http_reason
+          save_response(env, status, client.response, nil, reason) do |resp_headers|
             client.response_header.each do |name, value|
               resp_headers[name.to_sym] = value
             end

--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -57,7 +57,7 @@ module Faraday
           :headers => env[:request_headers],
           :body    => read_body(env)
 
-        save_response(env, resp.status.to_i, resp.body, resp.headers)
+        save_response(env, resp.status.to_i, resp.body, resp.headers, resp.reason_phrase)
 
         @app.call env
       rescue ::Excon::Errors::SocketError => err

--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -37,7 +37,7 @@ module Faraday
           :body   => env[:body],
           :header => env[:request_headers]
 
-        save_response env, resp.status, resp.body, resp.headers
+        save_response env, resp.status, resp.body, resp.headers, resp.reason
 
         @app.call env
       rescue ::HTTPClient::TimeoutError, Errno::ETIMEDOUT

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -46,7 +46,7 @@ module Faraday
             end
           end
 
-          save_response(env, http_response.code.to_i, http_response.body || '') do |response_headers|
+          save_response(env, http_response.code.to_i, http_response.body || '', nil, http_response.message) do |response_headers|
             http_response.each_header do |key, value|
               response_headers[key] = value
             end

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -35,7 +35,10 @@ module Faraday
           raise Error::ConnectionFailed, $!
         end
 
-        save_response(env, response.status, response.body, response.headers)
+        # Remove the "HTTP/1.1 200", leaving just the reason phrase
+        reason_phrase = response.status_line.gsub(/^.* \d{3} /, '')
+
+        save_response(env, response.status, response.body, response.headers, reason_phrase)
 
         @app.call env
       rescue ::Patron::TimeoutError => err

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -252,7 +252,8 @@ module Faraday
   end
 
   class Env < Options.new(:method, :body, :url, :request, :request_headers,
-    :ssl, :parallel_manager, :params, :response, :response_headers, :status)
+    :ssl, :parallel_manager, :params, :response, :response_headers, :status,
+    :reason_phrase)
 
     ContentLength = 'Content-Length'.freeze
     StatusesWithoutBody = Set.new [204, 304]

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -37,6 +37,10 @@ module Faraday
       finished? ? env.status : nil
     end
 
+    def reason_phrase
+      finished? ? env.reason_phrase : nil
+    end
+
     def headers
       finished? ? env.response_headers : {}
     end

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -114,6 +114,11 @@ module Adapters
         assert_equal expected, get('ssl').body
       end
 
+      def test_GET_reason_phrase
+        response = get('echo')
+        assert_equal "OK", response.reason_phrase
+      end
+
       def test_POST_send_url_encoded_params
         assert_equal %(post {"name"=>"zack"}), post('echo', :name => 'zack').body
       end

--- a/test/adapters/rack_test.rb
+++ b/test/adapters/rack_test.rb
@@ -14,8 +14,12 @@ module Adapters
     include Integration::Common
     include Integration::NonParallel
 
-    # Rack::MockResponse doesn't provide any way to access the reason phrase
-    undef :test_GET_reason_phrase
+    # Rack::MockResponse doesn't provide any way to access the reason phrase,
+    # so override the shared test from Common.
+    def test_GET_reason_phrase
+      response = get('echo')
+      assert_nil response.reason_phrase
+    end
 
     # not using shared test because error is swallowed by Sinatra
     def test_timeout

--- a/test/adapters/rack_test.rb
+++ b/test/adapters/rack_test.rb
@@ -14,6 +14,9 @@ module Adapters
     include Integration::Common
     include Integration::NonParallel
 
+    # Rack::MockResponse doesn't provide any way to access the reason phrase
+    undef :test_GET_reason_phrase
+
     # not using shared test because error is swallowed by Sinatra
     def test_timeout
       conn = create_connection(:request => {:timeout => 1, :open_timeout => 1})

--- a/test/adapters/typhoeus_test.rb
+++ b/test/adapters/typhoeus_test.rb
@@ -6,9 +6,6 @@ module Adapters
     def adapter() :typhoeus end
 
     Integration.apply(self, :Parallel) do
-      # Typhoeus::Response doesn't provide an easy way to access the reason phrase
-      undef :test_GET_reason_phrase
-
       # https://github.com/dbalatero/typhoeus/issues/75
       undef :test_GET_with_body
 
@@ -18,6 +15,13 @@ module Adapters
 
       # inconsistent outcomes ranging from successful response to connection error
       undef :test_proxy_auth_fail if ssl_mode?
+
+      # Typhoeus::Response doesn't provide an easy way to access the reason phrase,
+      # so override the shared test from Common.
+      def test_GET_reason_phrase
+        response = get('echo')
+        assert_nil response.reason_phrase
+      end
 
       def test_binds_local_socket
         host = '1.2.3.4'

--- a/test/adapters/typhoeus_test.rb
+++ b/test/adapters/typhoeus_test.rb
@@ -6,6 +6,9 @@ module Adapters
     def adapter() :typhoeus end
 
     Integration.apply(self, :Parallel) do
+      # Typhoeus::Response doesn't provide an easy way to access the reason phrase
+      undef :test_GET_reason_phrase
+
       # https://github.com/dbalatero/typhoeus/issues/75
       undef :test_GET_with_body
 


### PR DESCRIPTION
Reason phrases are sometimes used to report additional information about why a request failed, so they're very useful in troubleshooting failed request. Building on @davidbiehl's work mentioned in https://github.com/lostisland/faraday/issues/418, this adds reason phrase support to all adapters (except Rack).

@mislav, you said in #418 that you'd be happy to see a pull request about this, so here you go!