### PR TITLE
Parse headers from aggregated proxy requests/responses

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -95,7 +95,13 @@ module Faraday
 
       def parse(header_string)
         return unless header_string && !header_string.empty?
-        header_string.split(/\r\n/).
+
+        headers = header_string.split(/\r\n/)
+
+        # Break headers into distinct responses, and only consider the last response.
+        last_response = headers.slice_before(/^HTTP\//).to_a.last
+
+        last_response.
           tap  { |a| a.shift if a.first.index('HTTP/') == 0 }. # drop the HTTP status line
           map  { |h| h.split(/:\s*/, 2) }.reject { |p| p[0].nil? }. # split key and value, ignore blank lines
           each { |key, value|

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -98,8 +98,9 @@ module Faraday
 
         headers = header_string.split(/\r\n/)
 
-        # Break headers into distinct responses, and only consider the last response.
-        last_response = headers.slice_before(/^HTTP\//).to_a.last
+        # Find the last set of response headers.
+        start_index = headers.rindex { |x| x.match(/^HTTP\//) }
+        last_response = headers.slice(start_index, headers.size)
 
         last_response.
           tap  { |a| a.shift if a.first.index('HTTP/') == 0 }. # drop the HTTP status line

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -1,6 +1,25 @@
 require File.expand_path('../helper', __FILE__)
 
 class TestUtils < Faraday::TestCase
+
+  # Headers parsing
+
+  def test_headers
+    "HTTP/1.x 500 OK\r\nContent-Type: text/html; charset=UTF-8\r\n" \
+    "HTTP/1.x 200 OK\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n"
+  end
+
+  def test_headers_parsing_for_aggregated_responses
+    headers = Faraday::Utils::Headers.new()
+    headers.parse(test_headers)
+
+    result = headers.to_hash
+
+    assert_equal result["Content-Type"], "application/json; charset=UTF-8"
+  end
+
+  # URI parsing
+
   def setup
     @url = "http://example.com/abc"
   end


### PR DESCRIPTION
Prior to this commit when connecting to a proxy with auth, faraday
adapters would cause faraday to fail by first trying to connect without
auth and then connection again with auth, faraday could not handle the
response headers from the aggregate response of the two requests.
This commit addresses the above issue by changing faradays parse
function for headers to handle the case where there are multiple
repsonse headers by attempting to parse the last set of response
headers.