### PR TITLE
Make frozen-string-literal safe

### DIFF
--- a/lib/faraday/parameters.rb
+++ b/lib/faraday/parameters.rb
@@ -55,7 +55,7 @@ module Faraday
       end
 
       # The params have form [['key1', 'value1'], ['key2', 'value2']].
-      buffer = ''
+      buffer = String.new
       params.each do |parent, value|
         encoded_parent = escape(parent)
         buffer << "#{to_query.call(encoded_parent, value)}&"

--- a/lib/faraday/parameters.rb
+++ b/lib/faraday/parameters.rb
@@ -55,7 +55,7 @@ module Faraday
       end
 
       # The params have form [['key1', 'value1'], ['key2', 'value2']].
-      buffer = String.new
+      buffer = String.new('')
       params.each do |parent, value|
         encoded_parent = escape(parent)
         buffer << "#{to_query.call(encoded_parent, value)}&"


### PR DESCRIPTION
Hi, thanks for this great gem!

This PR makes Faraday works with RUBYOPT="--enable-frozen-string-literal". Here's a good article explaining it: https://freelancing-gods.com/2017/07/27/friendly-frozen-string-literals.html