### PR TITLE
Ignore nil headers in Env's Util::Headers' KeyMap for 0.9.x

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -44,6 +44,7 @@ module Faraday
       end
 
       def []=(k, v)
+        return if v.nil?
         k = KeyMap[k]
         k = (@names[k.downcase] ||= k)
         # join multiple values with a comma
@@ -74,7 +75,7 @@ module Faraday
       alias_method :key?, :include?
 
       def merge!(other)
-        other.each { |k, v| self[k] = v }
+        other.each { |k, v| self[k] = v unless v.nil? }
         self
       end
       alias_method :update, :merge!

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -33,6 +33,19 @@ class EnvTest < Faraday::TestCase
     assert_equal 'Faraday', headers['server']
   end
 
+  def test_request_create_ignores_nil_headers
+    conn = Faraday.new :url => 'http://sushi.com/api',
+      :headers => {'X-Another-Header' => nil},
+      :request => {:oauth => {:consumer_key => 'anonymous'}}
+
+    env = make_env(:get, conn) do |req|
+      req.headers['X-Some-Header'] = nil
+    end
+    headers = env.request_headers
+    assert_equal false, headers.has_key?('X-Some-Header')
+    assert_equal false, headers.has_key?('X-Another-Header')
+  end
+
   def test_request_create_stores_body
     env = make_env do |req|
       req.body = 'hi'


### PR DESCRIPTION
This prevents the net_http adapter from freaking out when encountering a header with a Nil value.

I am unsure where the best filtering logic should live. If you prefer a different class to be responsible for this, I'm happy to make changes to my approach.

Attempts to solve #727 