### PR TITLE
Allow setting min/max SSL version for a Net::HTTP connection on Ruby 2.5

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -106,6 +106,8 @@ module Faraday
         http.ca_path      = ssl[:ca_path]      if ssl[:ca_path]
         http.verify_depth = ssl[:verify_depth] if ssl[:verify_depth]
         http.ssl_version  = ssl[:version]      if ssl[:version]
+        http.min_version  = ssl[:min_version]  if ssl[:min_version]
+        http.max_version  = ssl[:max_version]  if ssl[:max_version]
       end
 
       def configure_request(http, req)

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -214,7 +214,8 @@ module Faraday
   end
 
   class SSLOptions < Options.new(:verify, :ca_file, :ca_path, :verify_mode,
-    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth, :version)
+    :cert_store, :client_cert, :client_key, :certificate, :private_key, :verify_depth,
+    :version, :min_version, :max_version)
 
     def verify?
       verify != false


### PR DESCRIPTION
The functionality in the OpenSSL gem was introduced in ruby/openssl#142 and supported by Net::HTTP in Ruby 2.5: https://github.com/ruby/ruby/commit/dcea9198a9d80bdf4eeacd9d9e9d883850a4a8d2

An example why this might be useful; for payment data the PCI DSS [mandates](https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls) that TLS 1.1 or newer is used after June 30. Using `ssl_version` would disallow the client negotiating TLS 1.2 (or 1.3 in the near future) if both sides support it, `min_version` doesn't have this problem.