### PR TITLE
Added filter method for logger middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ conn = Faraday.new(:url => 'http://sushi.com') do |faraday|
   faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
 end
 
+# Filter sensitive information from logs with a regex matcher
+
+conn = Faraday.new(:url => 'http://sushi.com/api_key=s3cr3t') do |faraday|
+  faraday.response :logger do | logger |
+    logger.filter(/(api_key=)(\w+)/,'\1[REMOVED]')
+  end
+end
+
 ## GET ##
 
 response = conn.get '/nigiri/sake.json'     # GET http://sushi.com/nigiri/sake.json

--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -12,22 +12,28 @@ module Faraday
         require 'logger'
         ::Logger.new(STDOUT)
       end
+      @filter = []
       @options = DEFAULT_OPTIONS.merge(options)
+      yield self if block_given?
     end
 
     def_delegators :@logger, :debug, :info, :warn, :error, :fatal
 
     def call(env)
-      info "#{env.method} #{env.url.to_s}"
-      debug('request') { dump_headers env.request_headers } if log_headers?(:request)
-      debug('request') { dump_body(env[:body]) } if env[:body] && log_body?(:request)
+      info "#{env.method} #{apply_filters(env.url.to_s)}"
+      debug('request') { apply_filters( dump_headers env.request_headers ) } if log_headers?(:request)
+      debug('request') { apply_filters( dump_body(env[:body]) ) } if env[:body] && log_body?(:request)
       super
     end
 
     def on_complete(env)
       info('Status') { env.status.to_s }
-      debug('response') { dump_headers env.response_headers } if log_headers?(:response)
-      debug('response') { dump_body env[:body] } if env[:body] && log_body?(:response)
+      debug('response') { apply_filters( dump_headers env.response_headers ) } if log_headers?(:response)
+      debug('response') { apply_filters( dump_body env[:body] ) } if env[:body] && log_body?(:response)
+    end
+
+    def filter(filter_word, filter_replacement)
+      @filter.push([ filter_word, filter_replacement ])
     end
 
     private
@@ -62,5 +68,13 @@ module Faraday
       else @options[:bodies]
       end
     end
+
+    def apply_filters(output)
+      @filter.each do |pattern, replacement|
+        output = output.to_s.gsub(pattern, replacement)
+      end
+      output
+    end
+
   end
 end


### PR DESCRIPTION
Allows you to filter sensitive information with a regex, allowing a gsub with redaction:

```ruby
conn = Faraday.new(:url => 'http://sushi.com/api_key=s3cr3t') do |faraday|
  faraday.response :logger do | logger |
    logger.filter(/(api_key=)(\w+)/,'\1[REMOVED]')
  end
end
```

It's back from the dead! 😄 

For more information see previous threads #286 and #282 