### PR TITLE
Explicitly require `date` for DateTime

### DIFF
--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module Faraday
   # Catches exceptions and retries each request a limited number of times.
   #


### PR DESCRIPTION
## Description
This change fixes an issue where it seems Farday is using `DateTime`, specifically for retry functionality, without requiring it. This leads to a `NameError`. Without explicitly requiring `date`, retry functionality fails with the following error:

```
NameError: uninitialized constant Faraday::Request::Retry::DateTime
from /Users/npresta/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/faraday-0.15.4/lib/faraday/request/retry.rb:194:in `calculate_retry_after'
Caused by Faraday::RetriableResponse:
from /Users/npresta/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/faraday-0.15.4/lib/faraday/request/retry.rb:129:in `block in call'
```

It looks like this was introduced in https://github.com/lostisland/faraday/commit/6ddf9c3b80d2eee6673c72d82d181a810746088c Perhaps the testing environment, or IRB, automatically requires `date`, but if you just run this in Ruby directly:

```
$ ruby -e 'DateTime.rfc2822("hi")'
-e:1:in `<main>': uninitialized constant DateTime (NameError)
```

Ruby version: 2.4.4

## Additional Notes

This seems like a straightforward bugfix, but likely doesn't impact many people (no open issues, no Google searches) so I would imagine most Ruby apps have `date` imported somewhere.
