### PR TITLE
Threading: do not memoize/reuse Patron session

### DIFF
--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -8,7 +8,8 @@ module Faraday
         # TODO: support streaming requests
         env[:body] = env[:body].read if env[:body].respond_to? :read
 
-        session = @session ||= create_session
+        session = ::Patron::Session.new
+        @config_block.call(session) if @config_block
         configure_ssl(session, env[:ssl]) if env[:url].scheme == 'https' and env[:ssl]
 
         if req = env[:request]
@@ -63,12 +64,6 @@ module Faraday
             actions << "OPTIONS" unless actions.include? "OPTIONS"
           end
         end
-      end
-
-      def create_session
-        session = ::Patron::Session.new
-        @config_block.call(session) if @config_block
-        session
       end
 
       def configure_ssl(session, ssl)

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -235,14 +235,14 @@ module Adapters
         []
       end
 
-      def create_connection(options = {})
+      def create_connection(options = {}, &optional_connection_config_blk)
         if adapter == :default
           builder_block = nil
         else
           builder_block = Proc.new do |b|
             b.request :multipart
             b.request :url_encoded
-            b.adapter adapter, *adapter_options
+            b.adapter adapter, *adapter_options, &optional_connection_config_blk
           end
         end
 

--- a/test/adapters/patron_test.rb
+++ b/test/adapters/patron_test.rb
@@ -18,13 +18,15 @@ module Adapters
       end
 
       def test_custom_adapter_config
-        adapter = Faraday::Adapter::Patron.new do |session|
+        conn = create_connection do |session|
+          assert_kind_of ::Patron::Session, session
           session.max_redirects = 10
+          throw :config_block_called
         end
 
-        session = adapter.create_session
-
-        assert_equal 10, session.max_redirects
+        assert_throws(:config_block_called) do
+          conn.get 'http://8.8.8.8:88'
+        end
       end
 
       def test_connection_timeout


### PR DESCRIPTION
This reverts changes from b0b1e386 and the Session object is going to be configured anew for each request.

The rationale/reason is that Patron session objects are not thread-safe by default, but are rather meant to be used thread-locally **or** pooled. Contrary to what one would believe, retaining a Patron session will not lead to the libCURL handle being reused across requests to achieve keepalive. Patron is architected in such a way that all resources associated to a specific request get initialized and allocated right when the request begins, and get freed/deallocated once the response has been read out or an abort has been raised. Therefore the only memory saving achieved from preserving a Patron session is the Ruby object for the Session itself.

This retaining however will lead to unpleasant situations with threads, since the same session might end up being reused by different threads. For example, when configuring Faraday like so:

    Faraday.default_connection = Faraday.new {|c|
      c.adapter :patron
    }

there will be effectively _one_ Session object reused across threads. Since Patron unlocks the GIL during request/response, this will lead to threads receiving response bodies for other threads and other unpleasant occurrences.

Also passes the block in create_connection in integration tests as the adapter configuration block.

## Todos
- [x] Tests
