### PR TITLE
Allow adapter to work with Net::HTTP::Persistent 3.0 breaking changes

### DIFF
--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -12,7 +12,7 @@ module Faraday
             options[:pool_size] = @connection_options[:pool_size] if @connection_options.key?(:pool_size)
             Net::HTTP::Persistent.new(options)
           else
-            Net::HTTP::Persistent.new('Faraday')
+            Net::HTTP::Persistent.new(name: 'Faraday')
           end
 
         proxy_uri = proxy_uri(env)

--- a/test/adapters/net_http_persistent_test.rb
+++ b/test/adapters/net_http_persistent_test.rb
@@ -13,7 +13,7 @@ module Adapters
           if Net::HTTP::Persistent.instance_method(:initialize).parameters.first == [:key, :name]
             Net::HTTP::Persistent.new(name: 'Faraday').reconnect_ssl
           else
-            Net::HTTP::Persistent.new('Faraday').ssl_cleanup(4)
+            Net::HTTP::Persistent.new(name: 'Faraday').ssl_cleanup(4)
           end
         end
       end if ssl_mode?


### PR DESCRIPTION
## Description

See also v3 release notes: https://github.com/drbrain/net-http-persistent/blob/master/History.txt
> Net::HTTP::Persistent::new now uses keyword arguments for +name+ and +proxy+.

