### PR TITLE
DO NOT MERGE, WIP: Carry #361: Support 'no_proxy' env variable

### DIFF
--- a/lib/faraday/autoload.rb
+++ b/lib/faraday/autoload.rb
@@ -72,7 +72,8 @@ module Faraday
       :Authorization => 'authorization',
       :BasicAuthentication => 'basic_authentication',
       :TokenAuthentication => 'token_authentication',
-      :Instrumentation => 'instrumentation'
+      :Instrumentation => 'instrumentation',
+      :Proxy => 'proxy'
   end
 
   class Response

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -79,14 +79,7 @@ module Faraday
       @params.update(options.params)   if options.params
       @headers.update(options.headers) if options.headers
 
-      @proxy = nil
-      proxy(options.fetch(:proxy) {
-        uri = ENV['http_proxy']
-        if uri && !uri.empty?
-          uri = 'http://' + uri if uri !~ /^http/i
-          uri
-        end
-      })
+      proxy(options.fetch(:proxy)) if options.proxy
 
       yield(self) if block_given?
 
@@ -280,10 +273,12 @@ module Faraday
       @parallel_manager = nil
     end
 
-    # Public: Gets or Sets the Hash proxy options.
+    # Public: Mounts proxy middleware
     def proxy(arg = nil)
-      return @proxy if arg.nil?
-      @proxy = ProxyOptions.from(arg)
+      # dont allow middleware to be set multiple times
+      unless builder.handlers.include?(Faraday::Request::Proxy)
+        builder.use Request::Proxy, arg
+      end
     end
 
     def_delegators :url_prefix, :scheme, :scheme=, :host, :host=, :port, :port=

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -80,7 +80,7 @@ module Faraday
       @params.update(options.params)   if options.params
       @headers.update(options.headers) if options.headers
 
-      proxy(options.proxy) if options.proxy
+      proxy(options.proxy)
 
       yield(self) if block_given?
 

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -379,7 +379,7 @@ module Faraday
       Request.create(method) do |req|
         req.params  = self.params.dup
         req.headers = self.headers.dup
-        req.options = self.options.merge(:proxy => self.proxy)
+        req.options = self.options
         yield(req) if block_given?
       end
     end

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -75,6 +75,10 @@ module Faraday
         options.new_builder(block_given? ? Proc.new { |b| } : nil)
       end
 
+      unless builder.handlers.include?(Faraday::Request::Proxy)
+        builder.use Request::Proxy, options.proxy
+      end
+
       self.url_prefix = url || 'http:/'
 
       @params.update(options.params)   if options.params

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -69,6 +69,7 @@ module Faraday
       @ssl = options.ssl
       @default_parallel_manager = options.parallel_manager
 
+
       @builder = options.builder || begin
         # pass an empty block to Builder so it doesn't assume default middleware
         options.new_builder(block_given? ? Proc.new { |b| } : nil)
@@ -79,7 +80,7 @@ module Faraday
       @params.update(options.params)   if options.params
       @headers.update(options.headers) if options.headers
 
-      proxy(options.fetch(:proxy)) if options.proxy
+      proxy(options.proxy) if options.proxy
 
       yield(self) if block_given?
 
@@ -275,7 +276,7 @@ module Faraday
 
     # Public: Mounts proxy middleware
     def proxy(arg = nil)
-      # dont allow middleware to be set multiple times
+      # Don't allow middleware to be set multiple times
       unless builder.handlers.include?(Faraday::Request::Proxy)
         builder.use Request::Proxy, arg
       end

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -235,7 +235,6 @@ module Faraday
     memoized(:password) { uri.password && Utils.unescape(uri.password) }
   end
 
-  # TODO: Should this have the :proxy option on it?
   class ConnectionOptions < Options.new(:request, :proxy, :ssl, :builder, :url,
     :parallel_manager, :params, :headers, :builder_class)
 

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -235,6 +235,7 @@ module Faraday
     memoized(:password) { uri.password && Utils.unescape(uri.password) }
   end
 
+  # TODO: Should this have the :proxy option on it?
   class ConnectionOptions < Options.new(:request, :proxy, :ssl, :builder, :url,
     :parallel_manager, :params, :headers, :builder_class)
 

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -19,7 +19,8 @@ module Faraday
       :authorization => [:Authorization, 'authorization'],
       :basic_auth => [:BasicAuthentication, 'basic_authentication'],
       :token_auth => [:TokenAuthentication, 'token_authentication'],
