### PR TITLE
Add optional content-length on parts in multipart requests

### DIFF
--- a/test/request_middleware_test.rb
+++ b/test/request_middleware_test.rb
@@ -136,6 +136,15 @@ class RequestMiddlewareTest < Faraday::TestCase
       response.headers['Content-Type']
   end
 
+  def test_multipart_with_content_length_limit_multivalue
+    payload = {a: 1, b: 2, c: Faraday::UploadIO.new(__FILE__, 'text/x-ruby', 'request_middleware_test.rb', use_part_content_length: :c), d: "1"}
+    response = @conn.post('/echo', payload)
+    # validate content-length
+    parts = response.env.body.instance_variable_get("@parts")
+    content_length = response.env.request_headers["Content-Length"]
+    assert_equal (parts.to_a[2].length - 2).to_s, content_length
+  end
+
   def test_multipart_with_arrays
     # assume params are out of order
     regexes = [


### PR DESCRIPTION
This will fix an issue I had with the middleware `Content-Length` layer of Faraday. When connecting to a HTTP server that was not accepting `Content-Length` of all chunked payload.

Some exotic server required the `Content-Length` of the part pushed with the multipart request, and not the entire length of the content including newline characters an other parts. Moreover, the `Content-Length` needed to be stripped of the trailing `\r\n` to work correctly. 

The fix is enabled by adding a parameter to the `Faraday::UploadIO` object initialiser, a snipped you can find below. By assigning the key (index) of the Faraday::UploadIO to the `:use_part_content_length` parameter, the `Content-Length` of the part configured is used.

```ruby
payload = {:c => Faraday::UploadIO.new(__FILE__, 'text/x-ruby', 'request_middleware_test.rb', use_part_content_length: :c)}
```

A test has been added to the `test/request_middleware_test.rb` file: `test_multipart_with_content_length_limit`.