### PR TITLE
[1.0 docs] YARD docblocks for classes Env, Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Faraday supports these adapters out of the box:
 
 * [Net::HTTP][net_http] _(default)_
 * [Net::HTTP::Persistent][persistent]
-* [Excon][]
-* [Patron][]
-* [EventMachine][]
-* [HTTPClient][]
+* [Excon][excon]
+* [Patron][patron]
+* [EventMachine][eventmachine]
+* [HTTPClient][httpclient]
 
 Adapters are slowly being moved into their own gems, or bundled with HTTP clients.
 Here is the list of known external adapters:
 
-* [Typhoeus][]
+* [Typhoeus][typhoeus]
 
 It also includes a Rack adapter for hitting loaded Rack applications through
 Rack::Test, and a Test adapter for stubbing requests by hand.

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -299,8 +299,10 @@ module Faraday
   #   @return [Object] sent if the connection is in parallel mode
   #
   # @!attribute params
+  #   @return [Hash]
   #
   # @!attribute response
+  #   @return [Response]
   #
   # @!attribute response_headers
   #   @return [Hash] HTTP headers from the server
@@ -371,7 +373,6 @@ module Faraday
     end
 
     # Sets content length to zero and the body to the empty string.
-    # @return [void]
     def clear_body
       request_headers[ContentLength] = '0'
       self.body = ''
@@ -416,7 +417,7 @@ module Faraday
       end
     end
 
-    # Internal
+    # @private
     def self.member_set
       @member_set ||= Set.new(members)
     end

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -268,6 +268,48 @@ module Faraday
     end
   end
 
+  # @!attribute method
+  #   @return [Symbol] HTTP method (`:get`, `:post`)
+  #
+  # @!attribute body
+  #   @return [String] The request body that will eventually be converted to a string.
+  #
+  # @!attribute url
+  #   @return [URI] URI instance for the current request.
+  #
+  # @!attribute request
+  #   @return [Hash] options for configuring the request.
+  #   Options for configuring the request.
+  #
+  #   - `:timeout`  open/read timeout Integer in seconds
+  #   - `:open_timeout` - read timeout Integer in seconds
+  #   - `:on_data`      - Proc for streaming
+  #   - `:proxy`        - Hash of proxy options
+  #       - `:uri`        - Proxy Server URI
+  #       - `:user`       - Proxy server username
+  #       - `:password`   - Proxy server password
+  #
+  # @!attribute request_headers
+  #   @return [Hash] HTTP Headers to be sent to the server.
+  #
+  # @!attribute ssl
+  #   @return [Hash] options for configuring SSL requests
+  #
+  # @!attribute parallel_manager
+  #   @return [Object] sent if the connection is in parallel mode
+  #
+  # @!attribute params
+  #
+  # @!attribute response
+  #
+  # @!attribute response_headers
+  #   @return [Hash] HTTP headers from the server
+  #
+  # @!attribute status
+  #   @return [Integer] HTTP response status code
+  #
+  # @!attribute reason_phrase
+  #   @return [String]
   class Env < Options.new(:method, :body, :url, :request, :request_headers,
     :ssl, :parallel_manager, :params, :response, :response_headers, :status,
     :reason_phrase)
@@ -287,7 +329,10 @@ module Faraday
 
     def_delegators :request, :params_encoder
 
-    # Public
+    # Build a new Env from given value. Respects and updates `custom_members`.
+    #
+    # @param value [Object] a value fitting Option.from(v).
+    # @return [Env] from given value
     def self.from(value)
       env = super(value)
       if value.respond_to?(:custom_members)
@@ -296,7 +341,7 @@ module Faraday
       env
     end
 
-    # Public
+    # @param key [Object]
     def [](key)
       if in_member_set?(key)
         super(key)
@@ -305,7 +350,8 @@ module Faraday
       end
     end
 
-    # Public
+    # @param key [Object]
+    # @param value [Object]
     def []=(key, value)
       if in_member_set?(key)
         super(key, value)
@@ -314,28 +360,29 @@ module Faraday
       end
     end
 
-    # Public
+    # @return [Boolean] true if status is in the set of {SuccessfulStatuses}.
     def success?
       SuccessfulStatuses.include?(status)
     end
 
-    # Public
+    # @return [Boolean] true if there's no body yet, and the method is in the set of {MethodsWithBodies}.
     def needs_body?
       !body && MethodsWithBodies.include?(method)
     end
 
-    # Public
+    # Sets content length to zero and the body to the empty string.
+    # @return [void]
     def clear_body
       request_headers[ContentLength] = '0'
       self.body = ''
     end
 
-    # Public
+    # @return [Boolean] true if the status isn't in the set of {StatusesWithoutBody}.
     def parse_body?
       !StatusesWithoutBody.include?(status)
     end
 
-    # Public
+    # @return [Boolean] true if there is a parallel_manager
     def parallel?
       !!parallel_manager
     end
