### PR TITLE
Support no_proxy via URI::Generic#find_proxy

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -448,9 +448,7 @@ module Faraday
       uri = ENV['http_proxy']
       if uri && !uri.empty?
         uri = 'http://' + uri if uri !~ /^http/i
-        return uri
-      else
-        return nil
+        uri
       end
     end
   end

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -79,15 +79,13 @@ module Faraday
       @params.update(options.params)   if options.params
       @headers.update(options.headers) if options.headers
 
-      @proxy = @no_proxy = nil
+      @proxy = nil
       proxy(options.fetch(:proxy) {
         uri = ENV['http_proxy']
         if uri && !uri.empty?
-          uri = 'http://' + uri unless uri.downcase.start_with?('http')
+          uri = 'http://' + uri if uri !~ /^http/i
           uri
         end
-      }, options.fetch(:no_proxy) {
-        ENV['no_proxy']
       })
 
       yield(self) if block_given?
@@ -283,12 +281,9 @@ module Faraday
     end
 
     # Public: Gets or Sets the Hash proxy options.
-    def proxy(proxy = nil, no_proxy = nil)
-      return @proxy if proxy.nil?
-      @no_proxy = no_proxy
-        .scan(/(?!\.)([^:,\s]+)(?::(\d+))?/)
-        .map {|host, port| [host, port, /(\A|\.)#{Regexp.quote host}\z/i]} unless no_proxy.nil?
-      @proxy = ProxyOptions.from(proxy)
+    def proxy(arg = nil)
+      return @proxy if arg.nil?
+      @proxy = ProxyOptions.from(arg)
     end
 
     def_delegators :url_prefix, :scheme, :scheme=, :host, :host=, :port, :port=
@@ -376,7 +371,6 @@ module Faraday
         req.url(url)                if url
         req.headers.update(headers) if headers
         req.body = body             if body
-        req.options.merge!(:proxy => self.proxy) if proxy_allowed?(build_exclusive_url(req.path))
         yield(req) if block_given?
       end
 
@@ -390,33 +384,8 @@ module Faraday
       Request.create(method) do |req|
         req.params  = self.params.dup
         req.headers = self.headers.dup
-        req.options = self.options
+        req.options = self.options.merge(:proxy => self.proxy)
         yield(req) if block_given?
-      end
-    end
-
-    def proxy_allowed?(url)
-      return true if @no_proxy.nil?
-      uri = Utils.URI(url)
-      @no_proxy.none? do |host, port, host_regex|
-        next false if (port && uri.port != port.to_i)
-        next true if host_regex =~ uri.host
-        if uri.hostname
-          require 'socket'
-          begin
-            addr = IPSocket.getaddress(uri.hostname)
-            next true if /\A127\.|\A::1\z/ =~ addr
-          rescue SocketError
-          end
-          next false unless addr
-          require 'ipaddr'
-          next true if
-            begin
-              IPAddr.new(host)
-            rescue
-              next false
-            end.include?(addr)
-        end
       end
     end
 

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -248,7 +248,7 @@ module Faraday
     memoized(:password) { uri.password && Utils.unescape(uri.password) }
   end
 
-  class ConnectionOptions < Options.new(:request, :ssl, :proxy, :no_proxy, :builder, :url,
+  class ConnectionOptions < Options.new(:request, :proxy, :ssl, :builder, :url,
     :parallel_manager, :params, :headers, :builder_class)
 
     options :request => RequestOptions, :ssl => SSLOptions

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -204,15 +204,6 @@ module Adapters
         end
       end
 
-      def test_no_proxy
-        proxy_uri = URI(ENV['LIVE_PROXY'])
-        conn = create_connection(:proxy => proxy_uri, :no_proxy => 'localhost')
-
-        res = conn.get '/echo'
-
-        assert_nil res['via']
-      end
-
       def test_proxy_auth_fail
         proxy_uri = URI(ENV['LIVE_PROXY'])
         proxy_uri.password = 'WRONG'

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -362,6 +362,24 @@ class TestConnection < Faraday::TestCase
     end
   end
 
+  if URI.parse("").respond_to?(:find_proxy)
+    def test_proxy_with_find_proxy
+      with_env 'http_proxy', "http://proxy.com/" do
+        conn = Faraday::Connection.new("http://sushi.com/")
+        assert_equal 'proxy.com', conn.proxy.host
+      end
+    end
+
+    def test_proxy_nil_with_no_proxy
+      with_env 'http_proxy', "http://example.com/" do
+        with_env 'no_proxy', "sushi.com" do
+          conn = Faraday::Connection.new("http://sushi.com/")
+          assert_nil conn.proxy
+        end
+      end
+    end
+  end
+
   def test_proxy_requires_uri
     conn = Faraday::Connection.new
     assert_raises ArgumentError do

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -6,23 +6,16 @@ class TestConnection < Faraday::TestCase
     Faraday.default_connection_options = nil
   end
 
-  def with_env(new_env)
-    old_env = {}
-
-    new_env.each do |key, value|
-      old_env[key] = ENV.fetch(key, false)
-      ENV[key] = value
-    end
-
+  def with_env(key, proxy)
+    old_value = ENV.fetch(key, false)
+    ENV[key] = proxy
     begin
       yield
     ensure
-      old_env.each do |key, value|
-        if value == false
-          ENV.delete key
-        else
-          ENV[key] = value
-        end
+      if old_value == false
+        ENV.delete key
+      else
+        ENV[key] = old_value
       end
     end
   end
@@ -292,7 +285,7 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_string
-    with_env 'http_proxy' => "http://duncan.proxy.com:80" do
+    with_env 'http_proxy', "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       conn.proxy 'http://proxy.com'
       assert_equal 'proxy.com', conn.proxy.host
@@ -300,7 +293,7 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_uri
-    with_env 'http_proxy' => "http://duncan.proxy.com:80" do
+    with_env 'http_proxy', "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       conn.proxy URI.parse('http://proxy.com')
       assert_equal 'proxy.com', conn.proxy.host
@@ -308,7 +301,7 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_hash_with_string_uri
-    with_env 'http_proxy' => "http://duncan.proxy.com:80" do
+    with_env 'http_proxy', "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       conn.proxy :uri => 'http://proxy.com', :user => 'rick'
       assert_equal 'proxy.com', conn.proxy.host
@@ -317,7 +310,7 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_hash
-    with_env 'http_proxy' => "http://duncan.proxy.com:80" do
+    with_env 'http_proxy', "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       conn.proxy :uri => URI.parse('http://proxy.com'), :user => 'rick'
       assert_equal 'proxy.com', conn.proxy.host
@@ -326,14 +319,14 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_http_env
-    with_env 'http_proxy' => "http://duncan.proxy.com:80" do
+    with_env 'http_proxy', "http://duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       assert_equal 'duncan.proxy.com', conn.proxy.host
     end
   end
 
   def test_proxy_accepts_http_env_with_auth
-    with_env 'http_proxy' => "http://a%40b:my%20pass@duncan.proxy.com:80" do
+    with_env 'http_proxy', "http://a%40b:my%20pass@duncan.proxy.com:80" do
       conn = Faraday::Connection.new
       assert_equal 'a@b',     conn.proxy.user
       assert_equal 'my pass', conn.proxy.password
@@ -341,7 +334,7 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_proxy_accepts_env_without_scheme
-    with_env 'http_proxy' => "localhost:8888" do
+    with_env 'http_proxy', "localhost:8888" do
       uri = Faraday::Connection.new.proxy[:uri]
       assert_equal 'localhost', uri.host
       assert_equal 8888, uri.port
@@ -349,21 +342,21 @@ class TestConnection < Faraday::TestCase
   end
 
   def test_no_proxy_from_env
-    with_env 'http_proxy' => nil do
+    with_env 'http_proxy', nil do
       conn = Faraday::Connection.new
       assert_nil conn.proxy
     end
   end
 
   def test_no_proxy_from_blank_env
-    with_env 'http_proxy' => '' do
+    with_env 'http_proxy', '' do
       conn = Faraday::Connection.new
       assert_nil conn.proxy
     end
   end
 
   def test_proxy_doesnt_accept_uppercase_env
-    with_env 'HTTP_PROXY' => "http://localhost:8888/" do
+    with_env 'HTTP_PROXY', "http://localhost:8888/" do
       conn = Faraday::Connection.new
       assert_nil conn.proxy
     end
@@ -373,79 +366,6 @@ class TestConnection < Faraday::TestCase
     conn = Faraday::Connection.new
     assert_raises ArgumentError do
       conn.proxy :uri => :bad_uri, :user => 'rick'
-    end
-  end
-
-  def test_proxy_allowed_when_url_in_no_proxy_list
-    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do
-      conn = Faraday::Connection.new
-      assert_equal conn.proxy_allowed?('http://example.com'), false
-    end
-  end
-
-  def test_proxy_allowed_when_prefixed_url_is_not_in_no_proxy_list
-    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do
-      conn = Faraday::Connection.new
-      assert_equal conn.proxy_allowed?('http://prefixedexample.com'), true
-    end
-  end
-
-  def test_proxy_allowed_when_subdomain_url_is_in_no_proxy_list
-    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do
-      conn = Faraday::Connection.new
-      assert_equal conn.proxy_allowed?('http://subdomain.example.com'), false
-    end
-  end
-
-  def test_proxy_allowed_when_url_not_in_no_proxy_list
-    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example2.com' do
-      conn = Faraday::Connection.new
-      assert_equal conn.proxy_allowed?('http://example.com'), true
-    end
-  end
-
-  def test_proxy_allowed_when_ip_address_is_not_in_no_proxy_list_but_url_is
-    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'localhost' do
-      conn = Faraday::Connection.new
-      assert_equal conn.proxy_allowed?('http://127.0.0.1'), false
-    end
-  end
-
-  def test_proxy_allowed_when_url_is_not_in_no_proxy_list_but_ip_address_is
-    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => '127.0.0.1' do
-      conn = Faraday::Connection.new
-      assert_equal conn.proxy_allowed?('http://localhost'), false
-    end
-  end
-
-  def test_proxy_allowed_in_multi_element_no_proxy_list
-    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example0.com,example.com,example1.com' do
-      conn = Faraday::Connection.new
-      assert_equal conn.proxy_allowed?('http://example0.com'), false
-      assert_equal conn.proxy_allowed?('http://example.com'), false
-      assert_equal conn.proxy_allowed?('http://example1.com'), false
-      assert_equal conn.proxy_allowed?('http://example2.com'), true
-    end
-  end
-
-  def test_proxy_allowed_when_ports_match_in_no_proxy_list
-    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com:7171' do
-      conn = Faraday::Connection.new
-      assert_equal conn.proxy_allowed?('http://example.com:7171'),  false
-    end
-  end
-
-  def test_proxy_allowed_when_port_is_not_set_in_no_proxy_list
-    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do
-      conn = Faraday::Connection.new
-      assert_equal conn.proxy_allowed?('http://example.com:7171'), false
-    end
-  end
-
-  def test_proxy_allowed_when_ports_mismatch_in_no_proxy_list
-    with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com:3000' do
-      conn = Faraday::Connection.new
-      assert_equal conn.proxy_allowed?('http://example.com:7171'), true
     end
   end
 

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -72,6 +72,11 @@ class EnvTest < Faraday::TestCase
     assert_equal false, env.ssl.verify
   end
 
+  def test_request_create_stores_proxy_options
+    env = make_env
+    assert_equal 'proxy.com', env.request.proxy.host
+  end
+
   def test_custom_members_are_retained
     env = make_env
     env[:foo] = "custom 1"


### PR DESCRIPTION
Default proxy value is set via `URI::Generic#find_proxy` if it's defined.
Maintenance cost is lower using upstream implementation than a implementation is made by myself.