-      :instrumentation => [:Instrumentation, 'instrumentation']
+      :instrumentation => [:Instrumentation, 'instrumentation'],
+      :proxy => [:Proxy, 'proxy']
 
     def self.create(request_method)
       new(request_method).tap do |request|

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -120,6 +120,8 @@ module Faraday
         ["#{uri.host}:#{uri.port}", "#{no_proxy_uri.host}:#{no_proxy_uri.port}"].map(&:downcase)
       end
 
+      return true if uri_pattern == no_proxy_pattern
+
       /(\A|\.)#{Regexp.quote no_proxy_pattern}\z/i =~ uri_pattern
     end
 

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -120,11 +120,7 @@ module Faraday
         ["#{uri.host}:#{uri.port}", "#{no_proxy_uri.host}:#{no_proxy_uri.port}"].map(&:downcase)
       end
 
-      return true if uri_pattern == no_proxy_pattern
-
-      no_proxy_parts = no_proxy_pattern.split('.')
-      uri_parts = uri_pattern.split('.')
-      uri_parts.reverse.take(no_proxy_parts.size) == no_proxy_parts.reverse
+      /(\A|\.)#{Regexp.quote no_proxy_pattern}\z/i =~ uri_pattern
     end
 
     def parse_uri(uri='')

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -1,0 +1,140 @@
+module Faraday
+  # Uses Environment variables to set proxies on a per-connection basis.
+  #
+  # If a proxy is not explicitly set, the following environment variables
+  # are used:
+  #   http_proxy, https_proxy, no_proxy
+  # (upper case instances are used in the absence of lower case equivalents)
+  #
+  # The no_proxy list specifies a comma-separated list of domains
+  # (and optionally ports) for which the proxy should not be used.
+  #
+  # Examples:
+  #   # uses environment variables
+  #   Faraday.new do |conn|
+  #     conn.request :proxy
+  #     conn.adapter ..
+  #   end
+  #
+  #   # ignores environment variables
+  #   Faraday.new do |conn|
+  #     conn.request :proxy 'http://my.proxy.com', /
+  #                  :user => 'dan', :password => '123'
+  #     conn.adapter ..
+  #   end
+  class Request::Proxy < Faraday::Middleware
+    def initialize(app, proxy_url=nil, options={})
+      @proxies = {:http => nil, :https => nil}
+      parse_proxy_options(proxy_url, options)
+      super(app)
+    end
+
+    def call(env)
+      env[:request][:proxy] = proxy_for(env.url)
+      @app.call(env)
+    end
+
+    private
+    def parse_proxy_options(proxy, options)
+      if proxy.is_a?(Hash)
+        options = proxy
+        proxy = options.delete(:uri)
+      end
+
+      parse_proxies(proxy, options)
+      parse_no_proxy_list
+    end
+
+    def parse_proxies(uri=nil, options={})
+      proxy = parse_uri(uri)
+
+      case proxy.scheme
+        when 'http'
+          @proxies[:http]  = parse_proxy_uri('http_proxy',  uri, options)
+        when 'https'
+          @proxies[:https] = parse_proxy_uri('https_proxy', uri, options)
+        when nil
+          # set both proxies according to ENV variables
+          @proxies[:http]  = parse_proxy_uri('http_proxy',  nil, options)
+          @proxies[:https] = parse_proxy_uri('https_proxy', nil, options)
+        else
+          raise ::TypeError, \
+          "#{uri} is not a http(s) proxy URL."
+      end
+    end
+
+    def parse_proxy_uri(proxy_type, uri, options)
+      proxy = uri || ENV[proxy_type.downcase] || ENV[proxy_type.upcase]
+
+      proxy_uri = parse_uri(proxy)
+
+      if options.include?(:user)
+        proxy_uri.user = options[:user]
+      end
+
+      if options.include?(:password)
+        proxy_uri.password = options[:password]
+      end
+
+      proxy_uri = nil if proxy_uri.scheme == nil
+
+      proxy_uri
+    end
+
+    def parse_no_proxy_list
+      @no_proxy ||= nil
+      proxy_list = ENV['no_proxy'] || ENV['NO_PROXY']
+      @no_proxy = proxy_list.split(',') unless proxy_list.nil?
+    end
+
+    def proxy_for(uri)
+      {:uri => @proxies[uri.scheme.to_sym]} if proxy_allowed_for(uri)
+    end
+
+    def proxy_allowed_for(uri)
+      return true  if uri.nil? || uri.host.nil?
+      return false unless @proxies[uri.scheme.to_sym]
+      return true  unless @no_proxy
+
+      proxy_required = true
+
+      @no_proxy.each do |no_proxy_domain|
+        # ignore wildcards in domain
+        no_proxy_uri = no_proxy_domain.gsub('*.','')
+
+        if domains_match? uri, parse_uri(no_proxy_uri)
+          proxy_required = false
+          break
+        end
+      end
+
+      proxy_required
+    end
+
+    def domains_match?(uri, no_proxy_uri)
+      if no_proxy_uri.port == 80
+        # domain matching is fine
+        uri_pattern       = uri.host
+        no_proxy_pattern  = no_proxy_uri.host
+      else
+        # need to match ports exactly
+        uri_pattern       = "#{uri.host}:#{uri.port}"
+        no_proxy_pattern  = "#{no_proxy_uri.host}:#{no_proxy_uri.port}"
+      end
+
+      uri_pattern.downcase == no_proxy_pattern.downcase
+    end
+
+    def parse_uri(uri='')
+      uri = uri.to_s
+      parsed = Utils::URI(uri)
+
+      # assume strings without scheme are of http
+      if parsed.class == URI::Generic && !uri.empty?
+        parsed = Utils::URI("http://#{uri}")
+      end
+
+      parsed
+    end
+  end
+end

