### PR TITLE
Fix Net::HTTP proxy issue

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -90,15 +90,14 @@ module Faraday
 
       def net_http_connection(env)
         proxy = env[:request][:proxy]
+        addr  = env[:url].host
+        port  = env[:url].port || (env[:url].scheme == 'https' ? 443 : 80)
         # HTTP.Proxy is obsolete, and Net::HTTP will use proxy from env as default
-        Net::HTTP.new(
-          env[:url].host,
-          env[:url].port || (env[:url].scheme == 'https' ? 443 : 80),
-          proxy[:uri].host,
-          proxy[:uri].port,
-          proxy[:user],
-          proxy[:password]
-        )
+        if proxy.nil?
+          Net::HTTP.new(addr, port, nil)
+        else
+          Net::HTTP.new(addr, port, proxy[:uri].host, proxy[:uri].port, proxy[:user], proxy[:password])
+        end
       end
 
       def configure_ssl(http, ssl)

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -89,11 +89,16 @@ module Faraday
       end
 
       def net_http_connection(env)
-        if proxy = env[:request][:proxy]
-          Net::HTTP::Proxy(proxy[:uri].host, proxy[:uri].port, proxy[:user], proxy[:password])
-        else
-          Net::HTTP
-        end.new(env[:url].host, env[:url].port || (env[:url].scheme == 'https' ? 443 : 80))
+        proxy = env[:request][:proxy]
+        # HTTP.Proxy is obsolete, and Net::HTTP will use proxy from env as default
+        Net::HTTP.new(
+          env[:url].host,
+          env[:url].port || (env[:url].scheme == 'https' ? 443 : 80),
+          proxy[:uri].host,
+          proxy[:uri].port,
+          proxy[:user],
+          proxy[:password]
+        )
       end
 
       def configure_ssl(http, ssl)

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -40,5 +40,24 @@ module Adapters
       assert_equal 1234, http.port
     end
 
+    def test_no_proxy_with_nil_input
+      url = URI('http://example.com')
+
+      adapter = Faraday::Adapter::NetHttp.new
+      http = adapter.net_http_connection(:url => url, :request => { :proxy => nil })
+
+      assert_equal false, http.proxy_from_env?
+    end
+
+    def test_no_proxy_with_empty_string
+      url = URI('http://example.com')
+
+      adapter = Faraday::Adapter::NetHttp.new
+      proxy = Faraday::ProxyOptions.from('')
+      http = adapter.net_http_connection(:url => url, :request => { :proxy => proxy })
+
+      assert_equal false, http.proxy_from_env?
+    end
+
   end
 end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -78,6 +78,14 @@ class OptionsTest < Faraday::TestCase
     assert_equal 'example.org', options.host
     assert_equal 'http', options.scheme
   end
+  
+  def test_proxy_options_from_empty_string
+    options = Faraday::ProxyOptions.from ''
+    assert_nil options.user
+    assert_nil options.password
+    assert_kind_of URI, options.uri
+    assert_nil options.host
+  end
 
   def test_proxy_options_hash_access
     proxy = Faraday::ProxyOptions.from 'http://a%40b:pw%20d@example.org'


### PR DESCRIPTION
1. Net::HTTP.Proxy is obsolete;
2. Net::HTTP use proxy from env as default

> Please refer to https://github.com/ruby/ruby/blob/trunk/lib/net/http.rb
Net::HTTP use proxy from env as default, so even though we set `''` to faraday proxy and use `net_http` as the adapter, in the end, `Net::HTTP` will still use the proxy from system env.
>
> And `Net::HTTP.Proxy` is obsolete, so move to use `Net::HTTP`