### PR TITLE
HTTP gem support, with Celluloid::IO integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,13 @@ source 'https://rubygems.org'
 
 gem 'ffi-ncurses', '~> 0.3', :platforms => :jruby
 gem 'jruby-openssl', '~> 0.8.8', :platforms => :jruby
+
 # Newer versions drop support for Ruby < 1.9.3, but we still support them.
-gem 'rake', '< 11.0.0'
+if RUBY_VERSION >= '1.9.3'
+  gem 'rake'
+else
+  gem 'rake', '< 11.0.0'
+end
 
 group :test do
   gem 'coveralls', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'simplecov'
   gem 'sinatra', '~> 1.3'
   gem 'typhoeus', '~> 0.3.3', :platforms => [:ruby_18, :ruby_19, :ruby_20, :ruby_21]
-  unless RUBY_VERSION < '2.0'
+  unless RUBY_VERSION >= '1.9.3'
     gem 'celluloid-io'
     gem 'http', '>= 0.6'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,10 @@ group :test do
   gem 'simplecov'
   gem 'sinatra', '~> 1.3'
   gem 'typhoeus', '~> 0.3.3', :platforms => [:ruby_18, :ruby_19, :ruby_20, :ruby_21]
-  gem 'celluloid-io', :platforms => [:jruby, :ruby_20, :ruby_21, :ruby_22]
-  gem 'http', '>= 0.6', :platforms => [:jruby, :ruby_20, :ruby_21, :ruby_22]
+  unless RUBY_VERSION < '2.0'
+    gem 'celluloid-io'
+    gem 'http', '>= 0.6'
+  end
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ group :test do
   gem 'simplecov'
   gem 'sinatra', '~> 1.3'
   gem 'typhoeus', '~> 0.3.3', :platforms => [:ruby_18, :ruby_19, :ruby_20, :ruby_21]
+  gem 'celluloid-io'
+  gem 'http', '>= 0.6'
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@ group :test do
   gem 'simplecov'
   gem 'sinatra', '~> 1.3'
   gem 'typhoeus', '~> 0.3.3', :platforms => [:ruby_18, :ruby_19, :ruby_20, :ruby_21]
-  gem 'celluloid-io'
-  gem 'http', '>= 0.6'
+  gem 'celluloid-io', :platforms => [:jruby, :ruby_20, :ruby_21, :ruby_22]
+  gem 'http', '>= 0.6', :platforms => [:jruby, :ruby_20, :ruby_21, :ruby_22]
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 
 gem 'ffi-ncurses', '~> 0.3', :platforms => :jruby
 gem 'jruby-openssl', '~> 0.8.8', :platforms => :jruby
-gem 'rake'
+# Newer versions drop support for Ruby < 1.9.3, but we still support them.
+gem 'rake', '< 11.0.0'
 
 group :test do
   gem 'coveralls', :require => false
@@ -20,7 +21,7 @@ group :test do
   gem 'simplecov'
   gem 'sinatra', '~> 1.3'
   gem 'typhoeus', '~> 0.3.3', :platforms => [:ruby_18, :ruby_19, :ruby_20, :ruby_21]
-  unless RUBY_VERSION >= '1.9.3'
+  if RUBY_VERSION >= '1.9.3'
     gem 'celluloid-io'
     gem 'http', '>= 0.6'
   end

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -14,7 +14,9 @@ module Faraday
       :em_http => [:EMHttp, 'em_http'],
       :excon => [:Excon, 'excon'],
       :rack => [:Rack, 'rack'],
-      :httpclient => [:HTTPClient, 'httpclient']
+      :httpclient => [:HTTPClient, 'httpclient'],
+      :http_gem => [:HttpGem, 'http_gem'],
+      :http_gem_celluloid_io => [:HttpGemCelluloidIO, 'http_gem_celluloid_io']
 
     # Public: This module marks an Adapter as supporting parallel requests.
     module Parallelism

