### PR TITLE
HTTPClient adapter shouldn't reset SSL each request

### DIFF
--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -100,12 +100,12 @@ module Faraday
         # Memoize the cert store so that the same one is passed to
         # HTTPClient each time, to avoid resyncing SSL sesions when
         # it's changed
-        if @cert_store.nil?
+        @cert_store ||= begin
           # Use the default cert store by default, i.e. system ca certs
-          @cert_store = OpenSSL::X509::Store.new
-          @cert_store.set_default_paths
+          cert_store = OpenSSL::X509::Store.new
+          cert_store.set_default_paths
+          cert_store
         end
-        @cert_store
       end
 
       def ssl_verify_mode(ssl)

--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -97,10 +97,15 @@ module Faraday
 
       def ssl_cert_store(ssl)
         return ssl[:cert_store] if ssl[:cert_store]
-        # Use the default cert store by default, i.e. system ca certs
-        cert_store = OpenSSL::X509::Store.new
-        cert_store.set_default_paths
-        cert_store
+        # Memoize the cert store so that the same one is passed to
+        # HTTPClient each time, to avoid resyncing SSL sesions when
+        # it's changed
+        if @cert_store.nil?
+          # Use the default cert store by default, i.e. system ca certs
+          @cert_store = OpenSSL::X509::Store.new
+          @cert_store.set_default_paths
+        end
+        @cert_store
       end
 
       def ssl_verify_mode(ssl)


### PR DESCRIPTION
This fixes #624, in conjunction with nahi/httpclient#343. The same
cert_store is passed to HTTPClient each request, so equality check
inside HTTPClient will skip the reset.