### PR TITLE
Use subclasses of Net::HTTPRequest instead of Net::HTTPGenericRequest

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -64,12 +64,10 @@ module Faraday
       private
 
       def create_request(env)
-        request = Net::HTTPGenericRequest.new \
-          env[:method].to_s.upcase,    # request method
-          !!env[:body],                # is there request body
-          :head != env[:method],       # is there response body
-          env[:url].request_uri,       # request uri path
-          env[:request_headers]        # request headers
+        klass = Net::HTTP.const_get(env[:method].to_s.capitalize)
+        request = klass.new \
+          env[:url].request_uri, # request uri path
+          env[:request_headers]  # request headers
 
         if env[:body].respond_to?(:read)
           request.body_stream = env[:body]

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -160,7 +160,7 @@ module Adapters
       def test_OPTIONS
         resp = run_request(:options, 'echo', nil, {})
 
-        body = 'options' if Faraday::TestCase.ruby_22_plus?
+        body = Faraday::TestCase.ruby_22_plus? ? 'options' : ''
 
         assert_equal body, resp.body
       end

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -160,7 +160,7 @@ module Adapters
       def test_OPTIONS
         resp = run_request(:options, 'echo', nil, {})
 
-        body = 'options' if ruby_22_plus?
+        body = 'options' if Faraday::TestCase.ruby_22_plus?
 
         assert_equal body, resp.body
       end

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -159,7 +159,10 @@ module Adapters
 
       def test_OPTIONS
         resp = run_request(:options, 'echo', nil, {})
-        assert_equal 'options', resp.body
+
+        body = 'options' if ruby_22_plus?
+
+        assert_equal body, resp.body
       end
 
       def test_HEAD_retrieves_no_response_body


### PR DESCRIPTION
Fixes a problem with `net-http-persistent` adapter that is checking the subclasses of `Net::HTTPRequest` for idempotence support.

Instead of directly instantiating `Net::HTTPGenericRequest`, use the appropriate `Net::HTTPRequest` subclass.

We stumbled upon this situation at @catawiki when we switched our internal API client to `faraday` (backed by `net-http-persistent`). Whenever we reloaded our `nginx` instances we saw `Net::HTTP::Persistent::Error: too many connection resets (due to end of file reached - EOFError)` exception being thrown to the application level, due to the sockets being closed.

It took a lot of trial and error and quite some digging to figure out what's going on even tho we haven't changed the underlying http library (`net-http-persistent`). There are a couple of reports online that *might* to be related to this issue (sparklemotion/mechanize#123, drbrain/net-http-persistent#37) and a couple of gems such as [`elasticsearch-ruby`](https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-transport/lib/elasticsearch/transport/client.rb#L196-L208) *might* be affected by this issue depending on the configuration.

The problem is that `faraday` is creating a class of `Net::HTTPGenericRequest` for the `net-http` adapter. Yet the `net-http-persistent` gem (whose `faraday` adapter implementation is subclassing the `net-http` adapter) is [expecting a Net::HTTPRequest subclass](https://github.com/drbrain/net-http-persistent/blob/master/lib/net/http/persistent.rb#L914). Based on the class it decides [whether a request is idempotent](https://github.com/drbrain/net-http-persistent/blob/master/lib/net/http/persistent.rb#L723-L729).

If a request is idempotent then it [automatically retries the request once](https://github.com/drbrain/net-http-persistent/blob/master/lib/net/http/persistent.rb#L960-L965).

As a temporary workaround we used the `Faraday::Request::Retry` middleware as follows:

```Ruby
client.use ::Faraday::Request::Retry, :max => 1, :exceptions => [::Net::HTTP::Persistent::Error]
```

(`max` is set intentionally to `1`)

The idea for the approach in this PR is liberally taken from [mechanize]( https://github.com/sparklemotion/mechanize/blob/master/lib/mechanize/http/agent.rb#L503).

**Note:** this change is breaking the specs. In Ruby [1.8](https://github.com/ruby/ruby/blob/ruby_1_8/lib/net/http.rb#L1642), [1.9.3](https://github.com/ruby/ruby/blob/ruby_1_9_3/lib/net/http.rb#L2151), [2.1](https://github.com/ruby/ruby/blob/ruby_2_1/lib/net/http/requests.rb#L49) the `Net::Http::Options` is marked as not returning a body. This has been [fixed](https://github.com/ruby/ruby/commit/90a16cb228bd803368357cf4478430bc56b7a110) in Ruby [2.2](https://github.com/ruby/ruby/blob/ruby_2_2/lib/net/http/requests.rb#L49), even tho OPTIONS [may have a request body since RFC2616](https://tools.ietf.org/html/rfc2616#section-9.2). Previously the specs passed because the check was `:head != env[:method]`. So I'm not sure what's the appropriate approach for the specs or if this change is acceptable overall (the behaviour now depends on the Ruby version?).

~~I'll open~~ I've opened [PR #83](https://github.com/drbrain/net-http-persistent/pull/83) to `net-http-persistent` as well to use `#method` instead of checking the class hierarchy.

@mislav what do you think?