### PR TITLE
Support additional options for NetHttpPersistent adapter.

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -32,10 +32,7 @@ module Faraday
         super
         with_net_http_connection(env) do |http|
           configure_ssl(http, env[:ssl]) if env[:url].scheme == 'https' and env[:ssl]
-
-          req = env[:request]
-          http.read_timeout = http.open_timeout = req[:timeout] if req[:timeout]
-          http.open_timeout = req[:open_timeout]                if req[:open_timeout]
+          configure_request_options(http, env[:request])
 
           begin
             http_response = perform_request(http, env)
@@ -107,6 +104,11 @@ module Faraday
         http.ca_path      = ssl[:ca_path]      if ssl[:ca_path]
         http.verify_depth = ssl[:verify_depth] if ssl[:verify_depth]
         http.ssl_version  = ssl[:version]      if ssl[:version]
+      end
+
+      def configure_request_options(http, req)
+        http.read_timeout = http.open_timeout = req[:timeout] if req[:timeout]
+        http.open_timeout = req[:open_timeout]                if req[:open_timeout]
       end
 
       def ssl_cert_store(ssl)

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -44,6 +44,12 @@ module Faraday
         http.ca_file      = ssl[:ca_file]      if ssl[:ca_file]
         http.ssl_version  = ssl[:version]      if ssl[:version]
       end
+
+      def configure_request_options(http, req)
+        super
+        http.idle_timeout          = req[:idle_timeout]          if req[:idle_timeout]
+        http.retry_change_requests = req[:retry_change_requests] if req[:retry_change_requests]
+      end
     end
   end
 end

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -189,8 +189,8 @@ module Faraday
   end
 
   class RequestOptions < Options.new(:params_encoder, :proxy, :bind,
-    :timeout, :open_timeout, :boundary,
-    :oauth)
+    :timeout, :open_timeout, :idle_timeout, :boundary,
+    :oauth, :retry_change_requests)
 
     def []=(key, value)
       if key && key.to_sym == :proxy


### PR DESCRIPTION
The idle_timeout and retry_change_requests request options are documented at http://docs.seattlerb.org/net-http-persistent/Net/HTTP/Persistent.html.