### PR TITLE
Object#tap no longer required after dropping 1.8.7

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -239,25 +239,3 @@ module Faraday
     require_lib 'autoload'
   end
 end
-
-# not pulling in active-support JUST for this method.  And I love this method.
-class Object
-  # The primary purpose of this method is to "tap into" a method chain,
-  # in order to perform operations on intermediate results within the chain.
-  #
-  # Examples
-  #
-  #   (1..10).tap { |x| puts "original: #{x.inspect}" }.to_a.
-  #     tap    { |x| puts "array: #{x.inspect}" }.
-  #     select { |x| x%2 == 0 }.
-  #     tap    { |x| puts "evens: #{x.inspect}" }.
-  #     map    { |x| x*x }.
-  #     tap    { |x| puts "squares: #{x.inspect}" }
-  #
-  # Yields self.
-  # Returns self.
-  def tap
-    yield(self)
-    self
-  end unless Object.respond_to?(:tap)
-end


### PR DESCRIPTION
Since Faraday only supports Ruby 1.9+ (from https://github.com/lostisland/faraday/pull/600), `Object#tap` is a core method and
this monkey patch is no longer needed.