--- a/lib/faraday/adapter/http_gem.rb
+++ b/lib/faraday/adapter/http_gem.rb
@@ -1,0 +1,95 @@
+module Faraday
+  class Adapter
+    class HttpGem < Faraday::Adapter
+      dependency 'http'
+
+      def initialize(app, options = {})
+        @client = ::HTTP::Client.new options
+        super(app)
+      end
+
+      def call(env)
+        super
+
+        # TODO: Support streaming.
+        #   HTTP gem expects body to be String or Enumerable,
+        env[:body] = env[:body].read if env[:body].respond_to? :read
+
+        begin
+          res = @client.request(env[:method], env[:url], {
+              :body => env[:body],
+              :headers => env[:request_headers],
+              :proxy => proxy_options(env)
+            }.merge(socket_options(env)))
+        rescue HTTP::ConnectionError => e
+          raise Faraday::Error::ConnectionFailed, e
+        rescue OpenSSL::SSL::SSLError => e
+          raise Faraday::SSLError, e
+        end
+
+        save_response env, res.status, res.to_s, res.headers.to_h
+
+        @app.call env
+      end
+
+      private
+
+      def proxy_options(env)
+        return unless env[:request][:proxy]
+
+        rv = {
+          :proxy_address => env[:request][:proxy][:uri].host,
+          :proxy_port    => env[:request][:proxy][:uri].port
+        }
+
+        if env[:request][:proxy][:user]
+          rv[:proxy_username] = env[:request][:proxy][:user]
+          rv[:proxy_password] = env[:request][:proxy][:password]
+        end
+
+        rv
+      end
+
+      def socket_options(env)
+        rv = {}
+
+        if env[:url].scheme == 'https' && ssl = env[:ssl]
+          ctx      = OpenSSL::SSL::SSLContext.new
+
+          ctx.verify_mode  = ssl_verify_mode(ssl)
+          ctx.cert_store   = ssl_cert_store(ssl)
+
+          ctx.cert         = ssl[:client_cert]  if ssl[:client_cert]
+          ctx.key          = ssl[:client_key]   if ssl[:client_key]
+          ctx.ca_file      = ssl[:ca_file]      if ssl[:ca_file]
+          ctx.ca_path      = ssl[:ca_path]      if ssl[:ca_path]
+          ctx.verify_depth = ssl[:verify_depth] if ssl[:verify_depth]
+          ctx.ssl_version  = ssl[:version]      if ssl[:version]
+
+          rv.merge!(:ssl_context => ctx)
+        end
+
+        rv
+      end
+
+      def ssl_cert_store(ssl)
+        return ssl[:cert_store] if ssl[:cert_store]
+        # Use the default cert store by default, i.e. system ca certs
+        cert_store = OpenSSL::X509::Store.new
+        cert_store.set_default_paths
+        cert_store
+      end
+
+      def ssl_verify_mode(ssl)
+        ssl[:verify_mode] || begin
+          if ssl.fetch(:verify, true)
+            OpenSSL::SSL::VERIFY_PEER
+          else
+            OpenSSL::SSL::VERIFY_NONE
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/faraday/adapter/http_gem_celluloid_io.rb
+++ b/lib/faraday/adapter/http_gem_celluloid_io.rb
@@ -1,0 +1,28 @@
+# I wonder why autoloading does not work
+require 'faraday/adapter/http_gem'
+
+module Faraday
+  class Adapter
+    class HttpGemCelluloidIO < HttpGem
+
+      dependency 'http'
+      dependency 'celluloid/io'
+
+
+      private
+
+      def socket_options(env)
+        rv = super(env)
+        
+        if env[:url].scheme == 'https' && ssl = env[:ssl]
+          rv.merge!( :ssl_socket_class => Celluloid::IO::SSLSocket )
+        else
+          rv.merge!( :socket_class => Celluloid::IO::TCPSocket )
+        end
+
+        rv
+      end
+
+    end
+  end
+end

--- a/lib/faraday/adapter/http_gem_celluloid_io.rb
+++ b/lib/faraday/adapter/http_gem_celluloid_io.rb
@@ -15,7 +15,7 @@ module Faraday
       def socket_options(env)
         rv = super(env)
         
