### PR TITLE
[1.0] UPGRADING.md: Mention Ruby 2.3+

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,7 +1,7 @@
 ## Faraday 1.0
 
 * Dropped support for jruby and Rubinius.
-* Officially supports Ruby 2.2+
+* Officially supports Ruby 2.3+
 * In order to specify the adapter you now MUST use the `#adapter` method on the connection builder. If you don't do so and your adapter inherits from `Faraday::Adapter` then Faraday will raise an exception. Otherwise, Faraday will automatically push the default adapter at the end of the stack causing your request to be executed twice.
 ```ruby
 class OfficialAdapter < Faraday::Adapter


### PR DESCRIPTION
## Description

This fixes a missed mention of "Ruby 2.2+".

See #827 

