### PR TITLE
fix default_connection_options merge bug

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -66,11 +66,7 @@ module Faraday
     # Returns a Faraday::Connection.
     def new(url = nil, options = nil)
       block = block_given? ? Proc.new : nil
-      if url.is_a?(Hash)
-        url = default_connection_options.merge(url)
-      else
-        options = options ? default_connection_options.merge(options) : default_connection_options.dup
-      end
+      options = options ? default_connection_options.merge(options) : default_connection_options.dup
       Faraday::Connection.new(url, options, &block)
     end
 

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -66,7 +66,11 @@ module Faraday
     # Returns a Faraday::Connection.
     def new(url = nil, options = nil)
       block = block_given? ? Proc.new : nil
-      options = options ? default_connection_options.merge(options) : default_connection_options.dup
+      if url.is_a?(Hash)
+        url = default_connection_options.merge(url)
+      else
+        options = options ? default_connection_options.merge(options) : default_connection_options.dup
+      end
       Faraday::Connection.new(url, options, &block)
     end
 

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -56,10 +56,7 @@ module Faraday
     #                     :password - String (optional)
     def initialize(url = nil, options = nil)
       if url.is_a?(Hash)
-        options = ConnectionOptions.from(url)
-        url     = options.url
-      elsif url.is_a?(ConnectionOptions)
-        options = url
+        options = options ? options.merge!(url) : ConnectionOptions.from(url)
         url     = options.url
       else
         options = ConnectionOptions.from(options)

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -58,6 +58,9 @@ module Faraday
       if url.is_a?(Hash)
         options = ConnectionOptions.from(url)
         url     = options.url
+      elsif url.is_a?(ConnectionOptions)
+        options = url
+        url     = options.url
       else
         options = ConnectionOptions.from(options)
       end

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -56,7 +56,7 @@ module Faraday
     #                     :password - String (optional)
     def initialize(url = nil, options = nil)
       if url.is_a?(Hash)
-        options = options ? options.merge!(url) : ConnectionOptions.from(url)
+        options = options ? options.merge(url) : ConnectionOptions.from(url)
         url     = options.url
       else
         options = ConnectionOptions.from(options)

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -424,7 +424,7 @@ class TestConnection < Faraday::TestCase
 
   def test_default_connection_options_without_url
     Faraday.default_connection_options.request.timeout = 10
-    conn = Faraday.new url: 'http://sushi.com/foo'
+    conn = Faraday.new :url => 'http://sushi.com/foo'
     assert_equal 10, conn.options.timeout
   end
 

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -416,6 +416,18 @@ class TestConnection < Faraday::TestCase
     assert Faraday.respond_to?(:post)
   end
 
+  def test_default_connection_options
+    Faraday.default_connection_options.request.timeout = 10
+    conn = Faraday.new 'http://sushi.com/foo'
+    assert_equal 10, conn.options.timeout
+  end
+
+  def test_default_connection_options_without_url
+    Faraday.default_connection_options.request.timeout = 10
+    conn = Faraday.new url: 'http://sushi.com/foo'
+    assert_equal 10, conn.options.timeout
+  end
+
   def env_url(url, params)
     conn = Faraday::Connection.new(url, :params => params)
     yield(conn) if block_given?


### PR DESCRIPTION
Hi guys, while working with Faraday I encountered a bug that was affecting `default_connection_options`.
This bug actually prevents default_connection_options to be merged when options are passed as `url` parameter. To give you an example, here is what I mean:

    Faraday.default_connection_options.request.timeout = 10
    conn = Faraday.new 'http://sushi.com/foo'
    conn.options.timeout => 10

    Faraday.default_connection_options.request.timeout = 10
    conn = Faraday.new url: 'http://sushi.com/foo'
    conn.options.timeout => nil

The first example works as expected, but in the second example (passing the url using the options syntax) all default_connection_options are ignored. Unfortunately, many gems that depends on Faraday (in our case, [Her](https://github.com/remiprev/her)) prefer the latter initialisation style.

In my PR I:

* Fixed the bug
* added tests to prove both bug and solution

Hope you agree on the solution I adopted and the tests I wrote. Please let me know if you want me to change something.

@mislav, I know you're busy with tons of other stuff, however this bug is causing us some trouble on a production environment so the sooner we can have this fix included in the next release, the better it is :) Thanks for your comprehension.