### PR TITLE
Make multipart boundary unique

### DIFF
--- a/test/request_middleware_test.rb
+++ b/test/request_middleware_test.rb
@@ -4,8 +4,8 @@ require File.expand_path('../helper', __FILE__)
 Faraday::CompositeReadIO.class_eval { attr_reader :ios }
 
 class RequestMiddlewareTest < Faraday::TestCase
-  def setup
-    @conn = Faraday.new do |b|
+  def conn
+    Faraday.new do |b|
       b.request :multipart
       b.request :url_encoded
       b.adapter :test do |stub|
@@ -18,38 +18,38 @@ class RequestMiddlewareTest < Faraday::TestCase
   end
 
   def test_does_nothing_without_payload
-    response = @conn.post('/echo')
+    response = conn.post('/echo')
     assert_nil response.headers['Content-Type']
     assert response.body.empty?
   end
 
   def test_ignores_custom_content_type
-    response = @conn.post('/echo', { :some => 'data' }, 'content-type' => 'application/x-foo')
+    response = conn.post('/echo', { :some => 'data' }, 'content-type' => 'application/x-foo')
     assert_equal 'application/x-foo', response.headers['Content-Type']
     assert_equal({ :some => 'data' }, response.body)
   end
 
   def test_url_encoded_no_header
-    response = @conn.post('/echo', { :fruit => %w[apples oranges] })
+    response = conn.post('/echo', { :fruit => %w[apples oranges] })
     assert_equal 'application/x-www-form-urlencoded', response.headers['Content-Type']
     assert_equal 'fruit%5B%5D=apples&fruit%5B%5D=oranges', response.body
   end
 
   def test_url_encoded_with_header
-    response = @conn.post('/echo', {'a'=>123}, 'content-type' => 'application/x-www-form-urlencoded')
+    response = conn.post('/echo', {'a'=>123}, 'content-type' => 'application/x-www-form-urlencoded')
     assert_equal 'application/x-www-form-urlencoded', response.headers['Content-Type']
     assert_equal 'a=123', response.body
   end
 
   def test_url_encoded_nested
-    response = @conn.post('/echo', { :user => {:name => 'Mislav', :web => 'mislav.net'} })
+    response = conn.post('/echo', { :user => {:name => 'Mislav', :web => 'mislav.net'} })
     assert_equal 'application/x-www-form-urlencoded', response.headers['Content-Type']
     expected = { 'user' => {'name' => 'Mislav', 'web' => 'mislav.net'} }
     assert_equal expected, Faraday::Utils.parse_nested_query(response.body)
   end
 
   def test_url_encoded_non_nested
-    response = @conn.post('/echo', { :dimensions => ['date', 'location']}) do |req|
+    response = conn.post('/echo', { :dimensions => ['date', 'location']}) do |req|
       req.options.params_encoder = Faraday::FlatParamsEncoder
     end
     assert_equal 'application/x-www-form-urlencoded', response.headers['Content-Type']
@@ -60,14 +60,14 @@ class RequestMiddlewareTest < Faraday::TestCase
 
   def test_url_encoded_unicode
     err = capture_warnings {
-      response = @conn.post('/echo', {:str => "eé cç aã aâ"})
+      response = conn.post('/echo', {:str => "eé cç aã aâ"})
       assert_equal "str=e%C3%A9+c%C3%A7+a%C3%A3+a%C3%A2", response.body
     }
     assert err.empty?, "stderr did include: #{err}"
   end
 
   def test_url_encoded_nested_keys
-    response = @conn.post('/echo', {'a'=>{'b'=>{'c'=>['d']}}})
+    response = conn.post('/echo', {'a'=>{'b'=>{'c'=>['d']}}})
     assert_equal "a%5Bb%5D%5Bc%5D%5B%5D=d", response.body
   end
 
@@ -79,7 +79,7 @@ class RequestMiddlewareTest < Faraday::TestCase
       /name=\"b\[d\]\"/]
 
     payload = {:a => 1, :b => {:c => Faraday::UploadIO.new(__FILE__, 'text/x-ruby'), :d => 2}}
-    response = @conn.post('/echo', payload)
+    response = conn.post('/echo', payload)
 
     assert_kind_of Faraday::CompositeReadIO, response.body
     assert response.headers['Content-Type'].start_with?(
@@ -102,7 +102,7 @@ class RequestMiddlewareTest < Faraday::TestCase
       /name=\"b\[\]\[d\]\"/]
 
     payload = {:a => 1, :b =>[{:c => Faraday::UploadIO.new(__FILE__, 'text/x-ruby'), :d => 2}]}
-    response = @conn.post('/echo', payload)
+    response = conn.post('/echo', payload)
 
     assert_kind_of Faraday::CompositeReadIO, response.body
     assert response.headers['Content-Type'].start_with?(
@@ -119,9 +119,8 @@ class RequestMiddlewareTest < Faraday::TestCase
 
   def test_multipart_unique_boundary
     payload = {:a => 1, :b =>[{:c => Faraday::UploadIO.new(__FILE__, 'text/x-ruby'), :d => 2}]}
-    response1 = @conn.post('/echo', payload)
-    setup
-    response2 = @conn.post('/echo', payload)
+    response1 = conn.post('/echo', payload)
+    response2 = conn.post('/echo', payload)
     assert response1.headers['Content-Type'] != response2.headers['Content-Type']
   end
 end


### PR DESCRIPTION
Fixes #672.

I use `SecureRandom.hex` to generate a unique multipart mime boundary suffix.