### PR TITLE
[1.0] YARD docblocks annotation - a beginning in a single file

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,4 @@
+--no-private
 --exclude test
 --exclude .github
 --exclude coverage

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,11 @@
+--exclude test
+--exclude .github
+--exclude coverage
+--exclude doc
+--exclude script
+--markup markdown
+--readme README.md
+
+lib/**/*.rb
+-
+CHANGELOG.md

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -52,17 +52,18 @@ module Faraday
     # @option options [Hash] :proxy Hash of Proxy options.
     # @return [Faraday::Connection]
     #
-    # @example
-    #
+    # @example With an URL argument
     #   Faraday.new 'http://faraday.com'
-    #   # => http://faraday.com?page=1
+    #   # => Faraday::Connection to http://faraday.com
     #   
+    # @example With an URL argument and an options hash
     #   Faraday.new 'http://faraday.com', :params => {:page => 1}
-    #   # => http://faraday.com?page=1
+    #   # => Faraday::Connection to http://faraday.com?page=1
     #
+    # @example With everything in an options hash
     #   Faraday.new :url => 'http://faraday.com',
     #               :params => {:page => 1}
-    #   # => Faraday::Connection
+    #   # => Faraday::Connection to http://faraday.com?page=1
     def new(url = nil, options = nil)
       block = block_given? ? Proc.new : nil
       options = options ? default_connection_options.merge(options) : default_connection_options

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -6,7 +6,7 @@ require 'forwardable'
 # Public: This is the main namespace for Faraday.  You can either use it to
 # create Faraday::Connection objects, or access it directly.
 #
-# Examples
+# @example
 #
 #   Faraday.get "http://faraday.com"
 #
@@ -37,33 +37,32 @@ module Faraday
     # Public: Tells faraday to ignore the environment proxy (http_proxy).
     attr_accessor :ignore_env_proxy
 
-    # Public: Initializes a new Faraday::Connection.
+    # Initializes a new {Connection}.
     #
-    # url     - The optional String base URL to use as a prefix for all
-    #           requests.  Can also be the options Hash.
-    # options - The optional Hash used to configure this Faraday::Connection.
-    #           Any of these values will be set on every request made, unless
-    #           overridden for a specific request.
-    #           :url     - String base URL.
-    #           :params  - Hash of URI query unencoded key/value pairs.
-    #           :headers - Hash of unencoded HTTP header key/value pairs.
-    #           :request - Hash of request options.
-    #           :ssl     - Hash of SSL options.
-    #           :proxy   - Hash of Proxy options.
+    # @param url [String,Hash] The optional String base URL to use as a prefix for all
+    #           requests.  Can also be the options Hash. Any of these values
+    #           will be set on every request made, unless overridden for a
+    #           specific request.
+    # @param options [Hash]
+    # @option options [String] :url Base URL
+    # @option options [Hash] :params Hash of URI query unencoded key/value pairs.
+    # @option options [Hash] :headers Hash of unencoded HTTP header key/value pairs.
+    # @option options [Hash] :request Hash of request options.
+    # @option options [Hash] :ssl Hash of SSL options.
+    # @option options [Hash] :proxy Hash of Proxy options.
+    # @return [Faraday::Connection]
     #
-    # Examples
+    # @example
     #
     #   Faraday.new 'http://faraday.com'
-    #
-    #   # http://faraday.com?page=1
+    #   # => http://faraday.com?page=1
+    #   
     #   Faraday.new 'http://faraday.com', :params => {:page => 1}
-    #
-    #   # same
+    #   # => http://faraday.com?page=1
     #
     #   Faraday.new :url => 'http://faraday.com',
-    #     :params => {:page => 1}
-    #
-    # Returns a Faraday::Connection.
+    #               :params => {:page => 1}
+    #   # => Faraday::Connection
     def new(url = nil, options = nil)
       block = block_given? ? Proc.new : nil
       options = options ? default_connection_options.merge(options) : default_connection_options


### PR DESCRIPTION
This PR adds a docblock to a single ~method~ file, to improve the API documentation in one place.

Just to see it work, and have it render at rubydoc.info later on. http://www.rubydoc.info/gems/faraday/Faraday

This early image is the rendered preview I had on my laptop:

![https://files.gitter.im/olleolleolle/56Jt/image.png](https://files.gitter.im/olleolleolle/56Jt/image.png)

The idea with this PR is to find a desired level of docblocks "documentation granularity" and exactness. What we're shooting for.