### PR TITLE
Remove unused class error

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -1,6 +1,5 @@
 module Faraday
   class Error < StandardError; end
-  class MissingDependency < Error; end
 
   class ClientError < Error
     attr_reader :response, :wrapped_exception
@@ -56,7 +55,7 @@ module Faraday
   class SSLError < ClientError
   end
 
-  [:MissingDependency, :ClientError, :ConnectionFailed, :ResourceNotFound,
+  [:ClientError, :ConnectionFailed, :ResourceNotFound,
    :ParsingError, :TimeoutError, :SSLError].each do |const|
     Error.const_set(const, Faraday.const_get(const))
   end


### PR DESCRIPTION
## Description

Since the JSON Request middleware was removed on https://github.com/lostisland/faraday/commit/db554b29260ff469e40e530af498b38433ede8ab this error class is not longer needed 
