### PR TITLE
Fix duplicate gem publishing via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,5 @@ deploy:
   on:
     tags: true
     repo: lostisland/faraday
+    rvm: 2.4.0
+    condition: '"$SSL" = "yes"'


### PR DESCRIPTION
Restrict gem publishing to the Ruby 2.4.0 + SSL matrix job.

Per https://github.com/rubygems/rubygems.org/issues/1551#issuecomment-290924620