### PR TITLE
Make Faraday::Request serialisable with Marshal.

### DIFF
--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -69,6 +69,26 @@ module Faraday
       headers[key] = value
     end
 
+    def marshal_dump
+      {
+        :method  => method,
+        :body    => body,
+        :headers => headers,
+        :path    => path,
+        :params  => params,
+        :options => options
+      }
+    end
+
+    def marshal_load(serialised)
+      self.method  = serialised[:method]
+      self.body    = serialised[:body]
+      self.headers = serialised[:headers]
+      self.path    = serialised[:path]
+      self.params  = serialised[:params]
+      self.options = serialised[:options]
+    end
+
     # ENV Keys
     # :method - a symbolized request method (:get, :post)
     # :body   - the request body that will eventually be converted to a string.

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -233,7 +233,7 @@ class ResponseTest < Faraday::TestCase
     assert_equal :post, @response.env[:method]
   end
 
-  def test_marshal
+  def test_marshal_response
     @response = Faraday::Response.new
     @response.on_complete { }
     @response.finish @env.merge(:params => 'moo')

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -243,6 +243,20 @@ class ResponseTest < Faraday::TestCase
     assert_equal %w[body response_headers status], loaded.env.keys.map { |k| k.to_s }.sort
   end
 
+  def test_marshal_request
+    @request = Faraday::Request.create(:post) do |request|
+      request.options      = Faraday::RequestOptions.new
+      request.params       = Faraday::Utils::ParamsHash.new({ 'a' => 'c' })
+      request.headers      = { 'b' => 'd' }
+      request.body         = 'hello, world!'
+      request.url 'http://localhost/foo'
+    end
+
+    loaded = Marshal.load(Marshal.dump(@request))
+
+    assert_equal @request, loaded
+  end
+
   def test_hash
     hash = @response.to_hash
     assert_kind_of Hash, hash


### PR DESCRIPTION
## Description
This partially aids #535, or rather the over-arching need for serialisation of `Faraday::Request`. I didn't include any JSON serialisation in this on purpose, as I believe it needs more discussion.
