### PR TITLE
Run Tests against Typhoeus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :test do
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]
   gem 'simplecov'
   gem 'sinatra', '~> 1.3'
+  gem 'typhoeus', '~> 1.3', :require => 'typhoeus'
 end
 
 gemspec

--- a/test/adapters/typhoeus_test.rb
+++ b/test/adapters/typhoeus_test.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../integration', __FILE__)
+
+require 'typhoeus/adapters/faraday'
+
+Faraday::Adapter.register_middleware :typhoeus => :Typhoeus
+
+module Adapters
+  class TyphoeusTest < Faraday::TestCase
+
+    def adapter() :typhoeus end
+
+    Integration.apply(self, :Parallel) do
+      def test_binds_local_socket
+        host = '1.2.3.4'
+        conn = create_connection :request => { :bind => { :host => host } }
+        assert_equal host, conn.options[:bind][:host]
+      end
+
+      # Typhoeus::Response doesn't provide an easy way to access the reason phrase,
+      # so override the shared test from Common.
+      def test_GET_reason_phrase
+        response = get('echo')
+        assert_nil response.reason_phrase
+      end
+    end
+
+    def test_custom_adapter_config
+      adapter = Faraday::Adapter::Typhoeus.new(nil, { :forbid_reuse => true, :maxredirs => 1 })
+
+      request = adapter.method(:typhoeus_request).call({})
+
+      assert_equal true, request.options[:forbid_reuse]
+      assert_equal 1, request.options[:maxredirs]
+    end
+  end
+end


### PR DESCRIPTION
Now that the legacy typhoeus adapter is removed (https://github.com/lostisland/faraday/pull/715), we should pull the typhoeus gem in and run the test suite against their code to make sure its working properly. This should highlight any divergence between how faraday works and how typhoeus expects it to work in upcoming versions.