### PR TITLE
Adapter support for Net::HTTP::Persistent v3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
+before_install: gem install bundler
 script: bundle exec script/test
 cache: bundler
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby RUBY_VERSION
+
 gem 'ffi-ncurses', '~> 0.3', :platforms => :jruby
 gem 'jruby-openssl', '~> 0.8.8', :platforms => :jruby
 gem 'rake'
@@ -13,24 +15,13 @@ group :test do
   gem 'httpclient', '>= 2.2'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'minitest', '>= 5.0.5'
-  gem 'net-http-persistent', '~> 2.9.4'
+  gem 'net-http-persistent'
   gem 'patron', '>= 0.4.2', :platforms => :ruby
   gem 'rack-test', '>= 0.6', :require => 'rack/test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]
   gem 'simplecov'
   gem 'sinatra', '~> 1.3'
   gem 'typhoeus', '~> 0.3.3', :platforms => [:ruby_18, :ruby_19, :ruby_20, :ruby_21]
-
-  # Below are dependencies of the gems we actually care about that have
-  # dropped support for older Rubies. Because they are not first-level
-  # dependencies, we don't need to specify an unconstrained version, so we can
-  # lump them together here.
-
-  if RUBY_VERSION < '2'
-    gem 'json', '< 2'
-    gem 'tins', '< 1.7.0'
-    gem 'term-ansicolor', '< 1.4'
-  end
 end
 
 gemspec

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -10,8 +10,11 @@ module Adapters
         if defined?(Net::HTTP::Persistent)
           # work around problems with mixed SSL certificates
           # https://github.com/drbrain/net-http-persistent/issues/45
-          http = Net::HTTP::Persistent.new('Faraday')
-          http.ssl_cleanup(4)
+          if Net::HTTP::Persistent.instance_method(:initialize).parameters.first == [:key, :name]
+            Net::HTTP::Persistent.new(name: 'Faraday').reconnect_ssl
+          else
+            Net::HTTP::Persistent.new('Faraday').ssl_cleanup(4)
+          end
         end
       end if ssl_mode?
     end


### PR DESCRIPTION
This PR attempts to support [Net::HTTP::Persistent](https://github.com/drbrain/net-http-persistent) 3.x or 2.x with its existing Faraday Adapter.

## Changes introduced

- For Net::HTTP::Persistent 3.x, there were changed APIs which needed changes in the existing Faraday Adapter
  - a constructor had gotten **keyword** arguments instead of **positional** ones
  - a cleaning-up method after SSL connections had been renamed
- Introduce the use of `ruby RUBY_VERSION` Ruby version hinting for Bundler in the Gemfile. 
  - The Gemfile is used during development and during test runs in CI.
  - with this, it was possible to **avoid pinning** to existing versions, and have the latest versions available supported by the _currently running platform_

## TODO

- [x] use `parameters` instead of `Net::HTTP::Persistent::VERSION` to find out which version is running

## Out of scope for this PR:

- tests for all 2.x/3.x of Net::HTTP::Persistent on all Ruby platforms. Example solution: [Thoughtbot's Appraisal gem](https://github.com/thoughtbot/appraisal) with sets of generated Gemfiles