### PR TITLE
Allow headers to be splitted with no space

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -97,7 +97,7 @@ module Faraday
         return unless header_string && !header_string.empty?
         header_string.split(/\r\n/).
           tap  { |a| a.shift if a.first.index('HTTP/') == 0 }. # drop the HTTP status line
-          map  { |h| h.split(/:\s+/, 2) }.reject { |p| p[0].nil? }. # split key and value, ignore blank lines
+          map  { |h| h.split(/:\s*/, 2) }.reject { |p| p[0].nil? }. # split key and value, ignore blank lines
           each { |key, value|
             # join multiple values with a comma
             if self[key]


### PR DESCRIPTION
Just found `Faraday` parses headers with `/:\s+/`, which doesn't allow headers like: `Location:www.jianshu.com`, which doesn't have a space after the colon. But explorer handles it and I found `Typhoeus` handles it, just Faraday using Typhoeus could not handle it.

See examples below, header `Location`:

### With `curl`:
```
$ curl -I http://o1.la/OTk4Y
HTTP/1.1 302 Moved Temporarily
Date: Tue, 11 Oct 2016 05:08:56 GMT
Server: Microsoft-IIS/6.0
X-Powered-By: ASP.NET
X-Powered-By: PHP/5.4.41
Set-Cookie: PHPSESSID=knakj7t038nmf0176la6afrsb4; path=/
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Pragma: no-cache
Location:http://www.jianshu.com
Content-type: text/html; charset=UTF-8
Content-Length: 0
```

### With `Typhoeus`:
```
> request = Typhoeus::Request.new("http://o1.la/OTk4Y", :method => :head)
> request.run
> response = request.response
> response.headers
=> {"Date"=>"Tue, 11 Oct 2016 05:13:49 GMT",
 "Server"=>"Microsoft-IIS/6.0",
 "X-Powered-By"=>["ASP.NET", "PHP/5.4.41"],
 "Set-Cookie"=>"PHPSESSID=955ukgqk5f5nfno5hrev6v4796; path=/",
 "Expires"=>"Thu, 19 Nov 1981 08:52:00 GMT",
 "Cache-Control"=>"no-store, no-cache, must-revalidate, post-check=0, pre-check=0",
 "Pragma"=>"no-cache",
 "Location"=>"http://www.jianshu.com",
 "Content-type"=>"text/html; charset=UTF-8",
 "Content-Length"=>"0"}
```

### With `Faraday using Typhoeus`
```
> conn = Faraday.new(:url => "http://o1.la/OTk4Y") do |faraday|
>   faraday.request :retry, :max => 3, :interval => 1
>   faraday.adapter :typhoeus
> end
> resp = conn.head
> resp.headers
=> {"Date"=>"Tue, 11 Oct 2016 05:14:34 GMT",
 "Server"=>"Microsoft-IIS/6.0",
 "X-Powered-By"=>"ASP.NET, PHP/5.4.41",
 "Set-Cookie"=>"PHPSESSID=33ql4p7buhcupparecohoj1rq1; path=/",
 "Expires"=>"Thu, 19 Nov 1981 08:52:00 GMT",
 "Cache-Control"=>"no-store, no-cache, must-revalidate, post-check=0, pre-check=0",
 "Pragma"=>"no-cache",
 "Location:http://www.jianshu.com"=>nil,
 "Content-type"=>"text/html; charset=UTF-8",
 "Content-Length"=>"0"}
```