--- a/lib/faraday/request/proxy.rb
+++ b/lib/faraday/request/proxy.rb
@@ -112,17 +112,19 @@ module Faraday
     end
 
     def domains_match?(uri, no_proxy_uri)
-      if no_proxy_uri.port == 80
+      uri_pattern, no_proxy_pattern = if no_proxy_uri.port == 80
         # domain matching is fine
-        uri_pattern       = uri.host
-        no_proxy_pattern  = no_proxy_uri.host
+        [uri.host, no_proxy_uri.host].map(&:downcase)
       else
         # need to match ports exactly
-        uri_pattern       = "#{uri.host}:#{uri.port}"
-        no_proxy_pattern  = "#{no_proxy_uri.host}:#{no_proxy_uri.port}"
+        ["#{uri.host}:#{uri.port}", "#{no_proxy_uri.host}:#{no_proxy_uri.port}"].map(&:downcase)
       end
 
-      uri_pattern.downcase == no_proxy_pattern.downcase
+      return true if uri_pattern == no_proxy_pattern
+
+      no_proxy_parts = no_proxy_pattern.split('.')
+      uri_parts = uri_pattern.split('.')
+      uri_parts.reverse.take(no_proxy_parts.size) == no_proxy_parts.reverse
     end
 
     def parse_uri(uri='')

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -253,8 +253,6 @@ module Adapters
           end
 
         server = self.class.live_server
-        warn 'Integration test suite: Can not continue without live_server configured. See script/test for more.' unless server
-        raise 'Integration test suite: Can not continue without live_server configured. See script/test for more.' unless server
         url = '%s://%s:%d' % [server.scheme, server.host, server.port]
 
         options[:ssl] ||= {}

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -192,7 +192,7 @@ module Adapters
 
       def test_proxy
         proxy_uri = URI(ENV['LIVE_PROXY'])
-        conn = create_connection(:proxy => { uri: proxy_uri })
+        conn = create_connection(:proxy => { :uri => proxy_uri })
 
         res = conn.get '/echo'
         assert_equal 'get', res.body
@@ -206,7 +206,7 @@ module Adapters
       def test_proxy_auth_fail
         proxy_uri = URI(ENV['LIVE_PROXY'])
         proxy_uri.password = 'WRONG'
-        conn = create_connection(:proxy => { uri: proxy_uri, password: proxy_uri.password })
+        conn = create_connection(:proxy => { :uri => proxy_uri, :password => proxy_uri.password })
 
         err = assert_raises Faraday::Error::ConnectionFailed do
           conn.get '/echo'
@@ -253,6 +253,7 @@ module Adapters
         end
 
         server = self.class.live_server
