### PR TITLE
Bcarlson/http1 1 change to include body on deletes

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -14,7 +14,7 @@ require 'forwardable'
 #   conn.get '/'
 #
 module Faraday
-  VERSION = "0.12.1"
+  VERSION = "0.13.0"
 
   class << self
     # Public: Gets or sets the root path that Faraday is being loaded from.

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -116,44 +116,6 @@ module Faraday
 
     def_delegators :builder, :build, :use, :request, :response, :adapter, :app
 
-    # Public: Makes an HTTP request without a body.
-    #
-    # url     - The optional String base URL to use as a prefix for all
-    #           requests.  Can also be the options Hash.
-    # params  - Hash of URI query unencoded key/value pairs.
-    # headers - Hash of unencoded HTTP header key/value pairs.
-    #
-    # Examples
-    #
-    #   conn.get '/items', {:page => 1}, :accept => 'application/json'
-    #   conn.head '/items/1'
-    #
-    #   # ElasticSearch example sending a body with GET.
-    #   conn.get '/twitter/tweet/_search' do |req|
-    #     req.headers[:content_type] = 'application/json'
-    #     req.params[:routing] = 'kimchy'
-    #     req.body = JSON.generate(:query => {...})
-    #   end
-    #
-    # Yields a Faraday::Request for further request customizations.
-    # Returns a Faraday::Response.
-    #
-    # Signature
-    #
-    #   <verb>(url = nil, params = nil, headers = nil)
-    #
-    # verb - An HTTP verb: get, head, or delete.
-    %w[get head delete].each do |method|
-      class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def #{method}(url = nil, params = nil, headers = nil)
-          run_request(:#{method}, url, nil, headers) { |request|
-            request.params.update(params) if params
-            yield(request) if block_given?
-          }
-        end
-      RUBY
-    end
-
     # Public: Makes an HTTP request with a body.
     #
     # url     - The optional String base URL to use as a prefix for all
@@ -180,7 +142,7 @@ module Faraday
     #   <verb>(url = nil, body = nil, headers = nil)
     #
     # verb - An HTTP verb: post, put, or patch.
-    %w[post put patch].each do |method|
+    %w[post put patch get head delete].each do |method|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{method}(url = nil, body = nil, headers = nil, &block)
           run_request(:#{method}, url, body, headers, &block)

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -85,7 +85,7 @@ module Adapters
       end
 
       def test_GET_send_url_encoded_params
-        assert_equal %(get ?{"name"=>"zack"}), get('echo', :name => 'zack').body
+        assert_equal %(get {"name"=>"zack"}), get('echo', :name => 'zack').body
       end
 
       def test_GET_retrieves_the_response_headers
@@ -176,6 +176,13 @@ module Adapters
 
       def test_DELETE_retrieves_the_body
         assert_equal %(delete), delete('echo').body
+      end
+
+      def test_DELETE_with_body
+        response = delete('echo') do |req|
+          req.body = {'bodyrock' => true}
+        end
+        assert_equal %(delete {"bodyrock"=>"true"}), response.body
       end
 
       def test_timeout

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -546,6 +546,10 @@ class TestRequestParams < Faraday::TestCase
     assert_equal expected, query.split('&').sort
   end
 
+  def assert_body_equal(expected, body)
+    assert_equal expected, body
+  end
+
   def with_default_params_encoder(encoder)
     old_encoder = Faraday::Utils.default_params_encoder
     begin
@@ -558,8 +562,19 @@ class TestRequestParams < Faraday::TestCase
 
   def test_merges_connection_and_request_params
     create_connection 'http://a.co/?token=abc', :params => {'format' => 'json'}
-    query = get '?page=1', :limit => 5
+    # query = get '?page=1', :limit => 5
+    query = get '?page=1&limit=5'
     assert_query_equal %w[format=json limit=5 page=1 token=abc], query
+  end
+
+  def test_body_and_request_params_on_connection
+    create_connection 'http://a.co/?token=abc', :params => {'format' => 'json'}
+    body = { :limit => 5 }
+    env = get_with_body('?page=1', body)
+    query = env[:url].query
+    assert_query_equal %w[format=json page=1 token=abc], query
+    assert_body_equal env[:body], body
+
   end
 
   def test_overrides_connection_params
@@ -578,8 +593,8 @@ class TestRequestParams < Faraday::TestCase
   end
 
   def test_overrides_request_params
-    create_connection
-    query = get '?p=1&a=a', :p => 2
+    create_connection 'http://a.co', :params => {:p => 1}
+    query = get '?p=2&a=a'
     assert_query_equal %w[a=a p=2], query
   end
 
@@ -601,9 +616,10 @@ class TestRequestParams < Faraday::TestCase
 
   def test_overrides_all_request_params
     create_connection :params => {:c => 'c'}
-    query = get '?p=1&a=a', :p => 2 do |req|
+    query = get '?p=1&a=a' do |req|
       assert_equal 'a', req.params[:a]
       assert_equal 'c', req.params['c']
+      req.params = {:p => 2}
       assert_equal 2, req.params['p']
       req.params = {:b => 'b'}
       assert_equal 'b', req.params['b']
@@ -650,10 +666,17 @@ class TestRequestParams < Faraday::TestCase
     end
 
     create_connection :params => {:color => 'red'}
-    query = get('', :feeling => 'blue') do |req|
+    query = get('?feeling=blue') do |req|
       req.options.params_encoder = encoder
     end
     assert_equal ["COLOR-RED", "FEELING-BLUE"], query.split(",").sort
+  end
+
+  def test_body_with_connection_no_request_params
+    hash = {:bench => 'press'}
+    create_connection 'http://a.co'
+    env = get_with_body(nil, hash)
+    assert_equal env[:body], hash
   end
 
   def get(*args)
@@ -661,5 +684,12 @@ class TestRequestParams < Faraday::TestCase
       yield(req) if block_given?
     end
     env[:url].query
+  end
+
+  def get_with_body(*args)
+    env = @conn.get(*args) do |req|
+      yield(req) if block_given?
+    end
+    env
   end
 end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -562,7 +562,6 @@ class TestRequestParams < Faraday::TestCase
 
   def test_merges_connection_and_request_params
     create_connection 'http://a.co/?token=abc', :params => {'format' => 'json'}
-    # query = get '?page=1', :limit => 5
     query = get '?page=1&limit=5'
     assert_query_equal %w[format=json limit=5 page=1 token=abc], query
   end


### PR DESCRIPTION
These changes are to support HTTP 1.1 RFC https://tools.ietf.org/html/rfc7231 where HEAD, GET, DELETE all support a request body instead of merging request params into the url. For example on the delete (https://tools.ietf.org/html/rfc7231#section-4.3.5) the follow outlines the support for bodies: 

>  A payload within a DELETE request message has no defined semantics;
   sending a payload body on a DELETE request might cause some existing
   implementations to reject the request.

The same verbiage is used for HEAD and GET.  Please let me know if there is anything else, or if i completely messed things up (totally possible).
