### PR TITLE
Inject connection class as a dependency

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -14,7 +14,7 @@ require 'forwardable'
 #   conn.get '/'
 #
 module Faraday
-  VERSION = "0.15.4"
+  VERSION = "0.16.0"
 
   class << self
     # Public: Gets or sets the root path that Faraday is being loaded from.

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -63,11 +63,11 @@ module Faraday
     #   Faraday.new :url => 'http://faraday.com',
     #     :params => {:page => 1}
     #
-    # Returns a Faraday::Connection.
+    # Returns an instance of the connection class (Faraday::Connection by default)
     def new(url = nil, options = nil)
       block = block_given? ? Proc.new : nil
       options = options ? default_connection_options.merge(options) : default_connection_options
-      Faraday::Connection.new(url, options, &block)
+      options[:connection_class].new(url, options, &block)
     end
 
     # Internal: Requires internal Faraday libraries.

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -249,7 +249,7 @@ module Faraday
   end
 
   class ConnectionOptions < Options.new(:request, :proxy, :ssl, :builder, :url,
-    :parallel_manager, :params, :headers, :builder_class)
+    :parallel_manager, :params, :headers, :builder_class, :connection_class)
 
     options :request => RequestOptions, :ssl => SSLOptions
 
@@ -258,6 +258,8 @@ module Faraday
     memoized(:ssl) { self.class.options_for(:ssl).new }
 
     memoized(:builder_class) { RackBuilder }
+
+    memoized(:connection_class) { Faraday::Connection }
 
     def new_builder(block)
       builder_class.new(&block)

--- a/test/faraday_test.rb
+++ b/test/faraday_test.rb
@@ -1,0 +1,13 @@
+require File.expand_path('../helper', __FILE__)
+
+class FakeFaradayConnection
+  def initialize(*); end
+end
+
+class FaradayTest < Faraday::TestCase
+  def test_instantiate_with_injected_connection_class
+    conn = Faraday.new "example.com", connection_class: FakeFaradayConnection
+
+    assert_equal conn.class, FakeFaradayConnection
+  end
+end


### PR DESCRIPTION
## Description
The `Faraday` module is a handy little builder for instances of `Faraday::Connection`, but it makes it hard to create a `Faraday::Connection` wrapper for custom behavior. By injecting a connection class the gem becomes more easily extended.

Case in point: In my example, I want to be able to log details of each request, in a specific format, to Datadog. If I could subclass `Faraday::Connection`, wrap the methods I care about with our custom code, and have the builder user our connection wrapper instead, we'd be pretty set.

## Todos
- [ ] Documentation
