### PR TITLE
Travis: use ruby-2.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3.1
+  - 2.3.3
   - jruby-19mode
   - jruby-20mode
   - jruby-21mode


### PR DESCRIPTION
This PR changes the Travis configuration to use latest stable 2.3 ruby.

- https://www.ruby-lang.org/en/news/2016/11/15/ruby-2-3-2-released/ [link to its changelog](http://svn.ruby-lang.org/repos/ruby/tags/v2_3_2/ChangeLog)
- https://www.ruby-lang.org/en/news/2016/11/21/ruby-2-3-3-released/