### PR TITLE
Fix compatibility with Net::HTTP::Persistent v3.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'httpclient', '>= 2.2'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'minitest', '>= 5.0.5'
-  gem 'net-http-persistent', '~> 3.0.0'
+  gem 'net-http-persistent', '~> 2.9.4'
   gem 'patron', '>= 0.4.2', :platforms => :ruby
   gem 'rack-test', '>= 0.6', :require => 'rack/test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'httpclient', '>= 2.2'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'minitest', '>= 5.0.5'
-  gem 'net-http-persistent', '~> 2.9.4'
+  gem 'net-http-persistent', '~> 3.0.0'
   gem 'patron', '>= 0.4.2', :platforms => :ruby
   gem 'rack-test', '>= 0.6', :require => 'rack/test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -5,17 +5,6 @@ module Adapters
 
     def adapter() :net_http_persistent end
 
-    Integration.apply(self, :NonParallel) do
-      def setup
-        if defined?(Net::HTTP::Persistent)
-          # work around problems with mixed SSL certificates
-          # https://github.com/drbrain/net-http-persistent/issues/45
-          http = Net::HTTP::Persistent.new(name: 'Faraday')
-          http.ssl_cleanup(4)
-        end
-      end if ssl_mode?
-    end
-
     def test_custom_adapter_config
       url = URI('https://example.com:1234')
 

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -10,7 +10,7 @@ module Adapters
         if defined?(Net::HTTP::Persistent)
           # work around problems with mixed SSL certificates
           # https://github.com/drbrain/net-http-persistent/issues/45
-          http = Net::HTTP::Persistent.new('Faraday')
+          http = Net::HTTP::Persistent.new(name: 'Faraday')
           http.ssl_cleanup(4)
         end
       end if ssl_mode?


### PR DESCRIPTION
Since the version 3.0.0 of Net::HTTP::Persistent.new arguments have changed in a non compatible way. It expects named arguments. The change happened in the following commit: https://github.com/drbrain/net-http-persistent/commit/5d4b76c22dd38d29b6fbc1ed700a2a1c78c5abc4#diff-9da42550715aa09be7174a0babadcad3R512

This PR attempts to be compatible with both versions 2 and 3.
