### PR TITLE
Improve response logger middleware output

### DIFF
--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -20,7 +20,7 @@ module Faraday
     def_delegators :@logger, :debug, :info, :warn, :error, :fatal
 
     def call(env)
-      info('request')  { "#{env.method} #{apply_filters(env.url.to_s)}" }
+      info('request')  { "#{env.method.upcase} #{apply_filters(env.url.to_s)}" }
       debug('request') { apply_filters( dump_headers env.request_headers ) } if log_headers?(:request)
       debug('request') { apply_filters( dump_body(env[:body]) ) } if env[:body] && log_body?(:request)
       super

--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -20,7 +20,7 @@ module Faraday
     def_delegators :@logger, :debug, :info, :warn, :error, :fatal
 
     def call(env)
-      info "#{env.method} #{apply_filters(env.url.to_s)}"
+      info('request')  { "#{env.method} #{apply_filters(env.url.to_s)}" }
       debug('request') { apply_filters( dump_headers env.request_headers ) } if log_headers?(:request)
       debug('request') { apply_filters( dump_body(env[:body]) ) } if env[:body] && log_body?(:request)
       super

--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -27,7 +27,7 @@ module Faraday
     end
 
     def on_complete(env)
-      info('Status') { env.status.to_s }
+      info('response')  { "Status #{env.status.to_s}" }
       debug('response') { apply_filters( dump_headers env.response_headers ) } if log_headers?(:response)
       debug('response') { apply_filters( dump_body env[:body] ) } if env[:body] && log_body?(:response)
     end

--- a/test/adapters/logger_test.rb
+++ b/test/adapters/logger_test.rb
@@ -44,6 +44,11 @@ module Adapters
       assert_match 'request: get http:/hello', @io.string
     end
 
+    def test_logs_status_code
+      @conn.get '/hello', nil, :accept => 'text/html'
+      assert_match 'response: Status 200', @io.string
+    end
+
     def test_logs_request_headers_by_default
       @conn.get '/hello', nil, :accept => 'text/html'
       assert_match %(Accept: "text/html), @io.string

--- a/test/adapters/logger_test.rb
+++ b/test/adapters/logger_test.rb
@@ -41,7 +41,7 @@ module Adapters
 
     def test_logs_method_and_url
       @conn.get '/hello', nil, :accept => 'text/html'
-      assert_match "get http:/hello", @io.string
+      assert_match 'request: get http:/hello', @io.string
     end
 
     def test_logs_request_headers_by_default

--- a/test/adapters/logger_test.rb
+++ b/test/adapters/logger_test.rb
@@ -41,7 +41,7 @@ module Adapters
 
     def test_logs_method_and_url
       @conn.get '/hello', nil, :accept => 'text/html'
-      assert_match 'request: get http:/hello', @io.string
+      assert_match 'request: GET http:/hello', @io.string
     end
 
     def test_logs_status_code


### PR DESCRIPTION
## Description

Currently, log output looks like this with the firmware enabled:

```
get https://api.example.com
Status: 200
```

This PR changes the log output to be formatted like this instead:

```
 request: GET https://api.example.com
response: Status 200
```

Where the `request` and `response` strings are set as the progname of the `INFO` log calls accordingly, just like the debug lines currently work.

Fixes #782
