### PR TITLE
Default options appear overwritten once set on a Connection instance

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -55,8 +55,7 @@ module Faraday
     #                     :user     - String (optional)
     #                     :password - String (optional)
     def initialize(url = nil, options = nil)
-
-      options = ConnectionOptions.from(options)
+      options = ConnectionOptions.from(options) unless options and options.is_a?(ConnectionOptions)
 
       if url.is_a?(Hash)
         options = options.merge(url)

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -51,7 +51,14 @@ module Faraday
     def merge(value)
       dup.update(value)
     end
+    
+    # Public
+    def dup
+      self.class.from(self)
+    end
 
+    alias clone dup
+    
     # Public
     def fetch(key, *args)
       unless symbolized_key_set.include?(key.to_sym)

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -453,6 +453,8 @@ class TestConnection < Faraday::TestCase
   def test_default_connection_options_persist_with_an_instance_overriding
     Faraday.default_connection_options.request.timeout = 10
     conn = Faraday.new 'http://nigiri.com/bar'
+    conn.options.timeout = 1
+    assert_equal 10, Faraday.default_connection_options.request.timeout
 
     other = Faraday.new :url => 'https://sushi.com/foo'
     other.options.timeout = 1

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -450,6 +450,16 @@ class TestConnection < Faraday::TestCase
     assert_equal 1, conn.options.open_timeout
   end
 
+  def test_default_connection_options_persist_with_an_instance_overriding
+    Faraday.default_connection_options.request.timeout = 10
+    conn = Faraday.new 'http://nigiri.com/bar'
+
+    other = Faraday.new :url => 'https://sushi.com/foo'
+    other.options.timeout = 1
+
+    assert_equal 10, Faraday.default_connection_options.request.timeout
+  end
+
   def env_url(url, params)
     conn = Faraday::Connection.new(url, :params => params)
     yield(conn) if block_given?


### PR DESCRIPTION
We noticed this when the timeout we set in our project (via `Faraday.default_connection_options.request.timeout = 10` in a Rails initializer), was not being used once another piece of code (in a 3rd party gem) created a Connection with a shorter timeout. Once a shorter timeout is used for a Connection, it seems to become the default for any new Connections that did not explicitly set their timeout.

This PR includes a failing unit test that illustrates the behavior. I am not familiar enough with the internals of Faraday to offer a fix yet, but I'll keep looking.

UPDATE: This bug only appears when the "offending" Connection instance is instantiated with only a Hash parameter to the constructor (i.e. `Faraday.new :url => 'https://foo.com'`).

_For example..._

````ruby
Faraday.default_connection_options.request = 10
conn_a = Faraday.new 'https://foo.com'  # default still 10 as expected

conn_b = Faraday.new 'https://bar.com'
conn_b.options.timeout = 1   # default still 10 as expected

conn_c = Faraday.new :url => 'https://baz.com' # note Hash style
conn_c.options.timeout = 1   # default is now 1!
````