### PR TITLE
ISSUE_TEMPLATE: Fix a typo

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,7 +12,7 @@ If possible, please provide the steps to reproduce the issue.
 
 ## CHECKLIST (delete before creating the issue)
 * If you're not reporting a bug/issue, you can ignore this whole template.
-* Are you using the latest Farday version? If not, please check the [Releases](https://github.com/lostisland/faraday/releases) page to see if the issue has already been fixed.
+* Are you using the latest Faraday version? If not, please check the [Releases](https://github.com/lostisland/faraday/releases) page to see if the issue has already been fixed.
 * Provide the Faraday and Ruby Version you're using while experiencing the issue.
 * Fill the `Issue description` and `Steps to Reproduce` sections.
 * Delete this checklist before posting the issue.


### PR DESCRIPTION
This PR corrects a typo in the issue template.

The name of this project was misspelled.