+        warn 'Integration test suite: Can not continue without live_server configured. See script/test for more.' unless server
         raise 'Integration test suite: Can not continue without live_server configured. See script/test for more.' unless server
         url = '%s://%s:%d' % [server.scheme, server.host, server.port]
 

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -267,7 +267,7 @@ class TestConnection < Faraday::TestCase
 
   def test_proxy_middleware_instantiated_via_proxy_option
     conn_no_proxy = Faraday::Connection.new
-    refute conn_no_proxy.builder.handlers.include?(Faraday::Request::Proxy)
+    assert conn_no_proxy.builder.handlers.include?(Faraday::Request::Proxy)
 
     conn_with_proxy = Faraday::Connection.new(nil, :proxy => 'http://proxy.com')
     assert conn_with_proxy.builder.handlers.include?(Faraday::Request::Proxy)
@@ -276,7 +276,7 @@ class TestConnection < Faraday::TestCase
   def test_proxy_middleware_instantiated_via_proxy_method
     conn = Faraday::Connection.new
 
-    refute conn.builder.handlers.include?(Faraday::Request::Proxy)
+    assert conn.builder.handlers.include?(Faraday::Request::Proxy)
     conn.proxy 'http://proxy.com'
 
     assert conn.builder.handlers.include?(Faraday::Request::Proxy)
@@ -300,8 +300,8 @@ class TestConnection < Faraday::TestCase
     other.params['b'] = '2'
     other.options[:open_timeout] = 10
 
-    assert_equal 2, other.builder.handlers.size
-    assert_equal 2, conn.builder.handlers.size
+    assert_equal 3, other.builder.handlers.size
+    assert_equal 3, conn.builder.handlers.size
     assert !conn.headers.key?('content-length')
     assert !conn.params.key?('b')
     assert_equal 5, other.options[:timeout]
@@ -315,7 +315,9 @@ class TestConnection < Faraday::TestCase
 
   def test_init_with_block
     conn = Faraday::Connection.new { }
-    assert_equal 0, conn.builder.handlers.size
+    assert_equal 1,
+                 conn.builder.handlers.size,
+                 "There should always be a Request::Proxy"
   end
 
   def test_init_with_block_yields_connection
@@ -324,7 +326,7 @@ class TestConnection < Faraday::TestCase
       faraday.url_prefix = 'http://sushi.com/omnom'
       assert_equal '1', faraday.params['a']
     }
-    assert_equal 1, conn.builder.handlers.size
+    assert_equal 2, conn.builder.handlers.size, "The adapter and Request::Proxy"
     assert_equal '/omnom', conn.path_prefix
   end
 

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -1,21 +1,6 @@
 require File.expand_path('../helper', __FILE__)
 
 class TestConnection < Faraday::TestCase
-
-  def with_env(key, proxy)
-    old_value = ENV.fetch(key, false)
-    ENV[key] = proxy
-    begin
-      yield
-    ensure
-      if old_value == false
-        ENV.delete key
-      else
-        ENV[key] = old_value
-      end
-    end
-  end
-
   def test_initialize_parses_host_out_of_given_url
     conn = Faraday::Connection.new "http://sushi.com"
     assert_equal 'sushi.com', conn.host
@@ -280,89 +265,21 @@ class TestConnection < Faraday::TestCase
     assert_equal '/sake.html', uri.path
   end
 
-  def test_proxy_accepts_string
-    with_env 'http_proxy', "http://duncan.proxy.com:80" do
-      conn = Faraday::Connection.new
-      conn.proxy 'http://proxy.com'
-      assert_equal 'proxy.com', conn.proxy.host
-    end
+  def test_proxy_middleware_instantiated_via_proxy_option
+    conn_no_proxy = Faraday::Connection.new
+    refute conn_no_proxy.builder.handlers.include?(Faraday::Request::Proxy)
+
+    conn_with_proxy = Faraday::Connection.new(nil, :proxy => 'http://proxy.com')
+    assert conn_with_proxy.builder.handlers.include?(Faraday::Request::Proxy)
   end
 
