### PR TITLE
Do not use :insecure option by default in Patron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,4 @@ deploy:
     repo: lostisland/faraday
     rvm: 2.4.0
     condition: '"$SSL" = "yes"'
-addons:
-  apt:
-    packages:
-      - ca-certificates
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,7 @@ deploy:
     repo: lostisland/faraday
     rvm: 2.4.0
     condition: '"$SSL" = "yes"'
+addons:
+  apt:
+    packages:
+      - ca-certificates

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -75,7 +75,7 @@ module Faraday
         if ssl.fetch(:verify, true)
           session.cacert = ssl[:ca_file]
         else
-          session.insecure = !!ssl.fetch(:verify, true)
+          session.insecure = true
         end
       end
     end

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -5,11 +5,11 @@ module Faraday
 
       def call(env)
         super
-
         # TODO: support streaming requests
         env[:body] = env[:body].read if env[:body].respond_to? :read
 
         session = @session ||= create_session
+        configure_ssl(session, env[:ssl]) if env[:url].scheme == 'https' and env[:ssl]
 
         if req = env[:request]
           session.timeout = session.connect_timeout = req[:timeout] if req[:timeout]
@@ -69,6 +69,14 @@ module Faraday
         session = ::Patron::Session.new
         @config_block.call(session) if @config_block
         session
+      end
+
+      def configure_ssl(session, ssl)
+        if ssl.fetch(:verify, true)
+          session.cacert = ssl[:ca_file]
+        else
+          session.insecure = !!ssl.fetch(:verify, true)
+        end
       end
     end
   end

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -67,7 +67,6 @@ module Faraday
 
       def create_session
         session = ::Patron::Session.new
-        session.insecure = true
         @config_block.call(session) if @config_block
         session
       end


### PR DESCRIPTION
The session.insecure option is set to true by default. This disables
the ssl verification of the host and, according to the Patron
documentation, one should "think twice before using this option".

See also
http://www.rubydoc.info/gems/patron/0.8.0/Patron%2FSession%3Ainsecure