### PR TITLE
expose wrapped_exception in all client errors

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -3,7 +3,7 @@ module Faraday
   class MissingDependency < Error; end
 
   class ClientError < Error
-    attr_reader :response
+    attr_reader :response, :wrapped_exception
 
     def initialize(ex, response = nil)
       @wrapped_exception = nil


### PR DESCRIPTION
I have come across the desire to know specifically why my error timed out or why my connection failed, and providing access to the `wrapped_exception` is useful to have more granular control over my exception handling. I would like to be able do do something like this (simplified example).

```ruby
begin
  # do some stuff
rescue Faraday::ConnectionFailed => e
  raise unless e.wrapped_exception.is_a?(Net::OpenTimeout)
  retries += 1
  retry
end
```