-  def test_proxy_accepts_uri
-    with_env 'http_proxy', "http://duncan.proxy.com:80" do
-      conn = Faraday::Connection.new
-      conn.proxy URI.parse('http://proxy.com')
-      assert_equal 'proxy.com', conn.proxy.host
-    end
-  end
-
-  def test_proxy_accepts_hash_with_string_uri
-    with_env 'http_proxy', "http://duncan.proxy.com:80" do
-      conn = Faraday::Connection.new
-      conn.proxy :uri => 'http://proxy.com', :user => 'rick'
-      assert_equal 'proxy.com', conn.proxy.host
-      assert_equal 'rick',      conn.proxy.user
-    end
-  end
-
-  def test_proxy_accepts_hash
-    with_env 'http_proxy', "http://duncan.proxy.com:80" do
-      conn = Faraday::Connection.new
-      conn.proxy :uri => URI.parse('http://proxy.com'), :user => 'rick'
-      assert_equal 'proxy.com', conn.proxy.host
-      assert_equal 'rick',      conn.proxy.user
-    end
-  end
-
-  def test_proxy_accepts_http_env
-    with_env 'http_proxy', "http://duncan.proxy.com:80" do
-      conn = Faraday::Connection.new
-      assert_equal 'duncan.proxy.com', conn.proxy.host
-    end
-  end
-
-  def test_proxy_accepts_http_env_with_auth
-    with_env 'http_proxy', "http://a%40b:my%20pass@duncan.proxy.com:80" do
-      conn = Faraday::Connection.new
-      assert_equal 'a@b',     conn.proxy.user
-      assert_equal 'my pass', conn.proxy.password
-    end
-  end
-
-  def test_proxy_accepts_env_without_scheme
-    with_env 'http_proxy', "localhost:8888" do
-      uri = Faraday::Connection.new.proxy[:uri]
-      assert_equal 'localhost', uri.host
-      assert_equal 8888, uri.port
-    end
-  end
-
-  def test_no_proxy_from_env
-    with_env 'http_proxy', nil do
-      conn = Faraday::Connection.new
-      assert_equal nil, conn.proxy
-    end
-  end
-
-  def test_no_proxy_from_blank_env
-    with_env 'http_proxy', '' do
-      conn = Faraday::Connection.new
-      assert_equal nil, conn.proxy
-    end
-  end
-
-  def test_proxy_doesnt_accept_uppercase_env
-    with_env 'HTTP_PROXY', "http://localhost:8888/" do
-      conn = Faraday::Connection.new
-      assert_nil conn.proxy
-    end
-  end
-
-  def test_proxy_requires_uri
+  def test_proxy_middleware_instantiated_via_proxy_method
     conn = Faraday::Connection.new
-    assert_raises ArgumentError do
-      conn.proxy :uri => :bad_uri, :user => 'rick'
-    end
+
+    refute conn.builder.handlers.include?(Faraday::Request::Proxy)
+    conn.proxy 'http://proxy.com'
+
+    assert conn.builder.handlers.include?(Faraday::Request::Proxy)
   end
 
   def test_dups_connection_object

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -9,7 +9,6 @@ class EnvTest < Faraday::TestCase
     @conn.options.timeout      = 3
     @conn.options.open_timeout = 5
     @conn.ssl.verify           = false
-    @conn.proxy 'http://proxy.com'
   end
 
   def test_request_create_stores_method
@@ -70,11 +69,6 @@ class EnvTest < Faraday::TestCase
   def test_request_create_stores_ssl_options
     env = make_env
     assert_equal false, env.ssl.verify
-  end
-
-  def test_request_create_stores_proxy_options
-    env = make_env
-    assert_equal 'proxy.com', env.request.proxy.host
   end
 
   def test_custom_members_are_retained

--- a/test/middleware_stack_test.rb
+++ b/test/middleware_stack_test.rb
@@ -159,6 +159,7 @@ class MiddlewareStackTest < Faraday::TestCase
     @builder.build do |b|
       handlers.each { |handler| b.use(*handler) }
       yield(b) if block_given?
+      b.use Faraday::Request::Proxy
 
       b.adapter :test do |stub|
         stub.get '/' do |env|

--- a/test/proxy_middleware_test.rb
+++ b/test/proxy_middleware_test.rb
@@ -261,12 +261,18 @@ class ProxyMiddlewareTest < Faraday::TestCase
   end
 
   def test_https_ignored_given_domain
-    with_env 'https_proxy' => 'http://proxy.com', 'no_proxy' => 'github.com' do
-      %w(www.github.com pages.github.com).each do |url|
+    with_env 'https_proxy' => 'https://ssl.proxy.com', 'no_proxy' => 'example.co.uk' do
+      %w(www.example.co.uk sales.eu.example.co.uk).each do |url|
         response = connection("https://#{url}"){ |b| b.request :proxy }.get('/test')
         proxy_options = response.env.request.proxy
 
         assert_nil proxy_options
