### PR TITLE
NetHttpPersistent adapter reuse SSL connections

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -28,6 +28,11 @@ module Faraday
       NET_HTTP_EXCEPTIONS << OpenSSL::SSL::SSLError if defined?(OpenSSL)
       NET_HTTP_EXCEPTIONS << Net::OpenTimeout if defined?(Net::OpenTimeout)
 
+      def initialize(app = nil, opts = {}, &block)
+        @cert_store = nil
+        super(app, opts, &block)
+      end
+
       def call(env)
         super
         with_net_http_connection(env) do |http|
@@ -117,10 +122,11 @@ module Faraday
 
       def ssl_cert_store(ssl)
         return ssl[:cert_store] if ssl[:cert_store]
+        return @cert_store if @cert_store
         # Use the default cert store by default, i.e. system ca certs
-        cert_store = OpenSSL::X509::Store.new
-        cert_store.set_default_paths
-        cert_store
+        @cert_store = OpenSSL::X509::Store.new
+        @cert_store.set_default_paths
+        @cert_store
       end
 
       def ssl_verify_mode(ssl)

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -6,15 +6,16 @@ module Faraday
       private
 
       def net_http_connection(env)
-        proxy_uri = proxy_uri(env)
-
         cached_connection do
           if Net::HTTP::Persistent.instance_method(:initialize).parameters.first == [:key, :name]
-            Net::HTTP::Persistent.new(name: 'Faraday', proxy: proxy_uri)
+            Net::HTTP::Persistent.new(name: 'Faraday')
           else
-            Net::HTTP::Persistent.new('Faraday', proxy_uri)
+            Net::HTTP::Persistent.new('Faraday')
           end
         end
+        proxy_uri = proxy_uri(env)
+        cached_connection.proxy = proxy_uri if cached_connection.proxy_uri != proxy_uri
+        cached_connection
       end
 
       def proxy_uri(env)

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -56,7 +56,7 @@ module Faraday
       end
 
       def http_set(http, attr, value)
-        if http.sent(attr) != value
+        if http.send(attr) != value
           http.send("#{attr}=", value)
         end
       end

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -17,6 +17,28 @@ module Adapters
           end
         end
       end if ssl_mode?
+
+      def test_reuses_tcp_sockets
+        # Ensure that requests are not reused from previous tests
+        Thread.current.keys
+          .select { |key| key.to_s =~ /\Anet_http_persistent_Faraday_/ }
+          .each { |key| Thread.current[key] = nil }
+
+        sockets = []
+        tcp_socket_open_wrapped = Proc.new do |*args, &block|
+          socket = TCPSocket.__minitest_stub__open(*args, &block)
+          sockets << socket
+          socket
+        end
+
+        TCPSocket.stub :open, tcp_socket_open_wrapped do
+          conn = create_connection
+          conn.post("/echo", :foo => "bar")
+          conn.post("/echo", :foo => "baz")
+        end
+
+        assert_equal 1, sockets.count
+      end
     end
 
     def test_custom_adapter_config
@@ -30,20 +52,6 @@ module Adapters
       adapter.send(:configure_request, http, {})
 
       assert_equal 123, http.idle_timeout
-    end
-
-    def test_caches_connections
-      adapter = Faraday::Adapter::NetHttpPersistent.new
-      a = adapter.send(:net_http_connection, :url => URI('https://example.com:1234/foo'), :request => {})
-      b = adapter.send(:net_http_connection, :url => URI('https://example.com:1234/bar'), :request => {})
-      assert_equal a.object_id, b.object_id
-    end
-
-    def test_does_not_cache_connections_for_different_hosts
-      adapter = Faraday::Adapter::NetHttpPersistent.new
-      a = adapter.send(:net_http_connection, :url => URI('https://example.com:1234/foo'), :request => {})
-      b = adapter.send(:net_http_connection, :url => URI('https://example2.com:1234/bar'), :request => {})
-      refute_equal a.object_id, b.object_id
     end
   end
 end

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -39,6 +39,29 @@ module Adapters
 
         assert_equal 1, sockets.count
       end
+
+      def test_does_not_reuse_tcp_sockets_when_proxy_changes
+        # Ensure that requests are not reused from previous tests
+        Thread.current.keys
+          .select { |key| key.to_s =~ /\Anet_http_persistent_Faraday_/ }
+          .each { |key| Thread.current[key] = nil }
+
+        sockets = []
+        tcp_socket_open_wrapped = Proc.new do |*args, &block|
+          socket = TCPSocket.__minitest_stub__open(*args, &block)
+          sockets << socket
+          socket
+        end
+
+        TCPSocket.stub :open, tcp_socket_open_wrapped do
+          conn = create_connection
+          conn.post("/echo", :foo => "bar")
+          conn.proxy = URI(ENV["LIVE_PROXY"])
+          conn.post("/echo", :foo => "bar")
+        end
+
+        assert_equal 2, sockets.count
+      end
     end
 
     def test_custom_adapter_config


### PR DESCRIPTION
## Description
Fixes #791 by only setting SSL attributes on the `Net::HTTP::Persistent` instance when params are changed.

@iMacTia this is a (not working yet) first stab at fixing the issue. The problem I'm running into is in order to determine when to actually update SSL params I need to compare the current and new values. Unfortunately some of these values like `cert_store` are of non-comparable types like `OpenSSL::X509::Store`. Any ideas?

Update: fixed issues with object comparison by caching the blank cert store.
