### PR TITLE
Support adapter customization

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -30,9 +30,10 @@ module Faraday
     extend Parallelism
     self.supports_parallel = false
 
-    def initialize(app = nil, &block)
-      super
-      @custom_config = block
+    def initialize(app = nil, opts = {}, &block)
+      super(app)
+      @connection_options = opts
+      @config_block = block
     end
 
     def call(env)

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -32,7 +32,7 @@ module Faraday
 
     def initialize(app = nil, &block)
       super
-      @custom_config = block if block_given?
+      @custom_config = block
     end
 
     def call(env)

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -30,6 +30,11 @@ module Faraday
     extend Parallelism
     self.supports_parallel = false
 
+    def initialize(app = nil, &block)
+      super
+      @custom_config = block if block_given?
+    end
+
     def call(env)
       env.clear_body if env.needs_body?
     end

--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -138,7 +138,7 @@ module Faraday
 
       # TODO: reuse the connection to support pipelining
       def perform_single_request(env)
-        req = EventMachine::HttpRequest.new(env[:url], connection_config(env))
+        req = create_request(env)
         req.setup_request(env[:method], request_config(env)).callback { |client|
           status = client.response_header.status
           reason = client.response_header.http_reason
@@ -148,6 +148,10 @@ module Faraday
             end
           end
         }
+      end
+
+      def create_request(env)
+        EventMachine::HttpRequest.new(env[:url], connection_config(env).merge(@connection_options))
       end
 
       def error_message(client)

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -19,7 +19,7 @@ module Faraday
 
       def call(env)
         super
-        request = EventMachine::HttpRequest.new(Utils::URI(env[:url].to_s), connection_config(env))
+        request = create_request(env)
 
         http_method = env[:method].to_s.downcase.to_sym
 
@@ -86,6 +86,10 @@ module Faraday
         else
           raise
         end
+      end
+
+      def create_request(env)
+        EventMachine::HttpRequest.new(Utils::URI(env[:url].to_s), connection_config(env).merge(@connection_options))
       end
     end
   end

--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -3,11 +3,6 @@ module Faraday
     class Excon < Faraday::Adapter
       dependency 'excon'
 
-      def initialize(app, connection_options = {})
-        @connection_options = connection_options
-        super(app)
-      end
-
       def call(env)
         super
 
@@ -50,7 +45,7 @@ module Faraday
           end
         end
 
-        conn = ::Excon.new(env[:url].to_s, opts.merge(@connection_options))
+        conn = create_connection(env, opts)
 
         resp = conn.request \
           :method  => env[:method].to_s.upcase,
@@ -70,6 +65,10 @@ module Faraday
         end
       rescue ::Excon::Errors::Timeout => err
         raise Error::TimeoutError, err
+      end
+
+      def create_connection(env, opts)
+        ::Excon.new(env[:url].to_s, opts.merge(@connection_options))
       end
 
       # TODO: support streaming requests

--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -29,6 +29,8 @@ module Faraday
           configure_ssl ssl
         end
 
+        configure_client
+
         # TODO Don't stream yet.
         # https://github.com/nahi/httpclient/pull/90
         env[:body] = env[:body].read if env[:body].respond_to? :read
@@ -93,6 +95,10 @@ module Faraday
           client.connect_timeout   = req[:open_timeout]
           client.send_timeout      = req[:open_timeout]
         end
+      end
+
+      def configure_client
+        @config_block.call(client) if @config_block
       end
 
       def ssl_cert_store(ssl)

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -110,7 +110,7 @@ module Faraday
         http.read_timeout = http.open_timeout = req[:timeout] if req[:timeout]
         http.open_timeout = req[:open_timeout]                if req[:open_timeout]
 
-        @custom_config.call(http) if @custom_config
+        @config_block.call(http) if @config_block
       end
 
       def ssl_cert_store(ssl)

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -32,10 +32,7 @@ module Faraday
         super
         with_net_http_connection(env) do |http|
           configure_ssl(http, env[:ssl]) if env[:url].scheme == 'https' and env[:ssl]
-
-          req = env[:request]
-          http.read_timeout = http.open_timeout = req[:timeout] if req[:timeout]
-          http.open_timeout = req[:open_timeout]                if req[:open_timeout]
+          configure_request(http, env[:request])
 
           begin
             http_response = perform_request(http, env)
