### PR TITLE
Honor Retry-After header

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -55,8 +55,12 @@ module Faraday
   class SSLError < ClientError
   end
 
+  class RetriableResponse < ClientError; end
+
   [:ClientError, :ConnectionFailed, :ResourceNotFound,
-   :ParsingError, :TimeoutError, :SSLError].each do |const|
+   :ParsingError, :TimeoutError, :SSLError, :RetriableResponse].each do |const|
     Error.const_set(const, Faraday.const_get(const))
   end
+
+
 end


### PR DESCRIPTION
## Description
Improve retry interval calculations to honor `Retry-After` header if present. This header may be set in case if a server does not respond or request being throttled. 

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [ ] Documentation

## Additional Notes
I thought to create separate middleware for this purpose but then decided to just improve existing retry logic.
