### PR TITLE
Include response on ClientErrors raised while parsing

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -3,7 +3,7 @@ module Faraday
   class MissingDependency < Error; end
 
   class ClientError < Error
-    attr_reader :response
+    attr_accessor :response
 
     def initialize(ex, response = nil)
       @wrapped_exception = nil

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -14,6 +14,9 @@ module Faraday
       # Calls the `parse` method if defined
       def on_complete(env)
         env.body = parse(env.body) if respond_to?(:parse) && env.parse_body?
+      rescue Faraday::Error::ClientError => err
+        err.response ||= env.response
+        raise err
       end
     end
 


### PR DESCRIPTION
The `ClientError` class allows a `response` object to be defined, and yet it does not seem to be defined in many cases. For parsing errors in particular, it can be beneficial for logging and debugging if the response object was properly available on the error.

Originally I was looking to incorporate this change in the [`FaradayMiddleware::ResponseMiddleware#parse` method](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response_middleware.rb#L45-L56) by passing `env` instead of `env[:body]`, but then I realized it was part of the standard `Faraday::Response::Middleware` interface to only pass the `body` in to the `parse` method.

An alternative implementation could be to raise a new `ClientError` instance instead of setting the `response` value on the error. In order to maintain the original error's class, one would need to create a new instance of the original error, e.g.: `raise err.class.new(err, env.response)`. This would also require changing the `TimeoutError#initialize` method to accept `response` as an optional parameter.

I'm also wondering if perhaps there was a specific reason the `response` object was not being set more consistently on `ClientError`s.