### PR TITLE
Update net_http.rb

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -17,6 +17,7 @@ module Faraday
         Errno::EHOSTUNREACH,
         Errno::EINVAL,
         Errno::ENETUNREACH,
+        Errno::EPIPE,
         Net::HTTPBadResponse,
         Net::HTTPHeaderSyntaxError,
         Net::ProtocolError,


### PR DESCRIPTION
Add recognition of uncaught `Errno::EPIPE: Broken pipe` error to `NET_HTTP_EXCEPTIONS`