### PR TITLE
Remove the presence of \n on the authorization headers

### DIFF
--- a/lib/faraday/request/authorization.rb
+++ b/lib/faraday/request/authorization.rb
@@ -16,8 +16,7 @@ module Faraday
 
     # Internal
     def self.build_hash(type, hash)
-      offset = KEY.size + type.size + 3
-      comma = ",\n#{' ' * offset}"
+      comma = ", "
       values = []
       hash.each do |key, value|
         values << "#{key}=#{value.to_s.inspect}"


### PR DESCRIPTION
We talk about this in the issue #372 with @iMacTia.

I change as little as possible in order to prevent issue with older versions of ruby. And make sure that the test are all green (at least in my local machine). 

Let me know if you would like another approach on this. Also I could not found another place where I should change this... if you have an idea or know about other place let me know and I'll change it as well.

Let me know what you think!
Have a great Thursday 


