### PR TITLE
Expose `pool_size` as a option for the NetHttpPersistent adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ end
 ### NetHttpPersistent
 ```ruby
 conn = Faraday.new(...) do |f|
-  f.adapter :net_http_persistent do |http| # yields Net::HTTP::Persistent
+  f.adapter :net_http_persistent, pool_size: 5 do |http| # yields Net::HTTP::Persistent
     http.idle_timeout = 100
     http.retry_change_requests = true
   end

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -8,7 +8,9 @@ module Faraday
       def net_http_connection(env)
         @cached_connection ||=
           if Net::HTTP::Persistent.instance_method(:initialize).parameters.first == [:key, :name]
-            Net::HTTP::Persistent.new(name: 'Faraday')
+            options = {}
+            options[:pool_size] = @connection_options[:pool_size] if @connection_options.key?(:pool_size)
+            Net::HTTP::Persistent.new(name: 'Faraday', **options)
           else
             Net::HTTP::Persistent.new('Faraday')
           end

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -8,9 +8,9 @@ module Faraday
       def net_http_connection(env)
         @cached_connection ||=
           if Net::HTTP::Persistent.instance_method(:initialize).parameters.first == [:key, :name]
-            options = {}
+            options = {name: 'Faraday'}
             options[:pool_size] = @connection_options[:pool_size] if @connection_options.key?(:pool_size)
-            Net::HTTP::Persistent.new(name: 'Faraday', **options)
+            Net::HTTP::Persistent.new(options)
           else
             Net::HTTP::Persistent.new('Faraday')
           end

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -64,6 +64,28 @@ module Adapters
       end
     end
 
+    def test_without_custom_connection_config
+      url = URI('https://example.com:1234')
+
+      adapter = Faraday::Adapter::NetHttpPersistent.new
+
+      http = adapter.send(:net_http_connection, :url => url, :request => {})
+
+      # `pool` is only present in net_http_persistent >= 3.0
+      assert http.pool.size != nil if http.respond_to?(:pool)
+    end
+
+    def test_custom_connection_config
+      url = URI('https://example.com:1234')
+
+      adapter = Faraday::Adapter::NetHttpPersistent.new(nil, {pool_size: 5})
+
+      http = adapter.send(:net_http_connection, :url => url, :request => {})
+
+      # `pool` is only present in net_http_persistent >= 3.0
+      assert_equal 5, http.pool.size if http.respond_to?(:pool)
+    end
+
     def test_custom_adapter_config
       url = URI('https://example.com:1234')
 


### PR DESCRIPTION
Expose `pool_size` as a connection option for the NetHttpPersistent adapter

Fixes: https://github.com/lostisland/faraday/issues/833

## Description
- Note: connection pool was only added to `net-http-persistent` from version 3.0
- The `pool_size` constructor param in Net::HTTP::Persistent has a default value so I've been careful to ensure this will still use the default behaviour when the `pool_size` adapter option is not provided.

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [x] Documentation

## Additional Notes
...
