### PR TITLE
Rescue IOError (fixes #630)

### DIFF
--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -48,7 +48,7 @@ module Faraday
         else
           raise Faraday::Error::ClientError, $!
         end
-      rescue Errno::ECONNREFUSED, EOFError
+      rescue Errno::ECONNREFUSED, IOError
         raise Faraday::Error::ConnectionFailed, $!
       rescue => err
         if defined?(OpenSSL) && OpenSSL::SSL::SSLError === err

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -10,7 +10,7 @@ module Faraday
   class Adapter
     class NetHttp < Faraday::Adapter
       NET_HTTP_EXCEPTIONS = [
-        EOFError,
+        IOError,
         Errno::ECONNABORTED,
         Errno::ECONNREFUSED,
         Errno::ECONNRESET,


### PR DESCRIPTION
Rescue IOError rather than EOFError to cover more exceptions