### PR TITLE
Tests for ruby 2.5 & rubinius 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script: bundle exec script/test
 cache: bundler
 
 rvm:
-  - 1.9.7
+  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
-dist: precise
 sudo: false
 language: ruby
-before_install: gem install bundler
 script: bundle exec script/test
 cache: bundler
 
 rvm:
-  - 1.9.3
+  - 1.9.7
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3.0
-  - 2.4.0
+  - 2.3
+  - 2.4
+  - 2.5.0
   - jruby-19mode
   - jruby-20mode
   - jruby-21mode
   - jruby-head
   - rbx-2
+  - rbx-3
 
 matrix:
   allow_failures:
@@ -28,6 +28,7 @@ matrix:
     - rvm: jruby-head
     # random crashes
     - rvm: rbx-2
+    - rvm: rbx-3
   fast_finish: true
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ rvm:
   - jruby-20mode
   - jruby-21mode
   - jruby-head
-  - rbx-2
-  - rbx-3
 
 matrix:
   allow_failures:
@@ -26,9 +24,6 @@ matrix:
     - rvm: jruby-20mode
     - rvm: jruby-21mode
     - rvm: jruby-head
-    # random crashes
-    - rvm: rbx-2
-    - rvm: rbx-3
   fast_finish: true
 
 env:


### PR DESCRIPTION
## Description
- Adds ruby 2.5 to the "rvm" list
- Adds rubinius 3 to the "rvm" list
- Moves to the default ubuntu distro of Travis : `trusty` insteand of `precise` which is now deprecated
- Remove ruby 2.3 & 2.4 minor version to automatically follow the latest maintenance release
  