+      end
+      %w(malwareexample.co.uk).each do |url|
+        response = connection("https://#{url}"){ |b| b.request :proxy }.get('/test')
+        proxy_options = response.env.request.proxy
+
+        assert proxy_options, "#{url} should not be ignored by the no_proxy 'example.co.uk'"
       end
     end
   end

--- a/test/proxy_middleware_test.rb
+++ b/test/proxy_middleware_test.rb
@@ -1,0 +1,292 @@
+require File.expand_path('../helper', __FILE__)
+
+class ProxyMiddlewareTest < Faraday::TestCase
+  def with_env(new_env)
+    old_env = {}
+
+    new_env.each do |key, value|
+      old_env[key] = ENV.fetch(key, false)
+      ENV[key] = value
+    end
+
+    begin
+      yield
+    ensure
+      old_env.each do |key, value|
+        if value == false
+          ENV.delete key
+        else
+          ENV[key] = value
+        end
+      end
+    end
+  end
+
+  def connection(url='http://example.com')
+    Faraday.new(url) do |builder|
+      yield builder
+      builder.adapter :test do |stub|
+        stub.get('/test') {[ 200, {}, '' ]}
+      end
+    end
+  end
+
+  def test_no_proxy_set_by_default
+    with_env 'HTTP_PROXY' => '', 'http_proxy' => nil do
+      response = connection{ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      assert_nil proxy_options
+    end
+  end
+
+  def test_raise_when_non_http_or_https_proxy_passed_in
+    conn = connection('http://example.com'){ |b| b.request :proxy, 'ftp://example.com'}
+    assert_raises TypeError do conn.get('/test') end
+  end
+
+  def test_proxy_accepts_env_without_scheme
+    with_env 'http_proxy' => "localhost:8888" do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'localhost', proxy_options.uri.host
+      assert_equal 8888,      proxy_options.uri.port
+    end
+  end
+
+  def test_http_proxy_in_env_is_set
+    with_env 'HTTP_PROXY' => nil, 'http_proxy' => 'http://proxy.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
+  end
+
+  def test_http_proxy_with_username_and_password
+    with_env 'HTTP_PROXY' => nil, 'http_proxy' => 'http://username:pass@proxy.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'proxy.com', proxy_options.uri.host
+      assert_equal 'username',  proxy_options.user
+      assert_equal 'pass',      proxy_options.password
+    end
+  end
+
+  def test_http_proxy_in_env_is_set_in_upper_case
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'http_proxy' => nil do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
+  end
+
+  def test_http_proxy_set_explicitly
+    conn = connection { |b| b.request :proxy, 'http://proxy.com' }
+    response = conn.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'http://proxy.com', proxy_options.uri.to_s
+  end
+
+  def test_http_proxy_set_explicitly_with_username_and_password
+    conn = connection { |b| b.request :proxy, 'http://proxy.com',
+                                      :user => 'username',
+                                      :password => 'pass' }
+    response = conn.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'proxy.com', proxy_options.uri.host
+    assert_equal 'username',  proxy_options.user
+    assert_equal 'pass',      proxy_options.password
+  end
+
+  # this is to allow connection#proxy to behave as before
+  def test_http_proxy_set_via_hash
+    conn = connection { |b| b.request :proxy,
+                                      {
+                                          :uri => 'http://proxy.com',
+                                          :user => 'username',
+                                          :password => 'pass'
+                                      }
+    }
+    response = conn.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'proxy.com', proxy_options.uri.host
+    assert_equal 'username',  proxy_options.user
+    assert_equal 'pass',      proxy_options.password
+  end
+
+  def test_http_proxy_with_encoded_username_and_password
+    conn = connection { |b| b.request :proxy,
+                                      {
+                                          :uri => 'http://proxy.com',
+                                          :user => '%27username%27',
+                                          :password => '%27password%27'
+                                      }
+    }
+    response = conn.get('/test')
+    proxy_options = response.env.request.proxy
+
+    refute_nil proxy_options
+    assert_equal 'proxy.com', proxy_options.uri.host
+    assert_equal "'username'",  proxy_options.user
+    assert_equal "'password'",      proxy_options.password
+  end
+
+  def test_lower_case_env_trumps_upper_case
+    with_env 'http_proxy' => 'http://proxy.com', 'HTTP_PROXY' => 'http://upper.proxy.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
+  end
+
+  def test_explicit_proxy_trumps_env
+    with_env 'HTTP_PROXY' => 'http://env.proxy.com' do
+      conn = connection { |b| b.request :proxy, 'http://ex.proxy.com' }
+      response = conn.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'http://ex.proxy.com', proxy_options.uri.to_s
+    end
+  end
+
+  def test_proxy_set_and_url_in_no_proxy_list_removes_proxy
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      assert_nil proxy_options
+    end
+  end
+
+  def test_proxy_set_and_url_not_in_no_proxy_list_sets_proxy
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example2.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
+  end
+
+  def test_proxy_set_in_multi_element_no_proxy_list
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example0.com,example.com,example1.com' do
+      response = connection { |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      assert_nil proxy_options
+    end
+  end
+
+  def test_proxy_ignored_when_ports_match_in_no_proxy_list
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example.com:7171' do
+      response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      assert_nil proxy_options
+    end
+  end
+
+  def test_proxy_ignored_when_port_is_not_set_in_no_proxy_list
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example.com' do
+      response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      assert_nil proxy_options
+    end
+  end
+
+  def test_proxy_set_when_ports_mismatch_in_no_proxy_list
+    with_env 'HTTP_PROXY' => 'http://proxy.com', 'NO_PROXY' => 'example.com:3000' do
+      response = connection('http://example.com:7171'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
+  end
+
+  def test_proxy_set_when_url_is_nil
+    with_env 'HTTP_PROXY' => 'http://proxy.com' do
+      response = connection(nil){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
+  end
+
+  def test_https_proxy_set_given_https_url
+    with_env 'HTTPS_PROXY' => 'https://ssl.proxy.com' do
+      response = connection('https://example.com'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'https://ssl.proxy.com', proxy_options.uri.to_s
+    end
+  end
+
+  def test_https_ignored_given_match_in_no_proxy_list
+    with_env 'HTTPS_PROXY' => 'https://ssl.proxy.com', 'NO_PROXY' => 'example.com' do
+      response = connection('https://example.com'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      assert_nil proxy_options
+    end
+  end
+
+  def test_https_ignored_when_http_url_requested
+    with_env 'http_proxy' => nil, 'HTTP_PROXY' => nil, 'HTTPS_PROXY' => 'https://ssl.proxy.com' do
+      response = connection('http://example.com'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      assert_nil proxy_options
+    end
+  end
+
+  def test_https_ignored_given_domain
+    with_env 'https_proxy' => 'http://proxy.com', 'no_proxy' => 'github.com' do
+      %w(www.github.com pages.github.com).each do |url|
+        response = connection("https://#{url}"){ |b| b.request :proxy }.get('/test')
+        proxy_options = response.env.request.proxy
+
+        assert_nil proxy_options
+      end
+    end
+  end
+
+  def test_https_ignored_given_match_subdomain
+    with_env 'https_proxy' => 'http://proxy.com', 'no_proxy' => 'pages.github.com' do
+      response = connection('https://pages.github.com'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      assert_nil proxy_options
+    end
+  end
+
+  def test_https_set_given_match_subdomain
+    with_env 'https_proxy' => 'http://proxy.com', 'no_proxy' => 'pages.github.com' do
+      response = connection('https://github.com'){ |b| b.request :proxy }.get('/test')
+      proxy_options = response.env.request.proxy
+
+      refute_nil proxy_options
+      assert_equal 'http://proxy.com', proxy_options.uri.to_s
+    end
+  end
+end


### PR DESCRIPTION
This PR, which is #361 and changes to make tests pass, is in progress :fire:

**Superseded by** #658 which does the same thing without adding the concept of "default middleware".

TODO: 

- [ ] DESIGN DECISION: decide how to get the added middleware into `default` status
- [ ] make the `default` case pass its 2 test failures due to same

```
  1) Failure:
Adapters::DefaultTest#test_proxy_auth_fail [/home/travis/build/lostisland/faraday/test/adapters/integration.rb:212]:
Faraday::ConnectionFailed expected but nothing was raised.

  2) Failure:
Adapters::DefaultTest#test_proxy [/home/travis/build/lostisland/faraday/test/adapters/integration.rb:203]:
Proxy was not able to append Via header.
Expected /:3998$/ to match nil.
```