### PR TITLE
[1.0] Travis CI matrix: Drop 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ script: bundle exec script/test
 cache: bundler
 
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ stubs.verify_stubbed_calls
 This library aims to support and is [tested against][travis] the following Ruby
 implementations:
 
-* Ruby 2.2+
+* Ruby 2.3+
 
 If something doesn't work on one of these Ruby versions, it's a bug.
 


### PR DESCRIPTION
## Description

This PR removes Ruby 2.2 from CI matrix. It's unsupported.

The README section on Required Ruby is also updated in this PR.

Fixes #827 

## TODO

- [x] Change the README.md too
