### PR TITLE
Ruby 2.4.0 and Minitest 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3
-  - 2.4
+  - 2.3.0
+  - 2.4.0-rc1
   - jruby-19mode
   - jruby-20mode
   - jruby-21mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3.1
+  - 2.3
+  - 2.4
   - jruby-19mode
   - jruby-20mode
   - jruby-21mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
-  - 2.4.0-rc1
+  - 2.4.0
   - jruby-19mode
   - jruby-20mode
   - jruby-21mode

--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -27,7 +27,7 @@ module Faraday
       DEFAULT_CHECK = lambda { |env,exception| false }
 
       def self.from(value)
-        if Fixnum === value
+        if Integer === value
           new(value)
         else
           super(value)

--- a/test/composite_read_io_test.rb
+++ b/test/composite_read_io_test.rb
@@ -40,22 +40,22 @@ class CompositeReadIOTest < Faraday::TestCase
     assert_equal "abc", io.read(3)
     assert_equal "d12", io.read(3)
     assert_equal "34", io.read(3)
-    assert_equal nil, io.read(3)
-    assert_equal nil, io.read(3)
+    assert_nil io.read(3)
+    assert_nil io.read(3)
   end
 
   def test_multipart_read_limited_size_larger_than_part
     io = composite_io(part("abcd"), part("1234"))
     assert_equal "abcd12", io.read(6)
     assert_equal "34", io.read(6)
-    assert_equal nil, io.read(6)
+    assert_nil io.read(6)
   end
 
   def test_multipart_read_with_blank_parts
     io = composite_io(part(""), part("abcd"), part(""), part("1234"), part(""))
     assert_equal "abcd12", io.read(6)
     assert_equal "34", io.read(6)
-    assert_equal nil, io.read(6)
+    assert_nil io.read(6)
   end
 
   def test_multipart_rewind
@@ -65,7 +65,7 @@ class CompositeReadIOTest < Faraday::TestCase
     io.rewind
     assert_equal "abc", io.read(3)
     assert_equal "d1234", io.read(5)
-    assert_equal nil, io.read(3)
+    assert_nil io.read(3)
     io.rewind
     assert_equal "ab", io.read(2)
   end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -344,14 +344,14 @@ class TestConnection < Faraday::TestCase
   def test_no_proxy_from_env
     with_env 'http_proxy', nil do
       conn = Faraday::Connection.new
-      assert_equal nil, conn.proxy
+      assert_nil conn.proxy
     end
   end
 
   def test_no_proxy_from_blank_env
     with_env 'http_proxy', '' do
       conn = Faraday::Connection.new
-      assert_equal nil, conn.proxy
+      assert_nil conn.proxy
     end
   end
 

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -142,7 +142,7 @@ class HeadersTest < Faraday::TestCase
     assert_equal 'application/json', @headers.delete('content-type')
     assert_equal 0, @headers.size
     assert !@headers.include?('content-type')
-    assert_equal nil, @headers.delete('content-type')
+    assert_nil @headers.delete('content-type')
   end
 
   def test_parse_response_headers_leaves_http_status_line_out

--- a/test/response_middleware_test.rb
+++ b/test/response_middleware_test.rb
@@ -63,10 +63,10 @@ class ResponseNoBodyMiddleWareTest < Faraday::TestCase
   end
 
   def test_204
-    assert_equal nil, @conn.get('no_content').body
+    assert_nil @conn.get('no_content').body
   end
 
   def test_304
-    assert_equal nil, @conn.get('not_modified').body
+    assert_nil @conn.get('not_modified').body
   end
 end


### PR DESCRIPTION
WIP to get Faraday supporting both Ruby 2.4 (currently RC1 available) and Minitest 6.
Fixes some deprecation warnings.

To be merged only after Ruby 2.4.0 gets his final release