-        if env[:url].scheme == 'https' && ssl = env[:ssl]
+        if env[:url].scheme == 'https' && env[:ssl]
           rv.merge!( :ssl_socket_class => Celluloid::IO::SSLSocket )
         else
           rv.merge!( :socket_class => Celluloid::IO::TCPSocket )

--- a/lib/faraday/adapter/http_gem_celluloid_io.rb
+++ b/lib/faraday/adapter/http_gem_celluloid_io.rb
@@ -6,6 +6,7 @@ module Faraday
     class HttpGemCelluloidIO < HttpGem
 
       dependency 'http'
+      dependency 'celluloid/current'
       dependency 'celluloid/io'
 
 

--- a/test/adapters/http_gem_celluloid_io_test.rb
+++ b/test/adapters/http_gem_celluloid_io_test.rb
@@ -6,6 +6,6 @@ module Adapters
 
     Integration.apply(self, :NonParallel) do
       def test_timeout; end
-    end
+    end unless RUBY_VERSION < '2.0'
   end
 end

--- a/test/adapters/http_gem_celluloid_io_test.rb
+++ b/test/adapters/http_gem_celluloid_io_test.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../integration', __FILE__)
+
+module Adapters
+  class HttpGemCelluloidIOTest < Faraday::TestCase
+    def adapter() :http_gem_celluloid_io end
+
+    Integration.apply(self, :NonParallel) do
+      def test_timeout; end
+    end
+  end
+end

--- a/test/adapters/http_gem_celluloid_io_test.rb
+++ b/test/adapters/http_gem_celluloid_io_test.rb
@@ -6,6 +6,6 @@ module Adapters
 
     Integration.apply(self, :NonParallel) do
       def test_timeout; end
-    end unless RUBY_VERSION >= '1.9.3'
+    end if RUBY_VERSION >= '1.9.3'
   end
 end

--- a/test/adapters/http_gem_celluloid_io_test.rb
+++ b/test/adapters/http_gem_celluloid_io_test.rb
@@ -6,6 +6,6 @@ module Adapters
 
     Integration.apply(self, :NonParallel) do
       def test_timeout; end
-    end unless RUBY_VERSION < '2.0'
+    end unless RUBY_VERSION >= '1.9.3'
   end
 end

--- a/test/adapters/http_gem_test.rb
+++ b/test/adapters/http_gem_test.rb
@@ -6,6 +6,6 @@ module Adapters
 
     Integration.apply(self, :NonParallel) do
       def test_timeout; end
-    end
+    end unless RUBY_VERSION < '2.0'
   end
 end

--- a/test/adapters/http_gem_test.rb
+++ b/test/adapters/http_gem_test.rb
@@ -6,6 +6,6 @@ module Adapters
 
     Integration.apply(self, :NonParallel) do
       def test_timeout; end
-    end unless RUBY_VERSION >= '1.9.3'
+    end if RUBY_VERSION >= '1.9.3'
   end
 end

--- a/test/adapters/http_gem_test.rb
+++ b/test/adapters/http_gem_test.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../integration', __FILE__)
+
+module Adapters
+  class HttpGemTest < Faraday::TestCase
+    def adapter() :http_gem end
+
+    Integration.apply(self, :NonParallel) do
+      def test_timeout; end
+    end
+  end
+end

--- a/test/adapters/http_gem_test.rb
+++ b/test/adapters/http_gem_test.rb
@@ -6,6 +6,6 @@ module Adapters
 
     Integration.apply(self, :NonParallel) do
       def test_timeout; end
-    end unless RUBY_VERSION < '2.0'
+    end unless RUBY_VERSION >= '1.9.3'
   end
 end


### PR DESCRIPTION
Yet another attempt at integrating the HTTP gem :) This time because of Celluloid::IO, apparently you need to use a specific socket constructor in conjunction with the HTTP gem to make full use of the Celluloid::IO reactor.

The author states his motivation here https://github.com/httprb/http#another-ruby-http-library-why-should-i-care including

Streaming support is still on the TODO list

All tests are green locally on ruby 2.2.3