@@ -353,12 +400,12 @@ module Faraday
       %(#<#{self.class}#{attrs.join(" ")}>)
     end
 
-    # Internal
+    # @private
     def custom_members
       @custom_members ||= {}
     end
 
-    # Internal
+    # @private
     if members.first.is_a?(Symbol)
       def in_member_set?(key)
         self.class.member_set.include?(key.to_sym)

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -11,17 +11,17 @@ module Faraday
   #   end
   #
   # @!attribute method
-  #   @return [String] the HTTP method of the Request
+  #   @return [Symbol] the HTTP method of the Request
   # @!attribute path
   #   @return [URI, String] the path
   # @!attribute params
-  #   @return [Object] query parameters
+  #   @return [Hash] query parameters
   # @!attribute headers
-  #   @return [Object] headers
+  #   @return [Faraday::Utils::Headers] headers
   # @!attribute body
-  #   @return [Object] body
+  #   @return [Hash] body
   # @!attribute options
-  #   @return [Object] options
+  #   @return [RequestOptions] options
   class Request < Struct.new(:method, :path, :params, :headers, :body, :options)
     extend MiddlewareRegistry
 

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -1,6 +1,7 @@
 module Faraday
-  # Used to setup urls, params, headers, and the request body in a sane manner.
+  # Used to setup URLs, params, headers, and the request body in a sane manner.
   #
+  # @example
   #   @connection.post do |req|
   #     req.url 'http://localhost', 'a' => '1' # 'http://localhost?a=1'
   #     req.headers['b'] = '2' # Header
@@ -9,6 +10,18 @@ module Faraday
   #     req.body = 'abc'
   #   end
   #
+  # @!attribute method
+  #   @return [String] the HTTP method of the Request
+  # @!attribute path
+  #   @return [URI, String] the path
+  # @!attribute params
+  #   @return [Object] query parameters
+  # @!attribute headers
+  #   @return [Object] headers
+  # @!attribute body
+  #   @return [Object] body
+  # @!attribute options
+  #   @return [Object] options
   class Request < Struct.new(:method, :path, :params, :headers, :body, :options)
     extend MiddlewareRegistry
 
@@ -21,13 +34,19 @@ module Faraday
       :token_auth => [:TokenAuthentication, 'token_authentication'],
       :instrumentation => [:Instrumentation, 'instrumentation']
 
+    # @param request_method [String]
+    # @yield [request] for block customization, if block given
+    # @yieldparam request [Request]
+    # @return [Request]
     def self.create(request_method)
       new(request_method).tap do |request|
         yield(request) if block_given?
       end
     end
 
-    # Public: Replace params, preserving the existing hash type
+    # Replace params, preserving the existing hash type.
+    #
+    # @param hash [Hash] new params
     def params=(hash)
       if params
         params.replace hash
@@ -36,7 +55,9 @@ module Faraday
       end
     end
 
-    # Public: Replace request headers, preserving the existing hash type
+    # Replace request headers, preserving the existing hash type.
+    #
+    # @param hash [Hash] new headers
     def headers=(hash)
       if headers
         headers.replace hash
@@ -45,6 +66,11 @@ module Faraday
       end
     end
 
+    # Update path and params.
+    #
+    # @param path [URI, String]
+    # @param params [Hash, nil]
+    # @return [void]
     def url(path, params = nil)
       if path.respond_to? :query
         if query = path.query
@@ -61,31 +87,19 @@ module Faraday
       self.params.update(params) if params
     end
 
+    # @param key [Object] key to look up in headers
+    # @return [Object] value of the given header name
     def [](key)
       headers[key]
     end
 
+    # @param key [Object] key of header to write
+    # @param value [Object] value of header
     def []=(key, value)
       headers[key] = value
     end
 
-    # ENV Keys
-    # :method - a symbolized request method (:get, :post)
-    # :body   - the request body that will eventually be converted to a string.
-    # :url    - URI instance for the current request.
-    # :status           - HTTP response status code
-    # :request_headers  - hash of HTTP Headers to be sent to the server
-    # :response_headers - Hash of HTTP headers from the server
-    # :parallel_manager - sent if the connection is in parallel mode
-    # :request - Hash of options for configuring the request.
-    #   :timeout      - open/read timeout Integer in seconds
-    #   :open_timeout - read timeout Integer in seconds
-    #   :on_data      - Proc for streaming
-    #   :proxy        - Hash of proxy options
-    #     :uri        - Proxy Server URI
-    #     :user       - Proxy server username
-    #     :password   - Proxy server password
-    # :ssl - Hash of options for configuring SSL requests.
+    # @return [Env] the Env for this Request
     def to_env(connection)
       Env.new(method, body, connection.build_exclusive_url(path, params),
         options, headers, connection.ssl, connection.parallel_manager)


### PR DESCRIPTION
## Description

This PR

- adds initial docblocks for Request, Env.
- makes Markdown links in the README.md compatible with more Markdown processors (relevant to people using YARD which has pluggable Markdown processors)

The goal is to have clear documentation also for gnarly parts of the codebase, to be able to ask people to fill out the rest. We ought to begin where it is most to do.

## Todos

- [ ] Review my writing - is it too implementation-specific in the docstrings in Env's tiny predicate methods, for example?
- [ ] Find any holes in the usage of docstrings, especially in Env.



