### PR TITLE
Options deep merge

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -63,7 +63,7 @@ module Faraday
     # Returns a Faraday::Connection.
     def new(url = nil, options = nil)
       block = block_given? ? Proc.new : nil
-      options = options ? default_connection_options.merge(options) : default_connection_options.dup
+      options = options ? default_connection_options.merge(options) : default_connection_options
       Faraday::Connection.new(url, options, &block)
     end
 

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -55,7 +55,7 @@ module Faraday
     #                     :user     - String (optional)
     #                     :password - String (optional)
     def initialize(url = nil, options = nil)
-      options = ConnectionOptions.from(options) unless options and options.is_a?(ConnectionOptions)
+      options = ConnectionOptions.from(options)
 
       if url.is_a?(Hash)
         options = options.merge(url)

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -67,11 +67,9 @@ module Faraday
     end
 
     # Public
-    def dup
+    def deep_dup
       self.class.from(self)
     end
-
-    alias clone dup
 
     # Public
     def fetch(key, *args)

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -18,17 +18,16 @@ module Faraday
     # Public
     def update(obj)
       obj.each do |key, value|
-        if sub_options = self.class.options_for(key)
-          value = sub_options.from(value) if value
-        elsif Hash === value
-          hash = {}
-          value.each do |hash_key, hash_value|
-            hash[hash_key] = hash_value
-          end
-          value = hash
+        sub_options = self.class.options_for(key)
+        if sub_options
+          new_value = sub_options.from(value) if value
+        elsif value.is_a?(Hash)
+          new_value = value.dup
+        else
+          new_value = value
         end
 
-        self.send("#{key}=", value) unless value.nil?
+        self.send("#{key}=", new_value) unless new_value.nil?
       end
       self
     end
@@ -51,14 +50,14 @@ module Faraday
     def merge(value)
       dup.update(value)
     end
-    
+
     # Public
     def dup
       self.class.from(self)
     end
 
     alias clone dup
-    
+
     # Public
     def fetch(key, *args)
       unless symbolized_key_set.include?(key.to_sym)

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -49,13 +49,7 @@ module Faraday
       other.each do |key, other_value|
         self_value = self.send(key)
         sub_options = self.class.options_for(key)
-        if sub_options
-          self_value = sub_options.from(self_value)
-          other_value = sub_options.from(other_value)
-          new_value = self_value.merge(other_value)
-        else
-          new_value = other_value
-        end
+        new_value = sub_options ? self_value.merge(other_value) : other_value
         self.send("#{key}=", new_value) unless new_value.nil?
       end
       self

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -32,8 +32,6 @@ module Faraday
       self
     end
 
-    alias merge! update
-
     # Public
     def delete(key)
       value = send(key)
@@ -47,8 +45,27 @@ module Faraday
     end
 
     # Public
-    def merge(value)
-      dup.update(value)
+    def merge!(other)
+      other.each do |key, other_value|
+        self_value = self.send(key)
+        sub_options = self.class.options_for(key)
+        if sub_options
+          self_value = sub_options.from(self_value)
+          other_value = sub_options.from(other_value)
+        end
+        if self_value.is_a?(Faraday::Options) && other_value.is_a?(Faraday::Options)
+          new_value = self_value.merge(other_value)
+        else
+          new_value = other_value
+        end
+        self.send("#{key}=", new_value) unless new_value.nil?
+      end
+      self
+    end
+
+    # Public
+    def merge(other)
+      dup.merge!(other)
     end
 
     # Public

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -52,8 +52,6 @@ module Faraday
         if sub_options
           self_value = sub_options.from(self_value)
           other_value = sub_options.from(other_value)
-        end
-        if self_value.is_a?(Faraday::Options) && other_value.is_a?(Faraday::Options)
           new_value = self_value.merge(other_value)
         else
           new_value = other_value

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -448,6 +448,7 @@ class TestConnection < Faraday::TestCase
     Faraday.default_connection_options = { request: { timeout: 10 } }
     conn = Faraday.new 'http://sushi.com/foo', request: { open_timeout: 1 }
     assert_equal 1, conn.options.open_timeout
+    assert_equal 10, conn.options.timeout
   end
 
   def test_default_connection_options_persist_with_an_instance_overriding

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -11,11 +11,11 @@ class OptionsTest < Faraday::TestCase
     sub_opts2 = SubOptions.from(sub_b: 4)
     opt1 = ParentOptions.from(a: 1, c: sub_opts1)
     opt2 = ParentOptions.from(b: 2, c: sub_opts2)
+
     merged = opt1.merge(opt2)
-    assert_equal merged.a, 1
-    assert_equal merged.b, 2
-    assert_equal merged.c.sub_a, 3
-    assert_equal merged.c.sub_b, 4
+
+    expected_sub_opts = SubOptions.from(sub_a: 3, sub_b: 4)
+    assert_equal merged, ParentOptions.from(a: 1, b: 2, c: expected_sub_opts)
   end
 
   def test_clear

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -1,9 +1,21 @@
 require File.expand_path('../helper', __FILE__)
 
 class OptionsTest < Faraday::TestCase
-  class SubOptions < Faraday::Options.new(:sub); end
+  SubOptions = Class.new(Faraday::Options.new(:sub_a, :sub_b))
   class ParentOptions < Faraday::Options.new(:a, :b, :c)
     options :c => SubOptions
+  end
+
+  def test_deep_merge
+    sub_opts1 = SubOptions.from(sub_a: 3)
+    sub_opts2 = SubOptions.from(sub_b: 4)
+    opt1 = ParentOptions.from(a: 1, c: sub_opts1)
+    opt2 = ParentOptions.from(b: 2, c: sub_opts2)
+    merged = opt1.merge(opt2)
+    assert_equal merged.a, 1
+    assert_equal merged.b, 2
+    assert_equal merged.c.sub_a, 3
+    assert_equal merged.c.sub_b, 4
   end
 
   def test_clear
