### PR TITLE
Add `Faraday.respond_to?`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ stack and default adapter (see [Faraday::RackBuilder#initialize](https://github.
 
 ```ruby
 response = Faraday.get 'http://sushi.com/nigiri/sake.json'
-response = Faraday.post url, body, headers
 ```
 
 ### Changing how parameters are serialized

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ stack and default adapter (see [Faraday::RackBuilder#initialize](https://github.
 
 ```ruby
 response = Faraday.get 'http://sushi.com/nigiri/sake.json'
+response = Faraday.post url, body, headers
 ```
 
 ### Changing how parameters are serialized

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -93,7 +93,7 @@ module Faraday
     alias require_lib require_libs
 
     def respond_to?(symbol, include_private = false)
-      default_connection.respond_to?(symbol) || super
+      default_connection.respond_to?(symbol, include_private) || super
     end
 
   private

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -92,7 +92,7 @@ module Faraday
 
     alias require_lib require_libs
 
-    def respond_to?(symbol)
+    def respond_to_missing?(symbol, include_private = false)
       default_connection.respond_to?(symbol) || super
     end
 

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -92,6 +92,10 @@ module Faraday
 
     alias require_lib require_libs
 
+    def respond_to?(symbol)
+      default_connection.respond_to?(symbol) || super
+    end
+
   private
     # Internal: Proxies method calls on the Faraday constant to
     # #default_connection.

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -92,7 +92,7 @@ module Faraday
 
     alias require_lib require_libs
 
-    def respond_to_missing?(symbol, include_private = false)
+    def respond_to?(symbol, include_private = false)
       default_connection.respond_to?(symbol) || super
     end
 

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -411,6 +411,14 @@ class TestConnection < Faraday::TestCase
     assert_equal '/omnom', conn.path_prefix
   end
 
+  def test_respond_to
+    assert Faraday.default_connection.respond_to?(:get)
+    assert Faraday.default_connection.respond_to?(:post)
+
+    assert Faraday.respond_to?(:get)
+    assert Faraday.respond_to?(:post)
+  end
+
   def env_url(url, params)
     conn = Faraday::Connection.new(url, :params => params)
     yield(conn) if block_given?

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -412,9 +412,6 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_respond_to
-    assert Faraday.default_connection.respond_to?(:get)
-    assert Faraday.default_connection.respond_to?(:post)
-
     assert Faraday.respond_to?(:get)
     assert Faraday.respond_to?(:post)
   end


### PR DESCRIPTION
There are some methods that Faraday _does_ respond to because of `method_missing`, but it does not report that it does actually respond to some of those methods.

---

I am not very familiar with `Faraday`'s test suite and could not figure out the right place to put these tests, please let me know if they should move elsewhere.