### PR TITLE
Travis: add 2.6.0 to CI matrix, remove sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 script: bundle exec script/test
 cache: bundler
@@ -10,7 +9,8 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
-  - 2.5.0
+  - 2.5
+  - 2.6  
   - ruby-head
   - jruby-19mode
   - jruby-20mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ script: bundle exec script/test
 cache: bundler
 
 rvm:
+  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
@@ -17,13 +18,6 @@ rvm:
   - jruby-head
 
 matrix:
-  include:
-    - rvm: "1.9.3"
-      before_install: "gem install rake -v 12.2.1"
-      env: SSL=no
-    - rvm: "1.9.3"
-      before_install: "gem install rake -v 12.2.1"
-      env: SSL=yes
   allow_failures:
     # "A fatal error has been detected by the Java Runtime Environment:
     #  Internal Error (sharedRuntime.cpp:843)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,13 @@ script: bundle exec script/test
 cache: bundler
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
   - 2.3
   - 2.4
   - 2.5
-  - 2.6  
+  - 2.6
   - ruby-head
   - jruby-19mode
   - jruby-20mode
@@ -18,6 +17,13 @@ rvm:
   - jruby-head
 
 matrix:
+  include:
+    - rvm: "1.9.3"
+      before_install: "gem install rake -v 12.2.1"
+      env: SSL=no
+    - rvm: "1.9.3"
+      before_install: "gem install rake -v 12.2.1"
+      env: SSL=yes
   allow_failures:
     # "A fatal error has been detected by the Java Runtime Environment:
     #  Internal Error (sharedRuntime.cpp:843)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 script: bundle exec script/test
-cache: bundler
 
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,13 @@ rvm:
   - jruby-21mode
   - jruby-head
 
+before_install:
+  - |
+    export RVM_CURRENT=`rvm current|cut -c6-8`
+    if [ "${RVM_CURRENT}" == "2.2" ]; then
+      gem install bundler -v '< 2'
+    fi
+
 matrix:
   allow_failures:
     # "A fatal error has been detected by the Java Runtime Environment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ script: bundle exec script/test
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
-  - 2.6
+  - 2.1.10
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
   - ruby-head
   - jruby-19mode
   - jruby-20mode
@@ -41,6 +41,6 @@ deploy:
   on:
     tags: true
     repo: lostisland/faraday
-    rvm: 2.4
+    rvm: 2.4.5
     condition: '"$SSL" = "yes"'
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,11 @@ ruby RUBY_VERSION
 
 gem 'ffi-ncurses', '~> 0.3', :platforms => :jruby
 gem 'jruby-openssl', '~> 0.8.8', :platforms => :jruby
-gem 'rake'
+if RUBY_VERSION > '2'
+  gem 'rake'
+else
+  gem 'rake', '= 12.2.1'
+end
 
 group :test do
   gem 'coveralls', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,12 @@ gem 'ffi-ncurses', '~> 0.3', :platforms => :jruby
 gem 'jruby-openssl', '~> 0.8.8', :platforms => :jruby
 if RUBY_VERSION > '2'
   gem 'rake'
+  gem 'tins'
 else
   gem 'rake', '= 12.2.1'
+  gem 'tins', '= 1.6.0'
 end
+
 
 group :test do
   gem 'coveralls', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ if RUBY_VERSION > '2'
   gem 'rake'
   gem 'tins'
 else
+  gem 'net-http-persistent', '< 3.0'
   gem 'rake', '= 12.2.1'
   gem 'tins', '= 1.6.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,11 @@ ruby RUBY_VERSION
 gem 'ffi-ncurses', '~> 0.3', :platforms => :jruby
 gem 'jruby-openssl', '~> 0.8.8', :platforms => :jruby
 if RUBY_VERSION > '2'
+  gem 'net-http-persistent', group: :test
   gem 'rake'
   gem 'tins'
 else
-  gem 'net-http-persistent', '< 3.0'
+  gem 'net-http-persistent', '< 3.0', group: :test
   gem 'rake', '= 12.2.1'
   gem 'tins', '= 1.6.0'
 end
@@ -23,7 +24,6 @@ group :test do
   gem 'httpclient', '>= 2.2'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'minitest', '>= 5.0.5'
-  gem 'net-http-persistent'
   gem 'patron', '>= 0.4.2', :platforms => :ruby
   gem 'rack-test', '>= 0.6', :require => 'rack/test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]


### PR DESCRIPTION
## Description

Updates **master branch** CI matrix, using aliases in rvm (`2.6` for latest in 2.6.x series).

Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration