### PR TITLE
Fix comparison error at sort in rare case

### DIFF
--- a/lib/faraday/parameters.rb
+++ b/lib/faraday/parameters.rb
@@ -16,10 +16,11 @@ module Faraday
             "Can't convert #{params.class} into Hash."
         end
         params = params.to_hash
-        params = params.map do |key, value|
-          key = key.to_s if key.kind_of?(Symbol)
-          [key, value]
+        params = params.inject({}) do |options, (key, value)|
+          options[key.to_s] = value
+          options
         end
+        params = params.to_a
         # Useful default for OAuth and caching.
         # Only to be used for non-Array inputs. Arrays should preserve order.
         params.sort!


### PR DESCRIPTION
I fixed comparison error at sort. This error is reproduced when duplicate string and symbol keys with different values are included in params.

```ruby
conn = Faraday.new(url: 'http://localhost:3000')
conn.post('/products', { :name => 'hogehoge', 'name' => nil })
```

```
ArgumentError at /products
=> comparison of Array with Array failed
```