### PR TITLE
Rounds the result of casting timeout from seconds to ms

### DIFF
--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -101,8 +101,8 @@ module Faraday
 
       def configure_timeout(req, env)
         env_req = request_options(env)
-        req.timeout = req.connect_timeout = (env_req[:timeout] * 1000) if env_req[:timeout]
-        req.connect_timeout = (env_req[:open_timeout] * 1000)          if env_req[:open_timeout]
+        req.timeout = req.connect_timeout = (env_req[:timeout] * 1000).ceil if env_req[:timeout]
+        req.connect_timeout = (env_req[:open_timeout] * 1000).ceil          if env_req[:open_timeout]
       end
 
       def configure_socket(req, env)


### PR DESCRIPTION
  * Prevents a warning in Typhoeus

Currently passing a float value to timeout in Farady (ie. 0.5) results in Typhoeus being passed 500.0 as the timeout in milliseconds. This forces Typhoeus to round the result so it can safely pass an integer to libCURL. 

This fix prevents this issue.

https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/easy_factory.rb#L107-L112

Happy to write a spec as well if you can point me in the correct direction.