### PR TITLE
Prefer #hostname over #host.

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -87,10 +87,10 @@ module Faraday
 
       def net_http_connection(env)
         if proxy = env[:request][:proxy]
-          Net::HTTP::Proxy(proxy[:uri].host, proxy[:uri].port, proxy[:user], proxy[:password])
+          Net::HTTP::Proxy(proxy[:uri].hostname, proxy[:uri].port, proxy[:user], proxy[:password])
         else
           Net::HTTP
-        end.new(env[:url].host, env[:url].port || (env[:url].scheme == 'https' ? 443 : 80))
+        end.new(env[:url].hostname, env[:url].port || (env[:url].scheme == 'https' ? 443 : 80))
       end
 
       def configure_ssl(http, ssl)


### PR DESCRIPTION
`#hostname` will remove brackets on IPv6 addresses.  Since [::1] is not resolvable, using `#host` is causing all IPv6 addresses to fail.

Before the change...
```
irb(main):008:0> u2 = URI.parse("https://[::1]:443/x/y/z")
=> #<URI::HTTPS https://[::1]/x/y/z>
irb(main):009:0> u2.host
=> "[::1]"
irb(main):010:0> u2.hostname
=> "::1"
irb(main):011:0> require 'faraday'
=> true
irb(main):012:0> c = Faraday.new("http://[::1]:3000") { |f| f.adapter(Faraday.default_adapter) }
=> #<Faraday::Connection:0x00000000f38248 @parallel_manager=nil, @headers={"User-Agent"=>"Faraday v0.12.0.1"}, @params={}, @options=#<Faraday::RequestOptions (empty)>, @ssl=#<Faraday::SSLOptions (empty)>, @default_parallel_manager=nil, @builder=#<Faraday::RackBuilder:0x00000000f27f10 @handlers=[Faraday::Adapter::NetHttp]>, @url_prefix=#<URI::HTTP http://[::1]:3000/>, @proxy=nil>
irb(main):013:0> c.get("/")
Faraday::ConnectionFailed: Failed to open TCP connection to [::1]:3000 (getaddrinfo: Name or service not known)
	from /home/bdunne/.rubies/ruby-2.3.3/lib/ruby/2.3.0/net/http.rb:882:in `rescue in block in connect'
	from /home/bdunne/.rubies/ruby-2.3.3/lib/ruby/2.3.0/net/http.rb:879:in `block in connect'
	from /home/bdunne/.rubies/ruby-2.3.3/lib/ruby/2.3.0/timeout.rb:91:in `block in timeout'
	from /home/bdunne/.rubies/ruby-2.3.3/lib/ruby/2.3.0/timeout.rb:101:in `timeout'
	from /home/bdunne/.rubies/ruby-2.3.3/lib/ruby/2.3.0/net/http.rb:878:in `connect'
	from /home/bdunne/.rubies/ruby-2.3.3/lib/ruby/2.3.0/net/http.rb:863:in `do_start'
	from /home/bdunne/.rubies/ruby-2.3.3/lib/ruby/2.3.0/net/http.rb:852:in `start'
	from /home/bdunne/.rubies/ruby-2.3.3/lib/ruby/2.3.0/net/http.rb:1398:in `request'
	from /home/bdunne/.rubies/ruby-2.3.3/lib/ruby/2.3.0/net/http.rb:1156:in `get'
	from /home/bdunne/.gem/ruby/2.3.3/gems/faraday-0.12.0.1/lib/faraday/adapter/net_http.rb:78:in `perform_request'
	from /home/bdunne/.gem/ruby/2.3.3/gems/faraday-0.12.0.1/lib/faraday/adapter/net_http.rb:38:in `block in call'
	from /home/bdunne/.gem/ruby/2.3.3/gems/faraday-0.12.0.1/lib/faraday/adapter/net_http.rb:85:in `with_net_http_connection'
	from /home/bdunne/.gem/ruby/2.3.3/gems/faraday-0.12.0.1/lib/faraday/adapter/net_http.rb:33:in `call'
	from /home/bdunne/.gem/ruby/2.3.3/gems/faraday-0.12.0.1/lib/faraday/rack_builder.rb:139:in `build_response'
	from /home/bdunne/.gem/ruby/2.3.3/gems/faraday-0.12.0.1/lib/faraday/connection.rb:386:in `run_request'
	from /home/bdunne/.gem/ruby/2.3.3/gems/faraday-0.12.0.1/lib/faraday/connection.rb:149:in `get'
	from (irb):13
	from /home/bdunne/.rubies/ruby-2.3.3/bin/irb:11:in `<main>'
```

Based on discussion in https://github.com/lostisland/faraday/pull/621