### PR TITLE
fix net_http_persistent adapter to be ready for >= v3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'httpclient', '>= 2.2'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'minitest', '>= 5.0.5'
-  gem 'net-http-persistent', '~> 2.9.4'
+  gem 'net-http-persistent', '~> 3.0.0'
   gem 'patron', '>= 0.4.2', :platforms => :ruby
   gem 'rack-test', '>= 0.6', :require => 'rack/test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -16,10 +16,10 @@ module Faraday
             define_method(:user) { proxy[:user] }
             define_method(:password) { proxy[:password] }
           end if proxy[:user]
-          return Net::HTTP::Persistent.new 'Faraday', proxy_uri
+          return Net::HTTP::Persistent.new(name: 'Faraday', proxy: proxy_uri)
         end
 
-        Net::HTTP::Persistent.new 'Faraday'
+        Net::HTTP::Persistent.new(name: 'Faraday')
       end
 
       def perform_request(http, env)

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -11,7 +11,7 @@ module Adapters
           # work around problems with mixed SSL certificates
           # https://github.com/drbrain/net-http-persistent/issues/45
           http = Net::HTTP::Persistent.new(name: 'Faraday')
-          http.ssl_cleanup(4)
+          http.reconnect_ssl
         end
       end if ssl_mode?
     end

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -10,7 +10,7 @@ module Adapters
         if defined?(Net::HTTP::Persistent)
           # work around problems with mixed SSL certificates
           # https://github.com/drbrain/net-http-persistent/issues/45
-          http = Net::HTTP::Persistent.new('Faraday')
+          http = Net::HTTP::Persistent.new(name: 'Faraday')
           http.ssl_cleanup(4)
         end
       end if ssl_mode?


### PR DESCRIPTION
Hi,

using `net_http_persistent` with version **3.0.0** crashes on initialisation, because the method signature of `Net::HTTP::Persistent::new` changed to named arguments. The backtrace is here:

```
ArgumentError:
       wrong number of arguments (given 1, expected 0)
net-http-persistent-3.0.0/lib/net/http/persistent.rb:505:in `initialize'
faraday-0.12.2/lib/faraday/adapter/net_http_persistent.rb:22:in `new'
faraday-0.12.2/lib/faraday/adapter/net_http_persistent.rb:22:in `net_http_connection'
faraday-0.12.2/lib/faraday/adapter/net_http.rb:85:in `with_net_http_connection'
faraday-0.12.2/lib/faraday/adapter/net_http.rb:33:in `call'
```

This commit should fix the issue for net_http_persistent >= 3.0.0.
Although, I followed the guidelines mentioned in CONTRIBUTING, I could not get the test suite to run. ~So please someone, run the tests for this adapter, to incorporate the fix.~ *(thanks Travis)

Kind regards,


Lukas Rieder