@@ -16,9 +28,9 @@ class OptionsTest < Faraday::TestCase
   def test_empty
     options = SubOptions.new
     assert options.empty?
-    options.sub = 1
+    options.sub_a = 1
     assert !options.empty?
-    options.delete(:sub)
+    options.delete(:sub_a)
     assert options.empty?
   end
 
@@ -32,9 +44,9 @@ class OptionsTest < Faraday::TestCase
 
   def test_key?
     options = SubOptions.new
-    assert !options.key?(:sub)
-    options.sub = 1
-    assert options.key?(:sub)
+    assert !options.key?(:sub_a)
+    options.sub_a = 1
+    assert options.key?(:sub_a)
   end
 
   def test_each_value
@@ -48,7 +60,7 @@ class OptionsTest < Faraday::TestCase
   def test_value?
     options = SubOptions.new
     assert !options.value?(1)
-    options.sub = 1
+    options.sub_a = 1
     assert options.value?(1)
   end
 
@@ -108,7 +120,7 @@ class OptionsTest < Faraday::TestCase
     assert_equal 1, options.a
     assert_nil options.b
     assert_kind_of SubOptions, options.c
-    assert_equal 1, options.c.sub
+    assert_equal 1, options.c.sub_a
   end
 
   def test_from_hash
@@ -119,19 +131,19 @@ class OptionsTest < Faraday::TestCase
   end
 
   def test_from_hash_with_sub_object
-    options = ParentOptions.from :a => 1, :c => {:sub => 1}
+    options = ParentOptions.from :a => 1, :c => {:sub_a => 1}
     assert_kind_of ParentOptions, options
     assert_equal 1, options.a
     assert_nil options.b
     assert_kind_of SubOptions, options.c
-    assert_equal 1, options.c.sub
+    assert_equal 1, options.c.sub_a
   end
 
   def test_inheritance
     subclass = Class.new(ParentOptions)
-    options = subclass.from(:c => {:sub => 'hello'})
+    options = subclass.from(:c => {:sub_a => 'hello'})
     assert_kind_of SubOptions, options.c
-    assert_equal 'hello', options.c.sub
+    assert_equal 'hello', options.c.sub_a
   end
 
   def test_from_deep_hash

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -18,6 +18,30 @@ class OptionsTest < Faraday::TestCase
     assert_equal merged, ParentOptions.from(a: 1, b: 2, c: expected_sub_opts)
   end
 
+  def test_dup_is_shallow
+    sub_opts = SubOptions.from(sub_a: 3)
+    opts = ParentOptions.from(b: 1, c: sub_opts)
+
+    duped = opts.dup
+    duped.b = 2
+    duped.c.sub_a = 4
+
+    assert_equal opts.b, 1
+    assert_equal opts.c.sub_a, 4
+  end
+
+  def test_deep_dup
+    sub_opts = SubOptions.from(sub_a: 3)
+    opts = ParentOptions.from(b: 1, c: sub_opts)
+
+    duped = opts.deep_dup
+    duped.b = 2
+    duped.c.sub_a = 4
+
+    assert_equal opts.b, 1
+    assert_equal opts.c.sub_a, 3
+  end
+
   def test_clear
     options = SubOptions.new(1)
     assert !options.empty?

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -18,6 +18,18 @@ class OptionsTest < Faraday::TestCase
     assert_equal merged, ParentOptions.from(a: 1, b: 2, c: expected_sub_opts)
   end
 
+  def test_deep_merge_with_hash
+    sub_opts1 = SubOptions.from(sub_a: 3)
+    sub_opts2 = { sub_b: 4 }
+    opt1 = ParentOptions.from(a: 1, c: sub_opts1)
+    opt2 = { b: 2, c: sub_opts2 }
+
+    merged = opt1.merge(opt2)
+
+    expected_sub_opts = SubOptions.from(sub_a: 3, sub_b: 4)
+    assert_equal merged, ParentOptions.from(a: 1, b: 2, c: expected_sub_opts)
+  end
+
   def test_dup_is_shallow
     sub_opts = SubOptions.from(sub_a: 3)
     opts = ParentOptions.from(b: 1, c: sub_opts)


### PR DESCRIPTION
As noted in https://github.com/lostisland/faraday/pull/629, deep merging of Options was not working.
This PR adds deep merging of Options.
Note that this does result in a new behavior in terms of deep merging nested nil options.
Previously, the nested instance options were completely overridden, allowing it to look like you could nil out an option on merge.

```ruby
    Faraday.default_connection_options.request.timeout = 10
    conn = Faraday.new 'http://sushi.com/foo', request: { timeout: nil }
    conn.options.timeout # => nil
```
But what was actually happening was the nested option was being completely replaced:

```ruby
    Faraday.default_connection_options.request.timeout = 10
    Faraday.default_connection_options.request.open_timeout = 1
    conn = Faraday.new 'http://sushi.com/foo', request: { timeout: nil }
    conn.options.timeout # => nil
    conn.options.open_timeout # => nil
```
Due to the underlying implementation of Options, merges will not replace any value with nil. Hence, the first code example now results in this:

```ruby
    Faraday.default_connection_options.request.timeout = 10
    conn = Faraday.new 'http://sushi.com/foo', request: { timeout: nil }
    conn.options.timeout # => 10
```

Note this is actually closer to the behavior of non-nested options currently:

```ruby
Foo = Faraday::Options.new(:a, :b)
Foo.new(1, nil).merge(Foo.new(nil, 2) # => #<Foo a=1, b=2>
```