### PR TITLE
[0.9 branch] Gemfile: hold back net-http-persistent < 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'httpclient', '>= 2.2'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'minitest', '>= 5.0.5'
-  gem 'net-http-persistent', '>= 2.9.4'
+  gem 'net-http-persistent', '>= 2.9.4', '< 3.0.0'
   gem 'patron', '>= 0.4.2', :platforms => :ruby
   gem 'rack-test', '>= 0.6', :require => 'rack/test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]


### PR DESCRIPTION
This PR wants to improve the spec suite for the stable **0.9 branch.**

It holds back net-http-persistent to a version before 3.0, which changed an arity.

---

EventMachine-based adapters still have problems.