### PR TITLE
Feature/v1.0/ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,36 +6,13 @@ script: bundle exec script/test
 cache: bundler
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
   - 2.2
-  - 2.3.0
-  - 2.4.0
-  - jruby-19mode
-  - jruby-20mode
-  - jruby-21mode
-  - jruby-head
-  - rbx-2
-
-matrix:
-  allow_failures:
-    # "A fatal error has been detected by the Java Runtime Environment:
-    #  Internal Error (sharedRuntime.cpp:843)"
-    - rvm: jruby-19mode
-    - rvm: jruby-20mode
-    - rvm: jruby-21mode
-    - rvm: jruby-head
-    # random crashes
-    - rvm: rbx-2
-  fast_finish: true
-
+  - 2.3
+  - 2.4
 env:
   matrix:
     - SSL=no
     - SSL=yes
-  global:
-    - JRUBY_OPTS="$JRUBY_OPTS --debug"
 deploy:
   provider: rubygems
   api_key:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Faraday supports these adapters out of the box:
 * [EventMachine][]
 * [HTTPClient][]
 
-Adapters are slowly being moved into their own gems, or bundled with HTTP clients:
+Adapters are slowly being moved into their own gems, or bundled with HTTP clients.
+Here is the list of known external adapters:
 
 * [Typhoeus][]
 
@@ -337,14 +338,12 @@ stubs.verify_stubbed_calls
 This library aims to support and is [tested against][travis] the following Ruby
 implementations:
 
-* Ruby 1.9.3+
-* [JRuby][] 1.7+
-* [Rubinius][] 2+
+* Ruby 2.2+
 
 If something doesn't work on one of these Ruby versions, it's a bug.
 
 This library may inadvertently work (or seem to work) on other Ruby
-implementations, however support will only be provided for the versions listed
+implementations and versions, however support will only be provided for the versions listed
 above.
 
 If you would like this library to support another Ruby version, you may

--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/faraday'
   spec.licenses = ['MIT']
 
-  spec.required_ruby_version = '>= 1.9'
+  spec.required_ruby_version = '>= 2.2'
 
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
 


### PR DESCRIPTION
## Description
JRuby and Rubinius tests have been red for too long.
There's no one actively supporting these languages and it doesn't make sense to keep supporting them this way. Moreover, Travis builds takes a lot of time to run the additional tests (for nothing).
This PR removes all jruby and rbx from Travis except for jruby-head (should be latest JRuby 9000). I worked a bit with JRuby so I'll try to make these tests green again but if that doesn't work then I'll drop it as well.

## Todos
- [x] ~Attempt to get green tests on JRuby Head (9xxx serie)~
- [x] Update README