### PR TITLE
Handle all connection timeout messages in Patron

### DIFF
--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -37,7 +37,7 @@ module Faraday
 
         @app.call env
       rescue ::Patron::TimeoutError => err
-        if err.message == "Connection time-out"
+        if err.message == "Connection time-out" || err.message.start_with?("Connection timed out")
           raise Faraday::Error::ConnectionFailed, err
         else
           raise Faraday::Error::TimeoutError, err

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -81,8 +81,7 @@ module Faraday
 
       private
 
-      def connection_timed_out_message?(message)
-        [ "Connection time-out",
+      CURL_TIMEOUT_MESSAGES = [ "Connection time-out",
           "Connection timed out",
           "Timed out before name resolve",
           "server connect has timed out",
@@ -90,7 +89,10 @@ module Faraday
           "name lookup timed out",
           "timed out before SSL",
           "connect() timed out"
-        ].any? { |curl_message| message.include?(curl_message) }
+        ].freeze
+
+      def connection_timed_out_message?(message)
+        CURL_TIMEOUT_MESSAGES.any? { |curl_message| message.include?(curl_message) }
       end
 
     end

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -88,7 +88,8 @@ module Faraday
           "server connect has timed out",
           "Resolving timed out",
           "name lookup timed out",
-          "timed out before SSL"
+          "timed out before SSL",
+          "connect() timed out"
         ].any? { |curl_message| message.include?(curl_message) }
       end
 

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -37,7 +37,7 @@ module Faraday
 
         @app.call env
       rescue ::Patron::TimeoutError => err
-        if err.message == "Connection time-out" || err.message.start_with?("Connection timed out")
+        if connection_timed_out_message?(err.message)
           raise Faraday::Error::ConnectionFailed, err
         else
           raise Faraday::Error::TimeoutError, err
@@ -78,6 +78,20 @@ module Faraday
           session.insecure = true
         end
       end
+
+      private
+
+      def connection_timed_out_message?(message)
+        [ "Connection time-out",
+          "Connection timed out",
+          "Timed out before name resolve",
+          "server connect has timed out",
+          "Resolving timed out",
+          "name lookup timed out",
+          "timed out before SSL"
+        ].any? { |curl_message| message.include?(curl_message) }
+      end
+
     end
   end
 end

--- a/test/adapters/patron_test.rb
+++ b/test/adapters/patron_test.rb
@@ -16,7 +16,7 @@ module Adapters
         # no support for SSL peer verification
         undef :test_GET_ssl_fails_with_bad_cert if ssl_mode?
       end
-      
+
       def test_custom_adapter_config
         adapter = Faraday::Adapter::Patron.new do |session|
           session.max_redirects = 10
@@ -25,6 +25,13 @@ module Adapters
         session = adapter.create_session
 
         assert_equal 10, session.max_redirects
+      end
+
+      def test_connection_timeout
+        conn = create_connection(:request => {:timeout => 10, :open_timeout => 1})
+        assert_raises Faraday::Error::ConnectionFailed do
+          conn.get 'http://8.8.8.8:88'
+        end
       end
     end
   end


### PR DESCRIPTION
Patron is able to differentiate between a connection timeout and a normal (send or receive) timeout. The Faraday Patron adapter throws a ::Patron::TimeoutError in case of a connection timeout. 

Unfortunately the Patron adapter needs to parse the original error message thrown by the curl library. Up until now the Patron adapter expected the error message to be "Connection time-out". 

curl on the other hand throws another error message when a connection timeout happens:
https://github.com/curl/curl/blob/e60fe20fdf94e829ba5fce33f7a9d6c281149f7d/lib/multi.c#L1375

```
Connection timed out after %ld milliseconds
```

Therefore to properly catch all cases of a connection timeout we need to support both error messages.