### PR TITLE
Carry #579: Faraday::Utils::Headers YAML can be serialized

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -113,7 +113,7 @@ module Faraday
       end
 
       def encode_with(coder)
-        coder['names'] = names
+        coder['names'] = @names
       end
 
       protected

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -112,6 +112,10 @@ module Faraday
         @names = coder['names']
       end
 
+      def encode_with(coder)
+        coder['names'] = names
+      end
+
       protected
 
       def names

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -108,6 +108,10 @@ module Faraday
           }
       end
 
+      def init_with(coder)
+        @names = coder['names']
+      end
+
       protected
 
       def names

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -63,5 +63,15 @@ class TestUtils < Faraday::TestCase
       Faraday::Utils.default_uri_parser = old_parser
     end
   end
+
+  # YAML parsing
+
+  def test_headers_yaml_roundtrip
+    headers = Faraday::Utils::Headers.new('User-Agent' => 'safari', 'Content-type' => 'text/html')
+    result = YAML.load(headers.to_yaml)
+
+    assert result.include?('user-agent'), 'Unable to hydrate to a correct Headers'
+    assert result.include?('content-type'), 'Unable to hydrate to a correct Headers'
+  end
 end
 


### PR DESCRIPTION
This PR is #579 and one more commit that has a test.

It exercises Header through to_yaml and YAML.load, and then uses its special methods with a simple assert on the output.