@@ -107,6 +104,13 @@ module Faraday
         http.ca_path      = ssl[:ca_path]      if ssl[:ca_path]
         http.verify_depth = ssl[:verify_depth] if ssl[:verify_depth]
         http.ssl_version  = ssl[:version]      if ssl[:version]
+      end
+
+      def configure_request(http, req)
+        http.read_timeout = http.open_timeout = req[:timeout] if req[:timeout]
+        http.open_timeout = req[:open_timeout]                if req[:open_timeout]
+
+        @custom_config.call(http) if @custom_config
       end
 
       def ssl_cert_store(ssl)

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -7,8 +7,8 @@ module Faraday
     class NetHttpPersistent < NetHttp
       dependency 'net/http/persistent'
 
-      def with_net_http_connection(env)
-        if proxy = env[:request][:proxy]
+      def net_http_connection(env)
+        if (proxy = env[:request][:proxy])
           proxy_uri = ::URI::HTTP === proxy[:uri] ? proxy[:uri].dup : ::URI.parse(proxy[:uri].to_s)
           proxy_uri.user = proxy_uri.password = nil
           # awful patch for net-http-persistent 2.8 not unescaping user/password
@@ -16,9 +16,10 @@ module Faraday
             define_method(:user) { proxy[:user] }
             define_method(:password) { proxy[:password] }
           end if proxy[:user]
+          return Net::HTTP::Persistent.new 'Faraday', proxy_uri
         end
 
-        yield Net::HTTP::Persistent.new 'Faraday', proxy_uri
+        Net::HTTP::Persistent.new 'Faraday'
       end
 
       def perform_request(http, env)

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -3,11 +3,6 @@ module Faraday
     class Patron < Faraday::Adapter
       dependency 'patron'
 
-      def initialize(app, &block)
-        super(app)
-        @block = block
-      end
-
       def call(env)
         super
 
@@ -73,7 +68,7 @@ module Faraday
       def create_session
         session = ::Patron::Session.new
         session.insecure = true
-        @block.call(session) if @block
+        @custom_config.call(session) if @custom_config
         session
       end
     end

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -68,7 +68,7 @@ module Faraday
       def create_session
         session = ::Patron::Session.new
         session.insecure = true
-        @custom_config.call(session) if @custom_config
+        @config_block.call(session) if @config_block
         session
       end
     end

--- a/test/adapters/em_http_test.rb
+++ b/test/adapters/em_http_test.rb
@@ -16,5 +16,15 @@ module Adapters
       end
     end unless jruby? and ssl_mode?
     # https://github.com/eventmachine/eventmachine/issues/180
+
+    def test_custom_adapter_config
+      url = URI('https://example.com:1234')
+
+      adapter = Faraday::Adapter::EMHttp.new nil, inactivity_timeout: 20
+
+      req = adapter.create_request(url: url, request: {})
+
+      assert_equal 20, req.connopts.inactivity_timeout
+    end
   end
 end

--- a/test/adapters/em_synchrony_test.rb
+++ b/test/adapters/em_synchrony_test.rb
@@ -18,5 +18,15 @@ module Adapters
         end
       end
     end
+
+    def test_custom_adapter_config
+      url = URI('https://example.com:1234')
+
+      adapter = Faraday::Adapter::EMSynchrony.new nil, inactivity_timeout: 20
+
+      req = adapter.create_request(url: url, request: {})
+
+      assert_equal 20, req.connopts.inactivity_timeout
+    end
   end
 end

--- a/test/adapters/excon_test.rb
+++ b/test/adapters/excon_test.rb
@@ -16,5 +16,15 @@ module Adapters
       # https://github.com/geemus/excon/issues/358
       undef :test_connection_error if RUBY_VERSION >= '2.1.0'
     end
+
+    def test_custom_adapter_config
+      url = URI('https://example.com:1234')
+
+      adapter = Faraday::Adapter::Excon.new nil, debug_request: true
+
+      conn = adapter.create_connection({url: url}, {})
+
+      assert_equal true, conn.data[:debug_request]
+    end
   end
 end

--- a/test/adapters/httpclient_test.rb
+++ b/test/adapters/httpclient_test.rb
@@ -20,12 +20,14 @@ module Adapters
       def test_custom_adapter_config
         adapter = Faraday::Adapter::HTTPClient.new do |client|
           client.keep_alive_timeout = 20
