### PR TITLE
Logger middleware: allow redefined STDOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Since the default middleware stack uses url\_encoded middleware and default adap
 ```ruby
 conn = Faraday.new(:url => 'http://sushi.com') do |faraday|
   faraday.request  :url_encoded             # form-encode POST params
-  faraday.response :logger                  # log requests to STDOUT
+  faraday.response :logger                  # log requests to $stdout
   faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
 end
 
@@ -79,7 +79,7 @@ response.body
 
 conn.get '/nigiri', { :name => 'Maguro' }   # GET http://sushi.com/nigiri?name=Maguro
 
-conn.get do |req|                           # GET http://sushi.com/search?page=2&limit=100  
+conn.get do |req|                           # GET http://sushi.com/search?page=2&limit=100
   req.url '/search', :page => 2
   req.params['limit'] = 100
 end
@@ -118,7 +118,7 @@ conn.get do |req|
   req.options.context = {
       foo: 'foo',
       bar: 'bar'
-  }          
+  }
 end
 ```
 

--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -10,7 +10,7 @@ module Faraday
       super(app)
       @logger = logger || begin
         require 'logger'
-        ::Logger.new(STDOUT)
+        ::Logger.new($stdout)
       end
       @filter = []
       @options = DEFAULT_OPTIONS.merge(options)


### PR DESCRIPTION
`STDOUT` is a constant that represents the standard output. `$stdout` is a global constant that is _usually_ set to `STDOUT`, but can be redefined if desirable.

This change continues to support logging to the standard output, but will also play nicely with users who chose to redefine `$stdout`.