### PR TITLE
Prevent logger from dumping request and response headers if they are empty 

### DIFF
--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -21,15 +21,23 @@ module Faraday
 
     def call(env)
       info "#{env.method} #{apply_filters(env.url.to_s)}"
-      debug('request') { apply_filters( dump_headers env.request_headers ) } if log_headers?(:request)
-      debug('request') { apply_filters( dump_body(env[:body]) ) } if env[:body] && log_body?(:request)
+      if env.request_headers && log_headers?(:request)
+        debug('request') { apply_filters(dump_headers(env.request_headers)) }
+      end
+      if env.body && log_body?(:request)
+        debug('request') { apply_filters(dump_body(env.body)) }
+      end
       super
     end
 
     def on_complete(env)
       info('Status') { env.status.to_s }
-      debug('response') { apply_filters( dump_headers env.response_headers ) } if log_headers?(:response)
-      debug('response') { apply_filters( dump_body env[:body] ) } if env[:body] && log_body?(:response)
+      if env.response_headers && log_headers?(:response)
+        debug('response') { apply_filters(dump_headers(env.response_headers)) }
+      end
+      if env.body && log_body?(:response)
+        debug('response') { apply_filters(dump_body(env.body)) }
+      end
     end
 
     def filter(filter_word, filter_replacement)

--- a/test/adapters/logger_test.rb
+++ b/test/adapters/logger_test.rb
@@ -22,6 +22,7 @@ module Adapters
           stubs.get('/filtered_headers') { [200, {'Content-Type' => 'text/html'}, 'headers response'] }
           stubs.get('/filtered_params') { [200, {'Content-Type' => 'text/html'}, 'params response'] }
           stubs.get('/filtered_url') { [200, {'Content-Type' => 'text/html'}, 'url response'] }
+          stubs.get('/empty_headers') { [200, nil, 'headers response'] }
         end
       end
     end
@@ -60,7 +61,7 @@ module Adapters
       refute_match %(Accept: "text/html), @io.string
     end
 
-    def test_does_log_response_headers_if_option_is_false
+    def test_does_not_log_response_headers_if_option_is_false
       app = conn(@logger, :headers => { :response => false })
       app.get '/hello', nil, :accept => 'text/html'
       refute_match %(Content-Type: "text/html), @io.string
@@ -127,5 +128,16 @@ module Adapters
       refute_match %(hunter2), @io.string
     end
 
+    def test_does_not_log_request_headers_if_headers_are_empty
+      app = conn(@logger, :headers => { :request => true })
+      app.get '/empty_headers', nil, nil
+      refute_match %(Accept: "text/html), @io.string
+    end
+
+    def test_does_not_log_response_headers_if_headers_are_empty
+      app = conn(@logger, :headers => { :response => true })
+      app.get '/empty_headers', nil, :accept => 'text/html'
+      refute_match %(Content-Type: "text/html), @io.string
+    end
   end
 end


### PR DESCRIPTION
Adds additional checks for presence of collection of headers before attempting to iterate through it.