### PR TITLE
Integer Unification for Ruby 2.4.0+

### DIFF
--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -27,7 +27,7 @@ module Faraday
       DEFAULT_CHECK = lambda { |env,exception| false }
 
       def self.from(value)
-        if Fixnum === value
+        if Integer === value
           new(value)
         else
           super(value)


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warnings in Ruby 2.4.0-rc1.

`warning: constant ::Fixnum is deprecated`

Thanks.