### PR TITLE
Unify ssl certificate options

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -100,6 +100,13 @@ module Faraday
         http.verify_mode  = ssl_verify_mode(ssl)
         http.cert_store   = ssl_cert_store(ssl)
 
+        if ssl[:client_cert].class == String
+          ssl[:client_cert] = OpenSSL::X509::Certificate.new(File.read(ssl[:client_cert]))
+        end
+        if ssl[:client_key].class == String
+          ssl[:client_key] = OpenSSL::PKey::RSA.new(File.read(ssl[:client_key]))
+        end
+
         http.cert         = ssl[:client_cert]  if ssl[:client_cert]
         http.key          = ssl[:client_key]   if ssl[:client_key]
         http.ca_file      = ssl[:ca_file]      if ssl[:ca_file]

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -41,5 +41,22 @@ module Adapters
       assert_equal 1234, http.port
     end
 
+    def test_accepts_file_paths_insted_of_objects_for_ssl_connections
+      `script/generate_certs`
+      url = URI('https://example.com:1234')
+      ssl = {
+        client_cert: 'tmp/faraday-cert.crt',
+        client_key: 'tmp/faraday-cert.key'
+      }
+      env = { ssl: ssl, url: url, request: {} }
+
+      adapter = Faraday::Adapter::NetHttp.new
+      http = adapter.net_http_connection(env)
+      adapter.configure_ssl(http, env[:ssl])
+
+      assert_equal OpenSSL::X509::Certificate, http.cert.class
+      assert_equal OpenSSL::PKey::RSA, http.key.class
+    end
+
   end
 end


### PR DESCRIPTION
net_http adapter instantiates certificate and key when it receives file
paths instead of objects.

Closes #486.