### PR TITLE
Warn about adapter being unset when making a request

### DIFF
--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -138,6 +138,8 @@ module Faraday
     #
     # Returns a Faraday::Response.
     def build_response(connection, request)
+      warn 'WARNING: No adapter was configured for this request' unless adapter_set?
+
       app.call(build_env(connection, request))
     end
 


### PR DESCRIPTION
Hi,

I was really surprised that you have to specify an adapter when using an initialiser with block. I would expect additional configuration abilities when passing in a block, but not a completely different behaviour. Especially when a `default_adapter` is publicly configurable, suggesting that it gets picked up by default.

I've added this simple warning to avoid confusion, because I was not sure how you guys feel about setting the defaults when initialising `Faraday::Connection` anyways and then exposing them for a reconfiguration within a passed block. If you're happy with it I'll open another PR.

As for this one — I'm less familiar with `MiniTest`. Can you suggest a good approach of testing this change?