+          client.ssl_config.timeout = 25
         end
 
         client = adapter.client
         adapter.configure_client
 
         assert_equal 20, client.keep_alive_timeout
+        assert_equal 25, client.ssl_config.timeout
       end
     end
   end

--- a/test/adapters/httpclient_test.rb
+++ b/test/adapters/httpclient_test.rb
@@ -16,6 +16,17 @@ module Adapters
         conn = create_connection :request => { :bind => { :host => host } }
         assert_equal host, conn.options[:bind][:host]
       end
+
+      def test_custom_adapter_config
+        adapter = Faraday::Adapter::HTTPClient.new do |client|
+          client.keep_alive_timeout = 20
+        end
+
+        client = adapter.client
+        adapter.configure_client
+
+        assert_equal 20, client.keep_alive_timeout
+      end
     end
   end
 end

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -16,5 +16,17 @@ module Adapters
       end if ssl_mode?
     end
 
+    def test_custom_adapter_config
+      url = URI('https://example.com:1234')
+
+      adapter = Faraday::Adapter::NetHttpPersistent.new do |http|
+        http.idle_timeout = 123
+      end
+
+      http = adapter.net_http_connection(:url => url, :request => {})
+      adapter.configure_request(http, {})
+
+      assert_equal 123, http.idle_timeout
+    end
   end
 end

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -40,5 +40,17 @@ module Adapters
       assert_equal 1234, http.port
     end
 
+    def test_custom_adapter_config
+      url = URI('https://example.com:1234')
+
+      adapter = Faraday::Adapter::NetHttp.new do |http|
+        http.continue_timeout = 123
+      end
+
+      http = adapter.net_http_connection(:url => url, :request => {})
+      adapter.configure_request(http, {})
+
+      assert_equal 123, http.continue_timeout
+    end
   end
 end

--- a/test/adapters/patron_test.rb
+++ b/test/adapters/patron_test.rb
@@ -17,5 +17,18 @@ module Adapters
         undef :test_GET_ssl_fails_with_bad_cert if ssl_mode?
       end
     end
+
+    def test_custom_adapter_config
+      url = URI('https://example.com:1234')
+
+      adapter = Faraday::Adapter::NetHttpPersistent.new do |http|
+        http.idle_timeout = 123
+      end
+
+      http = adapter.net_http_connection(:url => url, :request => {})
+      adapter.configure_request(http, {})
+
+      assert_equal 123, http.idle_timeout
+    end
   end
 end

--- a/test/adapters/patron_test.rb
+++ b/test/adapters/patron_test.rb
@@ -19,16 +19,13 @@ module Adapters
     end
 
     def test_custom_adapter_config
-      url = URI('https://example.com:1234')
-
-      adapter = Faraday::Adapter::NetHttpPersistent.new do |http|
-        http.idle_timeout = 123
+      adapter = Faraday::Adapter::Patron.new do |session|
+        session.max_redirects = 10
       end
 
-      http = adapter.net_http_connection(:url => url, :request => {})
-      adapter.configure_request(http, {})
+      session = adapter.create_session
 
-      assert_equal 123, http.idle_timeout
+      assert_equal 10, session.max_redirects
     end
   end
 end


### PR DESCRIPTION
Work in progress that wants to address #648

Usage:

### NetHttp (from #545 and #502)
```ruby
conn = Faraday.new(...) do |f|
  f.adapter :net_http do |http| # yields Net::HTTP
    http.idle_timeout = 100
    http.verify_callback = lambda do | preverify_ok, cert_store |
      # do something here...
    end
  end
end
```

### NetHttpPersistent (from #645, #585 and #470)
```ruby
conn = Faraday.new(...) do |f|
  f.adapter :net_http_persistent do |http| # yields Net::HTTP::Persistent
    http.idle_timeout = 100
    http.retry_change_requests = true
  end
end
```

### Patron (from #572)
```ruby
conn = Faraday.new(...) do |f|
  f.adapter :patron do |session| # yields Patron::Session
    session.max_redirects = 10
  end
end
```

### HTTPClient (from #622)
```ruby
conn = Faraday.new(...) do |f|
  f.adapter :httpclient do |client| # yields HTTPClient
    client.keep_alive_timeout = 20
    client.ssl_config.timeout = 25
  end
end
```