### PR TITLE
Fix typo in method documentation

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -126,7 +126,7 @@ module Faraday
     #     req.body = JSON.generate(:query => {...})
     #   end
     #
-    # Yields a Faraday::Response for further request customizations.
+    # Yields a Faraday::Request for further request customizations.
     # Returns a Faraday::Response.
     #
     # Signature
@@ -163,7 +163,7 @@ module Faraday
     #     req.body = JSON.generate(:user => 'kimchy', ...)
     #   end
     #
-    # Yields a Faraday::Response for further request customizations.
+    # Yields a Faraday::Request for further request customizations.
     # Returns a Faraday::Response.
     #
     # Signature


### PR DESCRIPTION
According to the `build_request` method, a `Faraday::Request` object is yielded, not a Response object.