### PR TITLE
Returns the http response when giving up on retrying by status

### DIFF
--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -140,7 +140,11 @@ module Faraday
           end
         end
 
-        raise unless exception.is_a?(Faraday::Error::RetriableResponse)
+        if exception.is_a?(Faraday::Error::RetriableResponse)
+          exception.response
+        else
+          raise
+        end
       end
     end
 

--- a/test/middleware/retry_test.rb
+++ b/test/middleware/retry_test.rb
@@ -232,9 +232,10 @@ module Middleware
 
     def test_should_retry_retriable_response
       params = { status: 429 }
-      conn(:max => 1, :retry_statuses => 429).get("/throttled", params)
+      response = conn(:max => 1, :retry_statuses => 429).get("/throttled", params)
 
       assert_equal 2, @times_called
+      assert_equal 429, response.status
     end
 
     def test_should_not_retry_non_retriable_response


### PR DESCRIPTION
## Description

#773 implemented retry by status, but, when the middleware gives up on retrying, we just get nil back as the response. This PR fixes that by returning the last available response the middleware got.

https://github.com/lostisland/faraday/pull/773/files#r176779382
