### PR TITLE
do not set Excon's write_timeout to our open_timeout

### DIFF
--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -30,7 +30,6 @@ module Faraday
 
           if req[:open_timeout]
             opts[:connect_timeout]   = req[:open_timeout]
-            opts[:write_timeout]     = req[:open_timeout]
           end
 
           if req[:proxy]


### PR DESCRIPTION
our timeout corresponds to all timeouts on the excon side.
our open_timeout exclusively corresponds to excon's connect_timeout (i.e.
timeout for opening a new connection).

As such we must only set the excon write_timeout from our timeout.
Previously we'd also set write_timeout from our open_timeout, overriding
the original timeout. Since open_timeout can be fairly short while
write_timeout may be fairly long (e.g. blocking upload of a large file)
the previous code made open_timeout effectively unusable as it would break
PUTing files.