### PR TITLE
Allow overriding env proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,22 @@ Faraday.new(...) do |conn|
 end
 ```
 
+## Proxy
+
+Faraday will try to automatically infer the proxy settings from your system using `URI#find_proxy`.
+This will retrieve them from environment variables such as http_proxy, ftp_proxy, no_proxy, etc.
+If for any reason you want to disable this behaviour, you can do so by setting the global varibale `ignore_env_proxy`:
+
+```ruby
+Faraday.ignore_env_proxy = true
+```
+
+You can also specify a custom proxy when initializing the connection
+
+```ruby
+Faraday.new('http://www.example.com', :proxy => 'http://proxy.com')
+```
+
 ## Advanced middleware usage
 
 The order in which middleware is stacked is important. Like with Rack, the

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -34,6 +34,9 @@ module Faraday
     #     Faraday.get "https://faraday.com"
     attr_writer :default_connection
 
+    # Public: Tells faraday to ignore the environment proxy (http_proxy).
+    attr_accessor :ignore_env_proxy
+
     # Public: Initializes a new Faraday::Connection.
     #
     # url     - The optional String base URL to use as a prefix for all
@@ -101,6 +104,7 @@ module Faraday
     end
   end
 
+  self.ignore_env_proxy = false
   self.root_path = File.expand_path "..", __FILE__
   self.lib_path = File.expand_path "../faraday", __FILE__
   self.default_adapter = :net_http

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -289,7 +289,7 @@ module Faraday
     # Public: Sets the Hash proxy options.
     def proxy=(new_value)
       @manual_proxy = true
-      @proxy = ProxyOptions.from(new_value)
+      @proxy = new_value ? ProxyOptions.from(new_value) : nil
     end
 
     def_delegators :url_prefix, :scheme, :scheme=, :host, :host=, :port, :port=
@@ -445,6 +445,7 @@ module Faraday
     end
 
     def proxy_from_env(url)
+      return if Faraday.ignore_env_proxy
       uri = nil
       if URI.parse('').respond_to?(:find_proxy)
         case url

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -243,8 +243,8 @@ module Faraday
       super(value)
     end
 
-    memoized(:user) { uri.user && Utils.unescape(uri.user) }
-    memoized(:password) { uri.password && Utils.unescape(uri.password) }
+    memoized(:user) { uri && uri.user && Utils.unescape(uri.user) }
+    memoized(:password) { uri && uri.password && Utils.unescape(uri.password) }
   end
 
   class ConnectionOptions < Options.new(:request, :proxy, :ssl, :builder, :url,

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -376,6 +376,13 @@ class TestConnection < Faraday::TestCase
     end
   end
 
+  def test_nil_proxy_overrides_env
+    with_env 'http_proxy' => 'http://duncan.proxy.com:80' do
+      conn = Faraday::Connection.new(proxy: nil)
+      assert_nil conn.proxy
+    end
+  end
+
   if URI.parse('').respond_to?(:find_proxy)
     def test_proxy_allowed_when_url_in_no_proxy_list
       with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -22,6 +22,16 @@ class TestConnection < Faraday::TestCase
     end
   end
 
+  def with_env_proxy_disabled
+    Faraday.ignore_env_proxy = true
+
+    begin
+      yield
+    ensure
+      Faraday.ignore_env_proxy = false
+    end
+  end
+
   def with_env(new_env)
     old_env = {}
 
@@ -396,10 +406,12 @@ class TestConnection < Faraday::TestCase
     end
   end
 
-  def test_nil_proxy_overrides_env
-    with_env 'http_proxy' => 'http://duncan.proxy.com:80' do
-      conn = Faraday::Connection.new(proxy: nil)
-      assert_nil conn.proxy
+  def test_ignore_env_proxy
+    with_env_proxy_disabled do
+      with_env 'http_proxy' => 'http://duncan.proxy.com:80' do
+        conn = Faraday::Connection.new(proxy: nil)
+        assert_nil conn.proxy
+      end
     end
   end
 

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -159,6 +159,11 @@ class OptionsTest < Faraday::TestCase
     assert_equal 'http', options.scheme
   end
 
+  def test_proxy_options_from_nil
+    options = Faraday::ProxyOptions.from nil
+    assert_nil options
+  end
+
   def test_proxy_options_hash_access
     proxy = Faraday::ProxyOptions.from 'http://a%40b:pw%20d@example.org'
     assert_equal 'a@b', proxy[:user]

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -161,7 +161,7 @@ class OptionsTest < Faraday::TestCase
 
   def test_proxy_options_from_nil
     options = Faraday::ProxyOptions.from nil
-    assert_nil options
+    assert_kind_of Faraday::ProxyOptions, options
   end
 
   def test_proxy_options_hash_access


### PR DESCRIPTION
## Description
Allows to ignore env proxy by setting `Faraday.ignore_env_proxy` to true
Fixes #752 