### PR TITLE
reuse persistent connections when using net-http-persistent

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -40,6 +40,8 @@ module Faraday
       env.clear_body if env.needs_body?
     end
 
+    private
+
     def save_response(env, status, body, headers = nil, reason_phrase = nil)
       env.status = status
       env.body = body

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -56,6 +56,8 @@ module Faraday
         raise Faraday::Error::TimeoutError, err
       end
 
+      private
+
       def create_request(env)
         request = Net::HTTPGenericRequest.new \
           env[:method].to_s.upcase,    # request method

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -16,7 +16,7 @@ module Adapters
       url.port = nil
 
       adapter = Faraday::Adapter::NetHttp.new
-      http = adapter.net_http_connection(:url => url, :request => {})
+      http = adapter.send(:net_http_connection, :url => url, :request => {})
 
       assert_equal 80, http.port
     end
@@ -26,7 +26,7 @@ module Adapters
       url.port = nil
 
       adapter = Faraday::Adapter::NetHttp.new
-      http = adapter.net_http_connection(:url => url, :request => {})
+      http = adapter.send(:net_http_connection, :url => url, :request => {})
 
       assert_equal 443, http.port
     end
@@ -35,7 +35,7 @@ module Adapters
       url = URI('https://example.com:1234')
 
       adapter = Faraday::Adapter::NetHttp.new
-      http = adapter.net_http_connection(:url => url, :request => {})
+      http = adapter.send(:net_http_connection, :url => url, :request => {})
 
       assert_equal 1234, http.port
     end
@@ -47,8 +47,8 @@ module Adapters
         http.continue_timeout = 123
       end
 
-      http = adapter.net_http_connection(:url => url, :request => {})
-      adapter.configure_request(http, {})
+      http = adapter.send(:net_http_connection, :url => url, :request => {})
+      adapter.send(:configure_request, http, {})
 
       assert_equal 123, http.continue_timeout
     end


### PR DESCRIPTION
https://github.com/lostisland/faraday/issues/776

/cc @iMacTia 

```
bundle console
require 'benchmark'

before:
>> Benchmark.realtime { 20.times { Faraday.get 'https://g.co/sddfsfds' } }
=> 4.300932000041939

after:
>> Benchmark.realtime { 20.times { Faraday.get 'https://g.co/sddfsfds' } }
=> 3.4228649999713525
```

con:
 - user could change ssl settings and would still use the old connection
 - memory leak when using tons of different urls/proxy settings

pro:
 - not a bunch of changes all over the place
 - "somewhat working" instead of "completely broken"


Moneky-patch:

```Ruby
Faraday::Adapter::NetHttpPersistent.prepend(Module.new do
  def net_http_connection(env)
    (@cached_connection ||= {})[env[:url].host] ||= super
  end
end)
```