### PR TITLE
Add Zlib::BufError to net/http error handling

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -21,6 +21,7 @@ module Faraday
         Net::HTTPHeaderSyntaxError,
         Net::ProtocolError,
         SocketError,
+        Zlib::BufError,
         Zlib::GzipFile::Error,
       ]
 


### PR DESCRIPTION
Got this error once:

```
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http/response.rb:363 in finish
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http/response.rb:363 in finish
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http/response.rb:265 in ensure in inflater
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http/response.rb:264 in inflater
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http/response.rb:280 in read_body_0
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http/response.rb:201 in read_body
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http.rb:1134 in block in get
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http.rb:1423 in block in transport_request
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http/response.rb:162 in reading_body
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http.rb:1422 in transport_request
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http.rb:1384 in request
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http.rb:1377 in block in request
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http.rb:853 in start
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http.rb:1375 in request
vendor/ruby-2.2.4/lib/ruby/2.2.0/net/http.rb:1133 in get
vendor/bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/adapter/net_http.rb:80 in perform_request
vendor/bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/adapter/net_http.rb:40 in block in call
vendor/bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/adapter/net_http.rb:87 in with_net_http_connection
vendor/bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/adapter/net_http.rb:32 in call
```