### PR TITLE
Integration test: raise error when no live server is configured

### DIFF
--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -9,7 +9,7 @@ module Adapters
   # `#adapter_options` optional. extra arguments for building an adapter
   module Integration
     def self.apply(base, *extra_features)
-      if base.live_server?
+      if base.live_server
         features = [:Common]
         features.concat extra_features
         features << :SSL if base.ssl_mode?
@@ -247,8 +247,6 @@ module Adapters
         end
 
         server = self.class.live_server
-        raise 'Integration test suite: Can not continue without live_server ' \
-              'configured. See CONTRIBUTING for usage.' unless server
         url = '%s://%s:%d' % [server.scheme, server.host, server.port]
 
         options[:ssl] ||= {}

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -246,6 +246,8 @@ module Adapters
         end
 
         server = self.class.live_server
+        raise 'Integration test suite: Can not continue without live_server ' \
+              'configured. See script/test for more.' unless server
         url = '%s://%s:%d' % [server.scheme, server.host, server.port]
 
         options[:ssl] ||= {}

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -18,6 +18,7 @@ module Adapters
       elsif !defined? @warned
         warn "Warning: Not running integration tests against a live server."
         warn "Start the server `ruby test/live_server.rb` and set the LIVE=1 env variable."
+        warn "See CONTRIBUTING for usage."
         @warned = true
       end
     end
@@ -247,7 +248,7 @@ module Adapters
 
         server = self.class.live_server
         raise 'Integration test suite: Can not continue without live_server ' \
-              'configured. See script/test for more.' unless server
+              'configured. See CONTRIBUTING for usage.' unless server
         url = '%s://%s:%d' % [server.scheme, server.host, server.port]
 
         options[:ssl] ||= {}


### PR DESCRIPTION
This PR is a developer-experience change to the integration tests: Before using a piece of configuration ("live_server") which may be `nil`, the test setup fails early and presents the user with an explanatory error.

  - Add a discoverable tip when trying to use a live server that is not configured

The benefit is that people who hack on the test suite learn their way around.

This happens to the user who tries to run:

```shell
$ ruby -Ilib:test test/adapters/net_http_test.rb
```