### PR TITLE
Missing request middleware in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ conn = Faraday.new(:url => 'http://www.example.com')
 response = conn.get '/users'                 # GET http://www.example.com/users' 
 ```
 
-Connections can also take an options hash as a parameter or be configured by using a block. Checkout the section called [Advanced middleware usage](#advanced-middleware-usage) for more details about how to use this block for configurations. 
+Connections can also take an options hash as a parameter or be configured by using a block. Checkout the section called [Advanced middleware usage](#advanced-middleware-usage) for more details about how to use this block for configurations.
+Since the default middleware stack uses url\_encoded middleware and default adapter, use them on building your own middleware stack.
 
 ```ruby
 conn = Faraday.new(:url => 'http://sushi.com') do |faraday|

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ end
 # Filter sensitive information from logs with a regex matcher
 
 conn = Faraday.new(:url => 'http://sushi.com/api_key=s3cr3t') do |faraday|
+  faraday.request  :url_encoded             # form-encode POST params
   faraday.response :logger do | logger |
     logger.filter(/(api_key=)(\w+)/,'\1[REMOVED]')
   end


### PR DESCRIPTION
Faraday's default middleware stack has url_encoded middleware but when
we use block to build middleware stack, the stack lacks the middleware
then following example codes in README will fail with NoMethodError like:

```ruby
# Gemfile
source "https://rubygems.org"
gem "faraday", "0.12.1"

# faraday_test.rb
require 'faraday'

conn = Faraday.new(:url => 'http://localhost:3000/api_key=s3cr3t') do |faraday|
  faraday.response :logger do | logger |
    logger.filter(/(api_key=)(\w+)/,'\1[REMOVED]')
  end
  faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
end

response = conn.get '/nigiri/sake.json'     # GET http://sushi.com/nigiri/sake.json
response.body

conn.get '/nigiri', { :name => 'Maguro' }   # GET http://sushi.com/nigiri?name=Maguro

conn.get do |req|                           # GET http://sushi.com/search?page=2&limit=100
  req.url '/search', :page => 2
  req.params['limit'] = 100
end

## POST ##

conn.post '/nigiri', { :name => 'Maguro' }  # POST "name=maguro" to http://sushi.com/nigiri
```

```bash
# Run rack app in other session
rackup -s webrick -b 'run(Proc.new { |env| p env; ["200", {}, ["hello"]] })' -p3000 -o127.0.0.

# Then run test script which is following README example
✔ bundle exec ruby faraday_test.rb
I, [2017-05-31T14:09:11.688312 #18653]  INFO -- : get http://localhost:3000/nigiri/sake.json
D, [2017-05-31T14:09:11.688417 #18653] DEBUG -- request: User-Agent: "Faraday v0.12.1"
I, [2017-05-31T14:09:11.693667 #18653]  INFO -- Status: 200
D, [2017-05-31T14:09:11.693750 #18653] DEBUG -- response: transfer-encoding: "chunked"
server: "WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)"
date: "Wed, 31 May 2017 05:09:11 GMT"
connection: "close"
I, [2017-05-31T14:09:11.694982 #18653]  INFO -- : get http://localhost:3000/nigiri?name=Maguro
D, [2017-05-31T14:09:11.695065 #18653] DEBUG -- request: User-Agent: "Faraday v0.12.1"
I, [2017-05-31T14:09:11.698329 #18653]  INFO -- Status: 200
D, [2017-05-31T14:09:11.698409 #18653] DEBUG -- response: transfer-encoding: "chunked"
server: "WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)"
date: "Wed, 31 May 2017 05:09:11 GMT"
connection: "close"
I, [2017-05-31T14:09:11.698644 #18653]  INFO -- : get http://localhost:3000/search?limit=100&page=2
D, [2017-05-31T14:09:11.698686 #18653] DEBUG -- request: User-Agent: "Faraday v0.12.1"
I, [2017-05-31T14:09:11.701862 #18653]  INFO -- Status: 200
D, [2017-05-31T14:09:11.701937 #18653] DEBUG -- response: transfer-encoding: "chunked"
server: "WEBrick/1.3.1 (Ruby/2.4.1/2017-03-22)"
date: "Wed, 31 May 2017 05:09:11 GMT"
connection: "close"
I, [2017-05-31T14:09:11.702162 #18653]  INFO -- : post http://localhost:3000/nigiri
D, [2017-05-31T14:09:11.702354 #18653] DEBUG -- request: User-Agent: "Faraday v0.12.1"
/Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/2.4.0/net/http/generic_request.rb:183:in `send_request_with_body': undefined method `bytesize' for {:name=>"Maguro"}:Hash (NoMethodError)
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/2.4.0/net/http/generic_request.rb:121:in `exec'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/2.4.0/net/http.rb:1444:in `block in transport_request'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/2.4.0/net/http.rb:1443:in `catch'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/2.4.0/net/http.rb:1443:in `transport_request'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/2.4.0/net/http.rb:1416:in `request'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/2.4.0/net/http.rb:1409:in `block in request'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/2.4.0/net/http.rb:877:in `start'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/2.4.0/net/http.rb:1407:in `request'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.1/lib/faraday/adapter/net_http.rb:80:in `perform_request'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.1/lib/faraday/adapter/net_http.rb:38:in `block in call'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.1/lib/faraday/adapter/net_http.rb:85:in `with_net_http_connection'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.1/lib/faraday/adapter/net_http.rb:33:in `call'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.1/lib/faraday/response.rb:8:in `call'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.1/lib/faraday/response/logger.rb:26:in `call'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.1/lib/faraday/rack_builder.rb:139:in `build_response'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.1/lib/faraday/connection.rb:386:in `run_request'
	from /Users/taiki-ono/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.1/lib/faraday/connection.rb:186:in `post'
	from faraday_test.rb:22:in `<main>'
```

This might be common pit-fall when users start using this library. I'm not sure but these documents will help them. What do you think of it?