### PR TITLE
[1.0] Travis: Drop old setting sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
## Description

This PR removes old sudo: false setting from Travis config. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration