### PR TITLE
Add support for Ruby 2.6 Net::HTTP write_timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5.0
+  - ruby-head
   - jruby-19mode
   - jruby-20mode
   - jruby-21mode
@@ -24,6 +25,7 @@ matrix:
     - rvm: jruby-20mode
     - rvm: jruby-21mode
     - rvm: jruby-head
+    - rvm: ruby-head
   fast_finish: true
 
 env:

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -116,10 +116,15 @@ module Faraday
       end
 
       def configure_request(http, req)
-        http.read_timeout = http.open_timeout = req[:timeout] if req[:timeout]
-        http.open_timeout = req[:open_timeout]                if req[:open_timeout]
-        # Only set if Net::Http supports it, since Ruby 2.5.
-        http.max_retries  = 0                                 if http.respond_to?(:max_retries=)
+        if req[:timeout]
+          http.read_timeout  = req[:timeout]
+          http.open_timeout  = req[:timeout]
+          http.write_timeout = req[:timeout] if http.respond_to?(:write_timeout=)
+        end
+        http.open_timeout  = req[:open_timeout]  if req[:open_timeout]
+        http.write_timeout = req[:write_timeout] if req[:write_timeout] && http.respond_to?(:write_timeout=)
+          # Only set if Net::Http supports it, since Ruby 2.5.
+        http.max_retries  = 0                    if http.respond_to?(:max_retries=)
 
         @config_block.call(http) if @config_block
       end

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -202,7 +202,7 @@ module Faraday
   end
 
   class RequestOptions < Options.new(:params_encoder, :proxy, :bind,
-    :timeout, :open_timeout, :boundary, :oauth, :context)
+    :timeout, :open_timeout, :write_timeout, :boundary, :oauth, :context)
 
     def []=(key, value)
       if key && key.to_sym == :proxy

--- a/test/adapters/net_http_test.rb
+++ b/test/adapters/net_http_test.rb
@@ -64,5 +64,16 @@ module Adapters
       # `max_retries=` is only present in Ruby 2.5
       assert_equal 0, http.max_retries if http.respond_to?(:max_retries=)
     end
+
+    def test_write_timeout
+      url = URI('http://example.com')
+
+      adapter = Faraday::Adapter::NetHttp.new
+
+      http = adapter.send(:net_http_connection, :url => url, :request => {})
+      adapter.send(:configure_request, http, { write_timeout: 10 })
+
+      assert_equal 10, http.write_timeout if http.respond_to?(:write_timeout=)
+    end
   end
 end


### PR DESCRIPTION
## Description
This was added in https://bugs.ruby-lang.org/issues/13396

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [x] Documentation
