### PR TITLE
Fix gemfile to pull in the net-http-persistent gem for Ruby 1.9.3+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'httpclient', '>= 2.2'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'minitest', '>= 5.0.5'
-  gem 'net-http-persistent', '>= 2.9.4'
+  gem 'net-http-persistent', '~> 2.9.4'
   gem 'patron', '>= 0.4.2', :platforms => :ruby
   gem 'rack-test', '>= 0.6', :require => 'rack/test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]


### PR DESCRIPTION
This allows the gem to work again on Ruby 1.9.3 to fix https://github.com/lostisland/faraday/issues/615.