### PR TITLE
Implement no_proxy feature

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -51,14 +51,14 @@ module Faraday
     def merge(value)
       dup.update(value)
     end
-    
+
     # Public
     def dup
       self.class.from(self)
     end
 
     alias clone dup
-    
+
     # Public
     def fetch(key, *args)
       unless symbolized_key_set.include?(key.to_sym)
@@ -242,7 +242,7 @@ module Faraday
     memoized(:password) { uri.password && Utils.unescape(uri.password) }
   end
 
-  class ConnectionOptions < Options.new(:request, :proxy, :ssl, :builder, :url,
+  class ConnectionOptions < Options.new(:request, :ssl, :proxy, :no_proxy, :builder, :url,
     :parallel_manager, :params, :headers, :builder_class)
 
     options :request => RequestOptions, :ssl => SSLOptions

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -204,6 +204,15 @@ module Adapters
         end
       end
 
+      def test_no_proxy
+        proxy_uri = URI(ENV['LIVE_PROXY'])
+        conn = create_connection(:proxy => proxy_uri, :no_proxy => 'localhost')
+
+        res = conn.get '/echo'
+
+        assert_nil res['via']
+      end
+
       def test_proxy_auth_fail
         proxy_uri = URI(ENV['LIVE_PROXY'])
         proxy_uri.password = 'WRONG'

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -383,10 +383,38 @@ class TestConnection < Faraday::TestCase
     end
   end
 
+  def test_proxy_allowed_when_prefixed_url_is_not_in_no_proxy_list
+    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do
+      conn = Faraday::Connection.new
+      assert_equal conn.proxy_allowed?('http://prefixedexample.com'), true
+    end
+  end
+
+  def test_proxy_allowed_when_subdomain_url_is_in_no_proxy_list
+    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do
+      conn = Faraday::Connection.new
+      assert_equal conn.proxy_allowed?('http://subdomain.example.com'), false
+    end
+  end
+
   def test_proxy_allowed_when_url_not_in_no_proxy_list
     with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example2.com' do
       conn = Faraday::Connection.new
       assert_equal conn.proxy_allowed?('http://example.com'), true
+    end
+  end
+
+  def test_proxy_allowed_when_ip_address_is_not_in_no_proxy_list_but_url_is
+    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'localhost' do
+      conn = Faraday::Connection.new
+      assert_equal conn.proxy_allowed?('http://127.0.0.1'), false
+    end
+  end
+
+  def test_proxy_allowed_when_url_is_not_in_no_proxy_list_but_ip_address_is
+    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => '127.0.0.1' do
+      conn = Faraday::Connection.new
+      assert_equal conn.proxy_allowed?('http://localhost'), false
     end
   end
 

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -6,16 +6,23 @@ class TestConnection < Faraday::TestCase
     Faraday.default_connection_options = nil
   end
 
-  def with_env(key, proxy)
-    old_value = ENV.fetch(key, false)
-    ENV[key] = proxy
+  def with_env(new_env)
+    old_env = {}
+
+    new_env.each do |key, value|
+      old_env[key] = ENV.fetch(key, false)
+      ENV[key] = value
+    end
+
     begin
       yield
     ensure
-      if old_value == false
-        ENV.delete key
-      else
-        ENV[key] = old_value
+      old_env.each do |key, value|
+        if value == false
+          ENV.delete key
+        else
+          ENV[key] = value
+        end
       end
     end
   end
@@ -285,7 +292,7 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_string
-    with_env 'http_proxy', "http://duncan.proxy.com:80" do
+    with_env 'http_proxy' => "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       conn.proxy 'http://proxy.com'
       assert_equal 'proxy.com', conn.proxy.host
@@ -293,7 +300,7 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_uri
-    with_env 'http_proxy', "http://duncan.proxy.com:80" do
+    with_env 'http_proxy' => "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       conn.proxy URI.parse('http://proxy.com')
       assert_equal 'proxy.com', conn.proxy.host
@@ -301,7 +308,7 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_hash_with_string_uri
-    with_env 'http_proxy', "http://duncan.proxy.com:80" do
+    with_env 'http_proxy' => "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       conn.proxy :uri => 'http://proxy.com', :user => 'rick'
       assert_equal 'proxy.com', conn.proxy.host
@@ -310,7 +317,7 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_hash
-    with_env 'http_proxy', "http://duncan.proxy.com:80" do
+    with_env 'http_proxy' => "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       conn.proxy :uri => URI.parse('http://proxy.com'), :user => 'rick'
       assert_equal 'proxy.com', conn.proxy.host
@@ -319,14 +326,14 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_http_env
-    with_env 'http_proxy', "http://duncan.proxy.com:80" do
+    with_env 'http_proxy' => "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       assert_equal 'duncan.proxy.com', conn.proxy.host
     end
   end
 
   def test_proxy_accepts_http_env_with_auth
-    with_env 'http_proxy', "http://a%40b:my%20pass@duncan.proxy.com:80" do
+    with_env 'http_proxy' => "http://a%40b:my%20pass@duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       assert_equal 'a@b',     conn.proxy.user
       assert_equal 'my pass', conn.proxy.password
@@ -334,7 +341,7 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_env_without_scheme
-    with_env 'http_proxy', "localhost:8888" do
+    with_env 'http_proxy' => "localhost:8888" do
       uri = Faraday::Connection.new.proxy[:uri]
       assert_equal 'localhost', uri.host
       assert_equal 8888, uri.port
@@ -342,21 +349,21 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_no_proxy_from_env
-    with_env 'http_proxy', nil do
+    with_env 'http_proxy' => nil do
       conn = Faraday::Connection.new
       assert_nil conn.proxy
     end
   end
 
   def test_no_proxy_from_blank_env
-    with_env 'http_proxy', '' do
+    with_env 'http_proxy' => '' do
       conn = Faraday::Connection.new
       assert_nil conn.proxy
     end
   end
 
   def test_proxy_doesnt_accept_uppercase_env
-    with_env 'HTTP_PROXY', "http://localhost:8888/" do
+    with_env 'HTTP_PROXY' => "http://localhost:8888/" do
       conn = Faraday::Connection.new
       assert_nil conn.proxy
     end
@@ -366,6 +373,51 @@ class TestConnection < Faraday::TestCase
     conn = Faraday::Connection.new
     assert_raises ArgumentError do
       conn.proxy :uri => :bad_uri, :user => 'rick'
+    end
+  end
+
+  def test_proxy_allowed_when_url_in_no_proxy_list
+    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do
+      conn = Faraday::Connection.new
+      assert_equal conn.proxy_allowed?('http://example.com'), false
+    end
+  end
+
+  def test_proxy_allowed_when_url_not_in_no_proxy_list
+    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example2.com' do
+      conn = Faraday::Connection.new
+      assert_equal conn.proxy_allowed?('http://example.com'), true
+    end
+  end
+
+  def test_proxy_allowed_in_multi_element_no_proxy_list
+    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example0.com,example.com,example1.com' do
+      conn = Faraday::Connection.new
+      assert_equal conn.proxy_allowed?('http://example0.com'), false
+      assert_equal conn.proxy_allowed?('http://example.com'), false
+      assert_equal conn.proxy_allowed?('http://example1.com'), false
+      assert_equal conn.proxy_allowed?('http://example2.com'), true
+    end
+  end
+
+  def test_proxy_allowed_when_ports_match_in_no_proxy_list
+    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com:7171' do
+      conn = Faraday::Connection.new
+      assert_equal conn.proxy_allowed?('http://example.com:7171'),  false
+    end
+  end
+
+  def test_proxy_allowed_when_port_is_not_set_in_no_proxy_list
+    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do
+      conn = Faraday::Connection.new
+      assert_equal conn.proxy_allowed?('http://example.com:7171'), false
+    end
+  end
+
+  def test_proxy_allowed_when_ports_mismatch_in_no_proxy_list
+    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com:3000' do
+      conn = Faraday::Connection.new
+      assert_equal conn.proxy_allowed?('http://example.com:7171'), true
     end
   end
 

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -72,11 +72,6 @@ class EnvTest < Faraday::TestCase
     assert_equal false, env.ssl.verify
   end
 
-  def test_request_create_stores_proxy_options
-    env = make_env
-    assert_equal 'proxy.com', env.request.proxy.host
-  end
-
   def test_custom_members_are_retained
     env = make_env
     env[:foo] = "custom 1"


### PR DESCRIPTION
A third stab at supporting the no_proxy environment variable.  Previously we had #361 and #637 which implemented no_proxy using a new Proxy middleware.  Although more modular in design, it runs into the issue where middleware is not typically enabled by default whereas this proxy middleware should be.  I implemented the feature differently by adding onto the existing proxy code instead of creating a middleware.  I reused some code and tests from the previous PRs, so they weren't entirely at a loss.  Feedback and comments welcome.

cc: @olleolleolle 