### PR TITLE
Travis: Include Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - ruby-head
 deploy:
   provider: rubygems


### PR DESCRIPTION
## Description

This PR adds Ruby 2.6.0 to the CI matrix.

