### PR TITLE
Support IPv6 addresses in the :net_http adapter

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -89,10 +89,10 @@ module Faraday
 
       def net_http_connection(env)
         if proxy = env[:request][:proxy]
-          Net::HTTP::Proxy(proxy[:uri].host, proxy[:uri].port, proxy[:user], proxy[:password])
+          Net::HTTP::Proxy(proxy[:uri].hostname, proxy[:uri].port, proxy[:user], proxy[:password])
         else
           Net::HTTP
-        end.new(env[:url].host, env[:url].port || (env[:url].scheme == 'https' ? 443 : 80))
+        end.new(env[:url].hostname, env[:url].port || (env[:url].scheme == 'https' ? 443 : 80))
       end
 
       def configure_ssl(http, ssl)

--- a/test/adapters/excon_test.rb
+++ b/test/adapters/excon_test.rb
@@ -5,7 +5,7 @@ module Adapters
 
     def adapter() :excon end
 
-    Integration.apply(self, :NonParallel) do
+    Integration.apply(self, :NonParallel, :IPv6) do
       # https://github.com/geemus/excon/issues/126 ?
       undef :test_timeout if ssl_mode?
 

--- a/test/adapters/httpclient_test.rb
+++ b/test/adapters/httpclient_test.rb
@@ -5,7 +5,7 @@ module Adapters
 
     def adapter() :httpclient end
 
-    Integration.apply(self, :NonParallel, :Compression) do
+    Integration.apply(self, :NonParallel, :Compression, :IPv6) do
       def setup
         require 'httpclient' unless defined?(HTTPClient)
         HTTPClient::NO_PROXY_HOSTS.delete('localhost')

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -75,6 +75,16 @@ module Adapters
       end
     end
 
+    module IPv6
+      def test_simple_ipv6_request
+        server = self.class.live_server
+        uri = URI('%s://%s:%d' % [server.scheme, '[::1]', server.port])
+        conn = create_connection({}, uri)
+
+        assert_equal 'get', conn.get('echo').body
+      end
+    end
+
     module Common
       extend Forwardable
       def_delegators :create_connection, :get, :head, :put, :post, :patch, :delete, :run_request
@@ -234,7 +244,7 @@ module Adapters
         []
       end
 
-      def create_connection(options = {})
+      def create_connection(options = {}, server = self.class.live_server)
         if adapter == :default
           builder_block = nil
         else
@@ -245,7 +255,6 @@ module Adapters
           end
         end
 
-        server = self.class.live_server
         url = '%s://%s:%d' % [server.scheme, server.host, server.port]
 
         options[:ssl] ||= {}

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -7,7 +7,7 @@ module Adapters
 
     def adapter() :net_http end
 
-    behaviors = [:NonParallel, :Compression]
+    behaviors = [:NonParallel, :Compression, :IPv6]
 
     Integration.apply(self, *behaviors)
 

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -40,5 +40,15 @@ module Adapters
       assert_equal 1234, http.port
     end
 
+    def test_ipv6_uri
+      url = URI('http://[::1]')
+      url.port = nil
+
+      adapter = Faraday::Adapter::NetHttp.new
+      http = adapter.net_http_connection(:url => url, :request => {})
+
+      assert_equal '::1', http.address
+    end
+
   end
 end

--- a/test/adapters/patron_test.rb
+++ b/test/adapters/patron_test.rb
@@ -6,7 +6,7 @@ module Adapters
     def adapter() :patron end
 
     unless jruby?
-      Integration.apply(self, :NonParallel) do
+      Integration.apply(self, :NonParallel, :IPv6) do
         # https://github.com/toland/patron/issues/34
         undef :test_PATCH_send_url_encoded_params
 

--- a/test/adapters/typhoeus_test.rb
+++ b/test/adapters/typhoeus_test.rb
@@ -5,7 +5,7 @@ module Adapters
 
     def adapter() :typhoeus end
 
-    Integration.apply(self, :Parallel) do
+    Integration.apply(self, :Parallel, :IPv6) do
       # https://github.com/dbalatero/typhoeus/issues/75
       undef :test_GET_with_body
 


### PR DESCRIPTION
Fixes #589.

The problem comes from Net::HTTP not being able to understand brackets when passed a literal IPv6 address:

```
Net::HTTP.start("[::1]") #=> :(
Net::HTTP.start("::1") #=> :)
```

URI provides two different methods to extract the network host from the URI: [#host](https://docs.ruby-lang.org/en/2.1.0/URI/Generic.html#attribute-i-host), and [#hostname](https://docs.ruby-lang.org/en/2.1.0/URI/Generic.html#method-i-hostname).

The only difference being that `#hostname` will unwrap brackets for IPv6 addresses, which is what we want here.

There's a bit more background on **why** there's a different method in this ruby-core discussion/bug report: https://bugs.ruby-lang.org/issues/3788
