### PR TITLE
Fix for serializing with YAML

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -108,6 +108,10 @@ module Faraday
           }
       end
 
+      def init_with(coder)
+        @names = coder['names']
+      end
+
       protected
 
       def names


### PR DESCRIPTION
Way to reproduce bug with current code:
`YAML.load(Faraday::Utils::Headers.new("User-Agent" => "safari").to_yaml)`

```
NoMethodError: undefined method `[]' for nil:NilClass
from /Users/Avael/.rvm/gems/ruby-2.3.0@showmojo/gems/faraday-0.9.2/lib/faraday/utils.rb:48:in `[]='
```

YAML is a standard tool for serializing, so I guess it should be supported. I believe that this bug can't be fixed outside of Faraday. I found this bug when I tried to serialize Faraday::Response instance for further storing in DB.
