### PR TITLE
Set max_retries to 0 if available.

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -118,6 +118,8 @@ module Faraday
       def configure_request(http, req)
         http.read_timeout = http.open_timeout = req[:timeout] if req[:timeout]
         http.open_timeout = req[:open_timeout]                if req[:open_timeout]
+        # Only set if Net::Http supports it, since Ruby 2.5.
+        http.max_retries  = 0                                 if http.respond_to?(:max_retries=)
 
         @config_block.call(http) if @config_block
       end

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -76,5 +76,17 @@ module Adapters
 
       assert_equal 123, http.idle_timeout
     end
+
+    def test_max_retries
+      url = URI('http://example.com')
+
+      adapter = Faraday::Adapter::NetHttpPersistent.new
+
+      http = adapter.send(:net_http_connection, :url => url, :request => {})
+      adapter.send(:configure_request, http, {})
+
+      # `max_retries=` is only present in Ruby 2.5
+      assert_equal 0, http.max_retries if http.respond_to?(:max_retries=)
+    end
   end
 end

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -52,5 +52,17 @@ module Adapters
 
       assert_equal 123, http.continue_timeout
     end
+
+    def test_no_retries
+      url = URI('http://example.com')
+
+      adapter = Faraday::Adapter::NetHttp.new
+
+      http = adapter.send(:net_http_connection, :url => url, :request => {})
+      adapter.send(:configure_request, http, {})
+
+      # `max_retries=` is only present in Ruby 2.5
+      assert_equal 0, http.max_retries if http.respond_to?(:max_retries=)
+    end
   end
 end


### PR DESCRIPTION
## Description
This PR sets the `max_retries` on `Net::Http` to zero where supported (Ruby 2.5+). This fixes #774. 

## Todos
- [ ] Documentation - maybe? We might need to document this is only since Ruby 2.5+.
