### PR TITLE
Correct parsing of uri with anchor in Request#url

### DIFF
--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -46,14 +46,12 @@ module Faraday
     end
 
     def url(path, params = nil)
-      if path.respond_to? :query
-        if query = path.query
-          path = path.dup
-          path.query = nil
-        end
-      else
-        path, query = path.split('?', 2)
+      path = Utils.URI(path)
+      if query = path.query
+        path = path.dup
+        path.query = nil
       end
+
       self.path = path
       self.params.merge_query query, options.params_encoder
       self.params.update(params) if params

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -46,12 +46,16 @@ module Faraday
     end
 
     def url(path, params = nil)
-      path = Utils.URI(path)
-      if query = path.query
-        path = path.dup
-        path.query = nil
+      if path.respond_to? :query
+        if query = path.query
+          path = path.dup
+          path.query = nil
+        end
+      else
+        anchor_index = path.index('#')
+        path = path.slice(0, anchor_index) unless anchor_index.nil?
+        path, query = path.split('?', 2)
       end
-
       self.path = path
       self.params.merge_query query, options.params_encoder
       self.params.update(params) if params

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -24,6 +24,13 @@ class EnvTest < Faraday::TestCase
     assert_equal 'http://sushi.com/api/foo.json?a=1', env.url.to_s
   end
 
+  def test_request_create_stores_uri_with_anchor
+    env = make_env do |req|
+      req.url 'foo.json?b=2&a=1#qqq'
+    end
+    assert_equal 'http://sushi.com/api/foo.json?a=1&b=2#qqq', env.url.to_s
+  end
+
   def test_request_create_stores_headers
     env = make_env do |req|
       req['Server'] = 'Faraday'

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -28,7 +28,7 @@ class EnvTest < Faraday::TestCase
     env = make_env do |req|
       req.url 'foo.json?b=2&a=1#qqq'
     end
-    assert_equal 'http://sushi.com/api/foo.json?a=1&b=2#qqq', env.url.to_s
+    assert_equal 'http://sushi.com/api/foo.json?a=1&b=2', env.url.to_s
   end
 
   def test_request_create_stores_headers


### PR DESCRIPTION
If pass into the method get url with an anchor, the library parses the parameters are not correct.
```ruby
2.3.0 :012 > Faraday.new.get('http://sushi.com?b=2&a=1#qqq').env[:url].to_s
 => "http://sushi.com?a=1%23qqq&b=2" 
```
