### PR TITLE
Add DEFAULT_EXCEPTIONS constant to Request::Retry

### DIFF
--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -20,6 +20,7 @@ module Faraday
   #
   class Request::Retry < Faraday::Middleware
 
+    DEFAULT_EXCEPTIONS = [Errno::ETIMEDOUT, 'Timeout::Error', Error::TimeoutError, Faraday::Error::RetriableResponse]
     IDEMPOTENT_METHODS = [:delete, :get, :head, :options, :put]
 
     class Options < Faraday::Options.new(:max, :interval, :max_interval, :interval_randomness,
@@ -57,9 +58,7 @@ module Faraday
       end
 
       def exceptions
-        Array(self[:exceptions] ||= [Errno::ETIMEDOUT, 'Timeout::Error',
-                                     Error::TimeoutError,
-                                     Faraday::Error::RetriableResponse])
+        Array(self[:exceptions] ||= DEFAULT_EXCEPTIONS)
       end
 
       def methods

--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -20,7 +20,7 @@ module Faraday
   #
   class Request::Retry < Faraday::Middleware
 
-    DEFAULT_EXCEPTIONS = [Errno::ETIMEDOUT, 'Timeout::Error', Error::TimeoutError, Faraday::Error::RetriableResponse]
+    DEFAULT_EXCEPTIONS = [Errno::ETIMEDOUT, 'Timeout::Error', Error::TimeoutError, Faraday::Error::RetriableResponse].freeze
     IDEMPOTENT_METHODS = [:delete, :get, :head, :options, :put]
 
     class Options < Faraday::Options.new(:max, :interval, :max_interval, :interval_randomness,


### PR DESCRIPTION
## Description
Adds a `DEFAULT_EXCEPTIONS` constant to `Request::Retry`, which allows easy access much like the `IDEMPOTENT_METHODS` constant

## Todos
None

## Additional Notes
Initial request in [Issue 813](https://github.com/lostisland/faraday/issues/813)
