### PR TITLE
Optionally log headers as they may contain sensitive information

### DIFF
--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -4,7 +4,7 @@ module Faraday
   class Response::Logger < Response::Middleware
     extend Forwardable
 
-    DEFAULT_OPTIONS = { :bodies => false }
+    DEFAULT_OPTIONS = { :bodies => false, :headers => false }
 
     def initialize(app, logger = nil, options = {})
       super(app)
@@ -33,6 +33,7 @@ module Faraday
     private
 
     def dump_headers(headers)
+      return unless @options[:headers]
       headers.map { |k, v| "#{k}: #{v.inspect}" }.join("\n")
     end
 

--- a/test/adapters/logger_test.rb
+++ b/test/adapters/logger_test.rb
@@ -23,8 +23,12 @@ module Adapters
       @logger = Logger.new(@io)
       @logger.level = Logger::DEBUG
 
-      @conn = conn(@logger)
+      @conn = conn(@logger, { :headers => true })
       @resp = @conn.get '/hello', nil, :accept => 'text/html'
+    end
+
+    def teardown
+      @io.rewind
     end
 
     def test_still_returns_output
@@ -37,6 +41,13 @@ module Adapters
 
     def test_logs_request_headers
       assert_match %(Accept: "text/html), @io.string
+    end
+
+    def test_doesnt_log_request_headers
+      @io.rewind #reset log data from conn.get in setup
+      app = conn(@logger, { :headers => false })
+      app.post '/ohyes', 'name=Tamago', :accept => 'text/html'
+      refute_match %(Accept: "text/html), @io.string
     end
 
     def test_logs_response_headers


### PR DESCRIPTION
If youre using basic auth for instance the credentials will be included
in the logs. Headers are also used for passing tokens regularly.

Ideally this would be a whitelist. Suggesting this simple change now so
that folks can take advantage of it.

https://en.wikipedia.org/wiki/List_of_HTTP_header_fields