### PR TITLE
If proxy is manually provided, this takes priority over `find_proxy`

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -82,6 +82,7 @@ module Faraday
       @params.update(options.params)   if options.params
       @headers.update(options.headers) if options.headers
 
+      @manual_proxy = !!options.proxy
       @proxy = options.proxy ? ProxyOptions.from(options.proxy) : proxy_from_env(url)
       @temp_proxy = @proxy
 
@@ -281,11 +282,13 @@ module Faraday
     def proxy(arg = nil)
       return @proxy if arg.nil?
       warn 'Warning: use of proxy(new_value) to set connection proxy have been DEPRECATED and will be removed in Faraday 1.0'
+      @manual_proxy = true
       @proxy = ProxyOptions.from(arg)
     end
 
     # Public: Sets the Hash proxy options.
     def proxy=(new_value)
+      @manual_proxy = true
       @proxy = ProxyOptions.from(new_value)
     end
 
@@ -371,10 +374,7 @@ module Faraday
       end
 
       # Resets temp_proxy
-      @temp_proxy = self.proxy
-
-      # Set temporary proxy if request url is absolute
-      @temp_proxy = proxy_from_env(url) if url && Utils.URI(url).absolute?
+      @temp_proxy = proxy_for_request(url)
 
       request = build_request(method) do |req|
         req.options = req.options.merge(:proxy => @temp_proxy)
@@ -468,6 +468,15 @@ module Faraday
       if uri && !uri.empty?
         uri = 'http://' + uri if uri !~ /^http/i
         uri
+      end
+    end
+
+    def proxy_for_request(url)
+      return self.proxy if @manual_proxy
+      if url && Utils.URI(url).absolute?
+        proxy_from_env(url)
+      else
+        self.proxy
       end
     end
   end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -437,6 +437,16 @@ class TestConnection < Faraday::TestCase
         assert_nil conn.instance_variable_get('@temp_proxy')
       end
     end
+
+    def test_issue
+      with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'google.co.uk' do
+        conn = Faraday.new
+        conn.proxy = 'http://proxy2.com'
+
+        assert_equal true, conn.instance_variable_get('@manual_proxy')
+        assert_equal 'proxy2.com', conn.proxy_for_request('https://google.co.uk').host
+      end
+    end
   end
 
   def test_proxy_requires_uri


### PR DESCRIPTION
Fixes #723