### PR TITLE
Request/Response lifecycle refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,16 +233,31 @@ conn.put '/profile', payload
 ## Writing middleware
 
 Middleware are classes that implement a `call` instance method. They hook into
-the request/response cycle.
+the request/response cycle with two callback methods: `on_request` and `on_response`.
+
+```ruby
+def on_request(env)
+  # do something with the request
+  # env.request_headers.merge!(...)
+end
+
+def on_complete(env)
+  # do something with the response
+  # raise RuntimeError if env.response.status != 200
+end
+```
+
+Alternatively, if your middleware requires a special implementation, you can take control of the cycle
+by overriding the `call` method, and calling `@app.call` where necessary to hand the request over to the next middleware. 
 
 ```ruby
 def call(request_env)
   # do something with the request
-  # request_env[:request_headers].merge!(...)
+  # request_env.request_headers.merge!(...)
 
   @app.call(request_env).on_complete do |response_env|
     # do something with the response
-    # response_env[:response_headers].merge!(...)
+    # response_env.response_headers.merge!(...)
   end
 end
 ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -12,6 +12,23 @@ Please note `Faraday::ClientError` was previously used for both.
   * Faraday::ForbiddenError (403)
   * Faraday::ProxyAuthError (407). Please note this raised a `Faraday::ConnectionFailed` before.
   * Faraday::UnprocessableEntityError (422)
+  
+### Adapters
+Adapters have been refactored so that they're not middlewares anymore.
+This means that they do not take `@app` as an initializer parameter anymore and they don't call `@app.call` anymore.
+If you're using a custom adapter, please ensure to change its initializer and `call` method.
+
+### Faraday::Env
+The `Faraday::Env` has been refactored by moving all response-related fields into the response.
+This means that if you need to access the response `body`, `headers`, `reason_phrase` or `status`, you'll need to pass through the `response`. (e.g. `env.response.headers`)
+However, the following helper methods have been introduced in `Faraday::Env` to ensure backwords compatibility when READING these fields: `response_body`, `response_headers`, `reason_phrase` and `status`.
+Moreover, since many existing middlewares still rely on the fact that the `body` is overridden after the response, the `body` getter maintains that functionality.
+But now you can access the request body even after a request has been completed using the `request_body` getter.
+
+### Middlewares
+Middlewares has been refactored, there's no `Faraday::Response::Middleware` class anymore and all "response" middlewares now inherit from the same `Faraday::Middleware` class as the "request" ones.
+There's also a new `on_request` callback that works very similarly to `on_complete` and can be used in "request" middlewares to avoid overriding `call`.
+
 
 ### Others
 * Dropped support for jruby and Rubinius.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,7 +21,7 @@ If you're using a custom adapter, please ensure to change its initializer and `c
 ### Faraday::Env
 The `Faraday::Env` has been refactored by moving all response-related fields into the response.
 This means that if you need to access the response `body`, `headers`, `reason_phrase` or `status`, you'll need to pass through the `response`. (e.g. `env.response.headers`)
-However, the following helper methods have been introduced in `Faraday::Env` to ensure backwords compatibility when READING these fields: `response_body`, `response_headers`, `reason_phrase` and `status`.
+However, the following helper methods have been introduced in `Faraday::Env` to ensure backwards compatibility when READING these fields: `response_body`, `response_headers`, `reason_phrase` and `status`.
 Moreover, since many existing middlewares still rely on the fact that the `body` is overridden after the response, the `body` getter maintains that functionality.
 But now you can access the request body even after a request has been completed using the `request_body` getter.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,14 +19,14 @@ This means that they do not take `@app` as an initializer parameter anymore and 
 If you're using a custom adapter, please ensure to change its initializer and `call` method.
 
 ### Faraday::Env
-The `Faraday::Env` has been refactored by moving all response-related fields into the response.
+The `Faraday::Env` has been refactored by moving all response-related fields into the `response` property.
 This means that if you need to access the response `body`, `headers`, `reason_phrase` or `status`, you'll need to pass through the `response`. (e.g. `env.response.headers`)
 However, the following helper methods have been introduced in `Faraday::Env` to ensure backwards compatibility when READING these fields: `response_body`, `response_headers`, `reason_phrase` and `status`.
 Moreover, since many existing middlewares still rely on the fact that the `body` is overridden after the response, the `body` getter maintains that functionality.
 But now you can access the request body even after a request has been completed using the `request_body` getter.
 
 ### Middlewares
-Middlewares has been refactored, there's no `Faraday::Response::Middleware` class anymore and all "response" middlewares now inherit from the same `Faraday::Middleware` class as the "request" ones.
+Middlewares have been refactored, there's no `Faraday::Response::Middleware` class anymore and all "response" middlewares now inherit from the same `Faraday::Middleware` class as the "request" ones.
 There's also a new `on_request` callback that works very similarly to `on_complete` and can be used in "request" middlewares to avoid overriding `call`.
 
 

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -2,6 +2,8 @@ require 'thread'
 require 'cgi'
 require 'set'
 require 'forwardable'
+require 'faraday/middleware_registry'
+require 'faraday/dependency_loader'
 
 # This is the main namespace for Faraday.
 #
@@ -145,126 +147,6 @@ module Faraday
   unless const_defined? :Timer
     require 'timeout'
     Timer = Timeout
-  end
-
-  # Adds the ability for other modules to register and lookup
-  # middleware classes.
-  module MiddlewareRegistry
-    # Register middleware class(es) on the current module.
-    #
-    # @param autoload_path [String] Middleware autoload path
-    # @param mapping [Hash{Symbol => Module, Symbol, Array<Module, Symbol, String>}] Middleware mapping from a lookup symbol to a reference to the middleware. - Classes can be expressed as:
-    #           - a fully qualified constant
-    #           - a Symbol
-    #           - a Proc that will be lazily called to return the former
-    #           - an array is given, its first element is the constant or symbol,
-    #             and its second is a file to `require`.
-    # @return [void]
-    #
-    # @example Lookup by a constant
-    #
-    #   module Faraday
-    #     class Whatever
-    #       # Middleware looked up by :foo returns Faraday::Whatever::Foo.
-    #       register_middleware :foo => Foo
-    #     end
-    #   end
-    #
-    # @example Lookup by a symbol
-    #
-    #   module Faraday
-    #     class Whatever
-    #       # Middleware looked up by :bar returns Faraday::Whatever.const_get(:Bar)
-    #       register_middleware :bar => :Bar
-    #     end
-    #   end
-    #
-    # @example Lookup by a symbol and string in an array
-    #
-    #   module Faraday
-    #     class Whatever
-    #       # Middleware looked up by :baz requires 'baz' and returns Faraday::Whatever.const_get(:Baz)
-    #       register_middleware :baz => [:Baz, 'baz']
-    #     end
-    #   end
-    #
-    def register_middleware(autoload_path = nil, mapping = nil)
-      if mapping.nil?
-        mapping = autoload_path
-        autoload_path = nil
-      end
-      middleware_mutex do
-        @middleware_autoload_path = autoload_path if autoload_path
-        (@registered_middleware ||= {}).update(mapping)
-      end
-    end
-
-    # Unregister a previously registered middleware class.
-    #
-    # @param key [Symbol] key for the registered middleware.
-    def unregister_middleware(key)
-      @registered_middleware.delete(key)
-    end
-
-    # Lookup middleware class with a registered Symbol shortcut.
-    #
-    # @param key [Symbol] key for the registered middleware.
-    # @return [Class] a middleware Class.
-    # @raise [Faraday::Error] if given key is not registered
-    #
-    # @example
-    #
-    #   module Faraday
-    #     class Whatever
-    #       register_middleware :foo => Foo
-    #     end
-    #   end
-    #
-    #   Faraday::Whatever.lookup_middleware(:foo)
-    #   # => Faraday::Whatever::Foo
-    #
-    def lookup_middleware(key)
-      load_middleware(key) ||
-        raise(Faraday::Error.new("#{key.inspect} is not registered on #{self}"))
-    end
-
-    def middleware_mutex(&block)
-      @middleware_mutex ||= begin
-        require 'monitor'
-        Monitor.new
-      end
-      @middleware_mutex.synchronize(&block)
-    end
-
-    def fetch_middleware(key)
-      defined?(@registered_middleware) && @registered_middleware[key]
-    end
-
-    def load_middleware(key)
-      value = fetch_middleware(key)
-      case value
-      when Module
-        value
-      when Symbol, String
-        middleware_mutex do
-          @registered_middleware[key] = const_get(value)
-        end
-      when Proc
-        middleware_mutex do
-          @registered_middleware[key] = value.call
-        end
-      when Array
-        middleware_mutex do
-          const, path = value
-          if root = @middleware_autoload_path
-            path = "#{root}/#{path}"
-          end
-          require(path)
-          @registered_middleware[key] = const
-        end
-        load_middleware(key)
-      end
-    end
   end
 
   require_libs "utils", "options", "connection", "rack_builder", "parameters",

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -1,28 +1,33 @@
 module Faraday
   # Base class for all Faraday adapters. Adapters are
   # responsible for fulfilling a Faraday request.
-  class Adapter < Middleware
+  class Adapter
+    extend MiddlewareRegistry
+    extend DependencyLoader
+
     CONTENT_LENGTH = 'Content-Length'.freeze
 
     register_middleware File.expand_path('../adapter', __FILE__),
-      :test => [:Test, 'test'],
-      :net_http => [:NetHttp, 'net_http'],
-      :net_http_persistent => [:NetHttpPersistent, 'net_http_persistent'],
-      :typhoeus => [:Typhoeus, 'typhoeus'],
-      :patron => [:Patron, 'patron'],
-      :em_synchrony => [:EMSynchrony, 'em_synchrony'],
-      :em_http => [:EMHttp, 'em_http'],
-      :excon => [:Excon, 'excon'],
-      :rack => [:Rack, 'rack'],
-      :httpclient => [:HTTPClient, 'httpclient']
+                        :test => [:Test, 'test'],
+                        :net_http => [:NetHttp, 'net_http'],
+                        :net_http_persistent => [:NetHttpPersistent, 'net_http_persistent'],
+                        :typhoeus => [:Typhoeus, 'typhoeus'],
+                        :patron => [:Patron, 'patron'],
+                        :em_synchrony => [:EMSynchrony, 'em_synchrony'],
+                        :em_http => [:EMHttp, 'em_http'],
+                        :excon => [:Excon, 'excon'],
+                        :rack => [:Rack, 'rack'],
+                        :httpclient => [:HTTPClient, 'httpclient']
 
     # This module marks an Adapter as supporting parallel requests.
     module Parallelism
       attr_writer :supports_parallel
-      def supports_parallel?() @supports_parallel end
+
+      def supports_parallel?()
+        @supports_parallel
+      end
 
       def inherited(subclass)
-        super
         subclass.supports_parallel = self.supports_parallel?
       end
     end
@@ -30,26 +35,24 @@ module Faraday
     extend Parallelism
     self.supports_parallel = false
 
-    def initialize(app = nil, opts = {}, &block)
-      super(app)
+    def initialize(opts = {}, &block)
+      @app = lambda { |env| env.response }
       @connection_options = opts
       @config_block = block
     end
 
     def call(env)
       env.clear_body if env.needs_body?
+      env.response ||= Response.new
     end
 
     private
 
     def save_response(env, status, body, headers = nil, reason_phrase = nil)
-      env.status = status
-      env.body = body
-      env.reason_phrase = reason_phrase && reason_phrase.to_s.strip
-      env.response_headers = Utils::Headers.new.tap do |response_headers|
-        response_headers.update headers unless headers.nil?
-        yield(response_headers) if block_given?
-      end
+      params = { status: status, body: body, headers: headers, reason_phrase: reason_phrase&.to_s&.strip }
+      env.parallel? ? env.response.apply_params(params) : env.response.finish(params)
+      yield(env.response.headers) if block_given?
+      env.response
     end
   end
 end

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -23,12 +23,12 @@ module Faraday
         super
         request = create_request(env)
 
-        http_method = env[:method].to_s.downcase.to_sym
+        http_method = env.method.to_s.downcase.to_sym
 
         # Queue requests for parallel execution.
-        if env[:parallel_manager]
-          env[:parallel_manager].add(request, http_method, request_config(env)) do |resp|
-            if (req = env[:request]).stream_response?
+        if env.parallel_manager
+          env.parallel_manager.add(request, http_method, request_config(env)) do |resp|
+            if (req = env.request).stream_response?
               warn "Streaming downloads for #{self.class.name} are not yet implemented."
               req.on_data.call(resp.response, resp.response.bytesize)
             end
@@ -40,7 +40,7 @@ module Faraday
             end
 
             # Finalize the response object with values from `env`.
-            env[:response].finish(env)
+            env.response.finish(env)
           end
 
         # Execute single request.
@@ -61,9 +61,9 @@ module Faraday
 
           raise client.error if client.error
 
-          if env[:request].stream_response?
+          if env.request.stream_response?
             warn "Streaming downloads for #{self.class.name} are not yet implemented."
-            env[:request].on_data.call(client.response, client.response.bytesize)
+            env.request.on_data.call(client.response, client.response.bytesize)
           end
           status = client.response_header.status
           reason = client.response_header.http_reason
@@ -100,7 +100,7 @@ module Faraday
       end
 
       def create_request(env)
-        EventMachine::HttpRequest.new(Utils::URI(env[:url].to_s), connection_config(env).merge(@connection_options))
+        EventMachine::HttpRequest.new(Utils::URI(env.url.to_s), connection_config(env).merge(@connection_options))
       end
     end
   end

--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -8,7 +8,7 @@ module Faraday
         super
 
         opts = {}
-        if env[:url].scheme == 'https' && ssl = env[:ssl]
+        if env.url.scheme == 'https' && ssl = env.ssl
           opts[:ssl_verify_peer] = !!ssl.fetch(:verify, true)
           opts[:ssl_ca_path] = ssl[:ca_path] if ssl[:ca_path]
           opts[:ssl_ca_file] = ssl[:ca_file] if ssl[:ca_file]
@@ -25,7 +25,7 @@ module Faraday
           opts[:nonblock] = false
         end
 
-        if ( req = env[:request] )
+        if ( req = env.request )
           if req[:timeout]
             opts[:read_timeout]      = req[:timeout]
             opts[:connect_timeout]   = req[:timeout]
@@ -51,8 +51,8 @@ module Faraday
         conn = create_connection(env, opts)
 
         resp = conn.request \
-          :method  => env[:method].to_s.upcase,
-          :headers => env[:request_headers],
+          :method  => env.method.to_s.upcase,
+          :headers => env.request_headers,
           :body    => read_body(env)
 
         if req.stream_response?
@@ -60,8 +60,6 @@ module Faraday
           req.on_data.call(resp.body, resp.body.bytesize)
         end
         save_response(env, resp.status.to_i, resp.body, resp.headers, resp.reason_phrase)
-
-        @app.call env
       rescue ::Excon::Errors::SocketError => err
         if err.message =~ /\btimeout\b/
           raise Faraday::TimeoutError, err
@@ -76,12 +74,12 @@ module Faraday
 
       # @return [Excon]
       def create_connection(env, opts)
-        ::Excon.new(env[:url].to_s, opts.merge(@connection_options))
+        ::Excon.new(env.url.to_s, opts.merge(@connection_options))
       end
 
       # TODO: support streaming requests
       def read_body(env)
-        env[:body].respond_to?(:read) ? env[:body].read : env[:body]
+        env.body.respond_to?(:read) ? env.body.read : env.body
       end
     end
   end

--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -15,7 +15,7 @@ module Faraday
         # enable compression
         client.transparent_gzip_decompression = true
 
-        if req = env[:request]
+        if req = env.request
           if proxy = req[:proxy]
             configure_proxy proxy
           end
@@ -27,7 +27,7 @@ module Faraday
           configure_timeouts req
         end
 
-        if env[:url].scheme == 'https' && ssl = env[:ssl]
+        if env.url.scheme == 'https' && ssl = env.ssl
           configure_ssl ssl
         end
 
@@ -35,19 +35,17 @@ module Faraday
 
         # TODO Don't stream yet.
         # https://github.com/nahi/httpclient/pull/90
-        env[:body] = env[:body].read if env[:body].respond_to? :read
+        env.body = env.body.read if env.body.respond_to? :read
 
-        resp = client.request env[:method], env[:url],
-          :body   => env[:body],
-          :header => env[:request_headers]
+        resp = client.request env.method, env.url,
+          :body   => env.body,
+          :header => env.request_headers
 
-        if (req = env[:request]).stream_response?
+        if (req = env.request).stream_response?
           warn "Streaming downloads for #{self.class.name} are not yet implemented."
           req.on_data.call(resp.body, resp.body.bytesize)
         end
         save_response env, resp.status, resp.body, resp.headers, resp.reason
-
-        @app.call env
       rescue ::HTTPClient::TimeoutError, Errno::ETIMEDOUT
         raise Faraday::TimeoutError, $!
       rescue ::HTTPClient::BadResponseError => err

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -23,7 +23,7 @@ module Faraday
 
       def proxy_uri(env)
         proxy_uri = nil
-        if (proxy = env[:request][:proxy])
+        if (proxy = env.request[:proxy])
           proxy_uri = ::URI::HTTP === proxy[:uri] ? proxy[:uri].dup : ::URI.parse(proxy[:uri].to_s)
           proxy_uri.user = proxy_uri.password = nil
           # awful patch for net-http-persistent 2.8 not unescaping user/password
@@ -36,7 +36,7 @@ module Faraday
       end
 
       def perform_request(http, env)
-        http.request env[:url], create_request(env)
+        http.request env.url, create_request(env)
       rescue Errno::ETIMEDOUT => error
         raise Faraday::TimeoutError, error
       rescue Net::HTTP::Persistent::Error => error

--- a/lib/faraday/adapter/rack.rb
+++ b/lib/faraday/adapter/rack.rb
@@ -28,25 +28,25 @@ module Faraday
       def call(env)
         super
         rack_env = {
-          :method => env[:method],
-          :input  => env[:body].respond_to?(:read) ? env[:body].read : env[:body],
-          'rack.url_scheme' => env[:url].scheme
+          :method => env.method,
+          :input  => env.body.respond_to?(:read) ? env.body.read : env.body,
+          'rack.url_scheme' => env.url.scheme
         }
 
-        env[:request_headers].each do |name, value|
+        env.request_headers.each do |name, value|
           name = name.upcase.tr('-', '_')
           name = "HTTP_#{name}" unless SPECIAL_HEADERS.include? name
           rack_env[name] = value
-        end if env[:request_headers]
+        end if env.request_headers
 
-        timeout  = env[:request][:timeout] || env[:request][:open_timeout]
+        timeout  = env.request[:timeout] || env.request[:open_timeout]
         response = if timeout
           Timer.timeout(timeout, Faraday::TimeoutError) { execute_request(env, rack_env) }
         else
           execute_request(env, rack_env)
         end
 
-        if (req = env[:request]).stream_response?
+        if (req = env.request).stream_response?
           warn "Streaming downloads for #{self.class.name} are not yet implemented."
           req.on_data.call(response.body, response.body.bytesize)
         end
@@ -56,7 +56,7 @@ module Faraday
       end
 
       def execute_request(env, rack_env)
-        @session.request(env[:url].to_s, rack_env)
+        @session.request(env.url.to_s, rack_env)
       end
     end
   end

--- a/lib/faraday/adapter/typhoeus.rb
+++ b/lib/faraday/adapter/typhoeus.rb
@@ -7,6 +7,11 @@ module Faraday
 
       dependency 'typhoeus'
       dependency 'typhoeus/adapters/faraday'
+
+      def initialize(adapter_options = {})
+        super()
+        @adapter_options = adapter_options
+      end
     end
   end
 end

--- a/lib/faraday/dependency_loader.rb
+++ b/lib/faraday/dependency_loader.rb
@@ -1,0 +1,29 @@
+module Faraday
+  module DependencyLoader
+    attr_accessor :load_error
+    private :load_error=
+
+    # self.load_error = nil
+
+    # Executes a block which should try to require and reference dependent libraries
+    def dependency(lib = nil)
+      lib ? require(lib) : yield
+    rescue LoadError, NameError => error
+      self.load_error = error
+    end
+
+    def new(*)
+      raise "missing dependency for #{self}: #{load_error.message}" unless loaded?
+      super
+    end
+
+    def loaded?
+      load_error.nil?
+    end
+
+    def inherited(subclass)
+      super
+      subclass.send(:load_error=, self.load_error)
+    end
+  end
+end

--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -1,37 +1,24 @@
 module Faraday
   class Middleware
     extend MiddlewareRegistry
-
-    class << self
-      attr_accessor :load_error
-      private :load_error=
-    end
-
-    self.load_error = nil
-
-    # Executes a block which should try to require and reference dependent libraries
-    def self.dependency(lib = nil)
-      lib ? require(lib) : yield
-    rescue LoadError, NameError => error
-      self.load_error = error
-    end
-
-    def self.new(*)
-      raise "missing dependency for #{self}: #{load_error.message}" unless loaded?
-      super
-    end
-
-    def self.loaded?
-      load_error.nil?
-    end
-
-    def self.inherited(subclass)
-      super
-      subclass.send(:load_error=, self.load_error)
-    end
+    extend DependencyLoader
 
     def initialize(app = nil)
       @app = app
+    end
+
+    # Calls `on_request` and `on_complete`
+    def call(env)
+      on_request(env) if respond_to?(:on_request)
+      @app.call(env).on_complete do |_|
+        on_complete(env)
+      end
+    end
+
+    # Override this to modify the environment after the response has finished.
+    # Calls the `parse` method if defined
+    def on_complete(env)
+      env.response.body = parse(env.response.body) if respond_to?(:parse) && env.parse_body?
     end
   end
 end

--- a/lib/faraday/middleware_registry.rb
+++ b/lib/faraday/middleware_registry.rb
@@ -1,0 +1,121 @@
+module Faraday
+  # Adds the ability for other modules to register and lookup
+  # middleware classes.
+  module MiddlewareRegistry
+    # Register middleware class(es) on the current module.
+    #
+    # @param autoload_path [String] Middleware autoload path
+    # @param mapping [Hash{Symbol => Module, Symbol, Array<Module, Symbol, String>}] Middleware mapping from a lookup symbol to a reference to the middleware. - Classes can be expressed as:
+    #           - a fully qualified constant
+    #           - a Symbol
+    #           - a Proc that will be lazily called to return the former
+    #           - an array is given, its first element is the constant or symbol,
+    #             and its second is a file to `require`.
+    # @return [void]
+    #
+    # @example Lookup by a constant
+    #
+    #   module Faraday
+    #     class Whatever
+    #       # Middleware looked up by :foo returns Faraday::Whatever::Foo.
+    #       register_middleware :foo => Foo
+    #     end
+    #   end
+    #
+    # @example Lookup by a symbol
+    #
+    #   module Faraday
+    #     class Whatever
+    #       # Middleware looked up by :bar returns Faraday::Whatever.const_get(:Bar)
+    #       register_middleware :bar => :Bar
+    #     end
+    #   end
+    #
+    # @example Lookup by a symbol and string in an array
+    #
+    #   module Faraday
+    #     class Whatever
+    #       # Middleware looked up by :baz requires 'baz' and returns Faraday::Whatever.const_get(:Baz)
+    #       register_middleware :baz => [:Baz, 'baz']
+    #     end
+    #   end
+    #
+    def register_middleware(autoload_path = nil, mapping = nil)
+      if mapping.nil?
+        mapping = autoload_path
+        autoload_path = nil
+      end
+      middleware_mutex do
+        @middleware_autoload_path = autoload_path if autoload_path
+        (@registered_middleware ||= {}).update(mapping)
+      end
+    end
+
+    # Unregister a previously registered middleware class.
+    #
+    # @param key [Symbol] key for the registered middleware.
+    def unregister_middleware(key)
+      @registered_middleware.delete(key)
+    end
+
+    # Lookup middleware class with a registered Symbol shortcut.
+    #
+    # @param key [Symbol] key for the registered middleware.
+    # @return [Class] a middleware Class.
+    # @raise [Faraday::Error] if given key is not registered
+    #
+    # @example
+    #
+    #   module Faraday
+    #     class Whatever
+    #       register_middleware :foo => Foo
+    #     end
+    #   end
+    #
+    #   Faraday::Whatever.lookup_middleware(:foo)
+    #   # => Faraday::Whatever::Foo
+    #
+    def lookup_middleware(key)
+      load_middleware(key) ||
+        raise(Faraday::Error.new("#{key.inspect} is not registered on #{self}"))
+    end
+
+    def middleware_mutex(&block)
+      @middleware_mutex ||= begin
+        require 'monitor'
+        Monitor.new
+      end
+      @middleware_mutex.synchronize(&block)
+    end
+
+    def fetch_middleware(key)
+      defined?(@registered_middleware) && @registered_middleware[key]
+    end
+
+    def load_middleware(key)
+      value = fetch_middleware(key)
+      case value
+      when Module
+        value
+      when Symbol, String
+        middleware_mutex do
+          @registered_middleware[key] = const_get(value)
+        end
+      when Proc
+        middleware_mutex do
+          @registered_middleware[key] = value.call
+        end
+      when Array
+        middleware_mutex do
+          const, path = value
+          if root = @middleware_autoload_path
+            path = "#{root}/#{path}"
+          end
+          require(path)
+          @registered_middleware[key] = const
+        end
+        load_middleware(key)
+      end
+    end
+  end
+end

--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -44,19 +44,17 @@ module Faraday
   # @!attribute reason_phrase
   #   @return [String]
   class Env < Options.new(:method, :body, :url, :request, :request_headers,
-                          :ssl, :parallel_manager, :params, :response, :response_headers, :status,
-                          :reason_phrase)
+                          :ssl, :parallel_manager, :params, :response)
 
     ContentLength = 'Content-Length'.freeze
     StatusesWithoutBody = Set.new [204, 304]
-    SuccessfulStatuses = 200..299
 
     # A Set of HTTP verbs that typically send a body.  If no body is set for
     # these requests, the Content-Length header is set to 0.
     MethodsWithBodies = Set.new [:post, :put, :patch, :options]
 
     options :request => RequestOptions,
-            :request_headers => Utils::Headers, :response_headers => Utils::Headers
+            :request_headers => Utils::Headers
 
     extend Forwardable
 
@@ -93,11 +91,6 @@ module Faraday
       end
     end
 
-    # @return [Boolean] true if status is in the set of {SuccessfulStatuses}.
-    def success?
-      SuccessfulStatuses.include?(status)
-    end
-
     # @return [Boolean] true if there's no body yet, and the method is in the set of {MethodsWithBodies}.
     def needs_body?
       !body && MethodsWithBodies.include?(method)
@@ -117,6 +110,26 @@ module Faraday
     # @return [Boolean] true if there is a parallel_manager
     def parallel?
       !!parallel_manager
+    end
+
+    def response_headers
+      response.headers
+    end
+
+    def status
+      response.status
+    end
+
+    def response_body
+      response.body
+    end
+
+    def request_body
+      self[:body]
+    end
+
+    def body
+      response&.finished? ? response_body : request_body
     end
 
     def inspect

--- a/lib/faraday/request/authorization.rb
+++ b/lib/faraday/request/authorization.rb
@@ -39,11 +39,10 @@ module Faraday
     end
 
     # @param env [Faraday::Env]
-    def call(env)
+    def on_request(env)
       unless env.request_headers[KEY]
         env.request_headers[KEY] = @header_value
       end
-      @app.call(env)
     end
   end
 end

--- a/lib/faraday/request/instrumentation.rb
+++ b/lib/faraday/request/instrumentation.rb
@@ -20,8 +20,8 @@ module Faraday
     #
     # @example Using ActiveSupport::Notifications to measure time spent for Faraday requests
     #   ActiveSupport::Notifications.subscribe('request.faraday') do |name, starts, ends, _, env|
-    #     url = env[:url]
-    #     http_method = env[:method].to_s.upcase
+    #     url = env.url
+    #     http_method = env.method.to_s.upcase
     #     duration = ends - starts
     #     $stderr.puts '[%s] %s %s (%.3f s)' % [url.host, http_method, url.request_uri, duration]
     #   end

--- a/lib/faraday/request/multipart.rb
+++ b/lib/faraday/request/multipart.rb
@@ -10,13 +10,12 @@ module Faraday
     # Checks for files in the payload, otherwise leaves everything untouched.
     #
     # @param env [Faraday::Env]
-    def call(env)
+    def on_request(env)
       match_content_type(env) do |params|
         env.request.boundary ||= unique_boundary
         env.request_headers[CONTENT_TYPE] += "; boundary=#{env.request.boundary}"
         env.body = create_multipart(env, params)
       end
-      @app.call env
     end
 
     # @param env [Faraday::Env]

--- a/lib/faraday/request/url_encoded.rb
+++ b/lib/faraday/request/url_encoded.rb
@@ -12,12 +12,11 @@ module Faraday
     # of another type.
     #
     # @param env [Faraday::Env]
-    def call(env)
+    def on_request(env)
       match_content_type(env) do |data|
         params = Faraday::Utils::ParamsHash[data]
         env.body = params.to_query(env.params_encoder)
       end
-      @app.call env
     end
 
     # @param env [Faraday::Env]

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -1,32 +1,32 @@
 module Faraday
-  class Response::RaiseError < Response::Middleware
+  class Response::RaiseError < Middleware
     ClientErrorStatuses = 400...500
     ServerErrorStatuses = 500...600
 
     def on_complete(env)
-      case env[:status]
+      case env.status
       when 400
-        raise Faraday::BadRequestError, response_values(env)
+        raise Faraday::BadRequestError, response_values(env.response)
       when 401
-        raise Faraday::UnauthorizedError, response_values(env)
+        raise Faraday::UnauthorizedError, response_values(env.response)
       when 403
-        raise Faraday::ForbiddenError, response_values(env)
+        raise Faraday::ForbiddenError, response_values(env.response)
       when 404
-        raise Faraday::ResourceNotFound, response_values(env)
+        raise Faraday::ResourceNotFound, response_values(env.response)
       when 407
         # mimic the behavior that we get with proxy requests with HTTPS
-        raise Faraday::ProxyAuthError.new(%{407 "Proxy Authentication Required"}, response_values(env))
+        raise Faraday::ProxyAuthError.new(%{407 "Proxy Authentication Required"}, response_values(env.response))
       when 422
-        raise Faraday::UnprocessableEntityError, response_values(env)
+        raise Faraday::UnprocessableEntityError, response_values(env.response)
       when ClientErrorStatuses
-        raise Faraday::ClientError, response_values(env)
+        raise Faraday::ClientError, response_values(env.response)
       when ServerErrorStatuses
-        raise Faraday::ServerError, response_values(env)
+        raise Faraday::ServerError, response_values(env.response)
       end
     end
 
-    def response_values(env)
-      {:status => env.status, :headers => env.response_headers, :body => env.body}
+    def response_values(response)
+      { :status => response.status, :headers => response.headers, :body => response.body }
     end
   end
 end

--- a/spec/faraday/adapter/excon_spec.rb
+++ b/spec/faraday/adapter/excon_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Faraday::Adapter::Excon do
   it 'allows to provide adapter specific configs' do
     url = URI('https://example.com:1234')
 
-    adapter = Faraday::Adapter::Excon.new(nil, debug_request: true)
+    adapter = Faraday::Adapter::Excon.new(debug_request: true)
 
-    conn = adapter.create_connection({ url: url }, {})
+    conn = adapter.create_connection(Faraday::Env.from(url: url), {})
 
     expect(conn.data[:debug_request]).to be_truthy
   end

--- a/spec/faraday/adapter/net_http_persistent_spec.rb
+++ b/spec/faraday/adapter/net_http_persistent_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
       http.idle_timeout = 123
     end
 
-    http = adapter.send(:net_http_connection, url: url, request: {})
+    http = adapter.send(:net_http_connection, Faraday::Env.from(url: url, request: {}))
     adapter.send(:configure_request, http, {})
 
     expect(http.idle_timeout).to eq(123)
@@ -21,7 +21,7 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
 
     adapter = Faraday::Adapter::NetHttpPersistent.new
 
-    http = adapter.send(:net_http_connection, url: url, request: {})
+    http = adapter.send(:net_http_connection, Faraday::Env.from(url: url, request: {}))
     adapter.send(:configure_request, http, {})
 
     # `max_retries=` is only present in Ruby 2.5
@@ -31,9 +31,9 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
   it 'allows to set pool_size on initialize' do
     url = URI('https://example.com')
 
-    adapter = Faraday::Adapter::NetHttpPersistent.new(nil, { pool_size: 5 })
+    adapter = Faraday::Adapter::NetHttpPersistent.new({ pool_size: 5 })
 
-    http = adapter.send(:net_http_connection, url: url, request: {})
+    http = adapter.send(:net_http_connection, Faraday::Env.from(url: url, request: {}))
 
     # `pool` is only present in net_http_persistent >= 3.0
     expect(http.pool.size).to eq(5) if http.respond_to?(:pool)

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Faraday::Adapter::NetHttp do
   context 'checking http' do
     let(:url) { URI('http://example.com') }
     let(:adapter) { Faraday::Adapter::NetHttp.new }
-    let(:http) { adapter.send(:net_http_connection, url: url, request: {}) }
+    let(:http) { adapter.send(:net_http_connection, Faraday::Env.from(url: url, request: {})) }
 
     it { expect(http.port).to eq(80) }
     it 'sets max_retries to 0' do

--- a/spec/faraday/options/env_spec.rb
+++ b/spec/faraday/options/env_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe Faraday::Env do
-  subject { Faraday::Env.new }
   it 'allows to access members' do
     expect(subject.method).to be_nil
     subject.method = :get
@@ -33,5 +32,31 @@ RSpec.describe Faraday::Env do
     expect(env2[:foo]).to eq("custom 1")
     expect(env2[:bar]).to eq(:custom_2)
     expect(subject[:baz]).to be_nil
+  end
+
+  describe '#body' do
+    subject { Faraday::Env.from(body: { foo: 'bar' }) }
+
+    context 'when response is not finished yet' do
+      it 'returns the request body' do
+        expect(subject.body).to eq({ foo: 'bar' })
+      end
+    end
+
+    context 'when response is finished' do
+      before { subject.response = Faraday::Response.new.finish(body: { bar: 'foo' }) }
+
+      it 'returns the response body' do
+        expect(subject.body).to eq({ bar: 'foo' })
+      end
+
+      it 'allows to access request_body' do
+        expect(subject.request_body).to eq({ foo: 'bar' })
+      end
+
+      it 'allows to access response_body' do
+        expect(subject.response_body).to eq({ bar: 'foo' })
+      end
+    end
   end
 end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Faraday::RackBuilder do
   # mock handler classes
   class Handler < Struct.new(:app)
     def call(env)
-      (env[:request_headers]['X-Middleware'] ||= '') << ":#{self.class.name.split('::').last}"
+      (env.request_headers['X-Middleware'] ||= '') << ":#{self.class.name.split('::').last}"
       app.call(env)
     end
   end

--- a/spec/faraday/request/authorization_spec.rb
+++ b/spec/faraday/request/authorization_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Faraday::Request::Authorization do
       b.request auth_type, *auth_config
       b.adapter :test do |stub|
         stub.get('/auth-echo') do |env|
-          [200, {}, env[:request_headers]['Authorization']]
+          [200, {}, env.request_headers['Authorization']]
         end
       end
     end

--- a/spec/faraday/request/instrumentation_spec.rb
+++ b/spec/faraday/request/instrumentation_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Faraday::Request::Instrumentation do
 
     name, env = instrumenter.instrumentations.first
     expect(name).to eq('request.faraday')
-    expect(env[:url].path).to eq('/')
+    expect(env.url.path).to eq('/')
   end
 
   context 'with custom name' do
@@ -62,7 +62,7 @@ RSpec.describe Faraday::Request::Instrumentation do
 
       name, env = instrumenter.instrumentations.first
       expect(name).to eq('custom')
-      expect(env[:url].path).to eq('/')
+      expect(env.url.path).to eq('/')
     end
   end
 

--- a/spec/faraday/request/multipart_spec.rb
+++ b/spec/faraday/request/multipart_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Faraday::Request::Multipart do
       b.request :url_encoded
       b.adapter :test do |stub|
         stub.post('/echo') do |env|
-          posted_as = env[:request_headers]['Content-Type']
-          [200, { 'Content-Type' => posted_as }, env[:body]]
+          posted_as = env.request_headers['Content-Type']
+          [200, { 'Content-Type' => posted_as }, env.body]
         end
       end
     end

--- a/spec/faraday/request/retry_spec.rb
+++ b/spec/faraday/request/retry_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Faraday::Request::Retry do
         %w(get post).each do |method|
           stub.send(method, '/unstable') do |env|
             calls << env.dup
-            env[:body] = nil # simulate blanking out response body
             callback.call
           end
         end
@@ -136,11 +135,11 @@ RSpec.describe Faraday::Request::Retry do
       @check = lambda { |_, _| true }
       expect { conn.post('/unstable', body) }.to raise_error(Errno::ETIMEDOUT)
       expect(times_called).to eq(3)
-      expect(calls.all? { |env| env[:body] == body }).to be_truthy
+      expect(calls.all? { |env| env.body == body }).to be_truthy
     end
 
     it 'does not retry if retry_if block returns false checking env' do
-      @check = lambda { |env, _| env[:method] != :post }
+      @check = lambda { |env, _| env.method != :post }
       expect { conn.post('/unstable') }.to raise_error(Errno::ETIMEDOUT)
       expect(times_called).to eq(1)
     end

--- a/spec/faraday/request/url_encoded_spec.rb
+++ b/spec/faraday/request/url_encoded_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Faraday::Request::UrlEncoded do
       b.request :url_encoded
       b.adapter :test do |stub|
         stub.post('/echo') do |env|
-          posted_as = env[:request_headers]['Content-Type']
-          [200, {'Content-Type' => posted_as}, env[:body]]
+          posted_as = env.request_headers['Content-Type']
+          [200, {'Content-Type' => posted_as}, env.body]
         end
       end
     end

--- a/spec/faraday/response/middleware_spec.rb
+++ b/spec/faraday/response/middleware_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Faraday::Response::Middleware do
+RSpec.describe Faraday::Middleware do
   let(:conn) do
     Faraday.new do |b|
       b.use custom_middleware
@@ -12,7 +12,7 @@ RSpec.describe Faraday::Response::Middleware do
 
   context 'with a custom ResponseMiddleware' do
     let(:custom_middleware) do
-      Class.new(Faraday::Response::Middleware) do
+      Class.new(Faraday::Middleware) do
         def parse(body)
           body.upcase
         end
@@ -26,7 +26,7 @@ RSpec.describe Faraday::Response::Middleware do
 
   context 'with a custom ResponseMiddleware but empty response' do
     let(:custom_middleware) do
-      Class.new(Faraday::Response::Middleware) do
+      Class.new(Faraday::Middleware) do
         def parse(body)
           raise 'this should not be called'
         end

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -1,9 +1,8 @@
 RSpec.describe Faraday::Response do
-  subject { Faraday::Response.new(env) }
+  subject { Faraday::Response.new.finish(params) }
 
-  let(:env) do
-    Faraday::Env.from(status: 404, body: 'yikes',
-                      response_headers: { 'Content-Type' => 'text/plain' })
+  let(:params) do
+    { status: 404, body: 'yikes', headers: { 'Content-Type' => 'text/plain' }, reason_phrase: 'not found' }
   end
 
   it { expect(subject.finished?).to be_truthy }
@@ -14,21 +13,12 @@ RSpec.describe Faraday::Response do
   it { expect(subject.headers['Content-Type']).to eq('text/plain') }
   it { expect(subject['content-type']).to eq('text/plain') }
 
-  describe '#apply_request' do
-    before { subject.apply_request(body: 'a=b', method: :post) }
+  describe '#apply_params' do
+    subject { Faraday::Response.new }
+    before { subject.apply_params(body: 'yikes', status: 200) }
 
     it { expect(subject.body).to eq('yikes') }
-    it { expect(subject.env[:method]).to eq(:post) }
-  end
-
-  describe '#to_hash' do
-    let(:hash) { subject.to_hash }
-
-    it { expect(hash).to be_a(Hash) }
-    it { expect(hash).to eq(env.to_hash) }
-    it { expect(hash[:status]).to eq(subject.status) }
-    it { expect(hash[:response_headers]).to eq(subject.headers) }
-    it { expect(hash[:body]).to eq(subject.body) }
+    it { expect(subject.status).to eq(200) }
   end
 
   describe 'marshal serialization support' do
@@ -37,38 +27,38 @@ RSpec.describe Faraday::Response do
 
     before do
       subject.on_complete {}
-      subject.finish(env.merge(params: 'moo'))
+      subject.finish(params)
     end
 
-    it { expect(loaded.env[:params]).to be_nil }
-    it { expect(loaded.env[:body]).to eq(env[:body]) }
-    it { expect(loaded.env[:response_headers]).to eq(env[:response_headers]) }
-    it { expect(loaded.env[:status]).to eq(env[:status]) }
+    it { expect(loaded.body).to eq(params[:body]) }
+    it { expect(loaded.headers).to eq(params[:headers]) }
+    it { expect(loaded.status).to eq(params[:status]) }
+    it { expect(loaded.reason_phrase).to eq(params[:reason_phrase]) }
   end
 
   describe '#on_complete' do
     subject { Faraday::Response.new }
 
     it 'parse body on finish' do
-      subject.on_complete { |env| env[:body] = env[:body].upcase }
-      subject.finish(env)
+      subject.on_complete { |response| response.body = response.body.upcase }
+      subject.finish(params)
 
       expect(subject.body).to eq('YIKES')
     end
 
     it 'can access response body in on_complete callback' do
-      subject.on_complete { |env| env[:body] = subject.body.upcase }
-      subject.finish(env)
+      subject.on_complete { |response| response.body = subject.body.upcase }
+      subject.finish(params)
 
       expect(subject.body).to eq('YIKES')
     end
 
-    it 'can access response body in on_complete callback' do
-      callback_env = nil
-      subject.on_complete { |env| callback_env = env }
+    it 'can access response in on_complete callback' do
+      callback_response = nil
+      subject.on_complete { |response| callback_response = response }
       subject.finish({})
 
-      expect(subject.env).to eq(callback_env)
+      expect(subject).to eq(callback_response)
     end
   end
 end

--- a/test/adapters/test_middleware_test.rb
+++ b/test/adapters/test_middleware_test.rb
@@ -9,7 +9,7 @@ module Adapters
           [200, {'Content-Type' => 'text/html'}, 'hello']
         end
         stub.get('/method-echo') do |env|
-          [200, {'Content-Type' => 'text/html'}, env[:method].to_s]
+          [200, {'Content-Type' => 'text/html'}, env.method.to_s]
         end
         stub.get(/\A\/resources\/\d+(?:\?|\z)/) do
           [200, {'Content-Type' => 'text/html'}, 'show']
@@ -95,10 +95,10 @@ module Adapters
 
     def test_yields_env_to_stubs
       @stubs.get '/hello' do |env|
-        assert_equal '/hello',     env[:url].path
-        assert_equal 'foo.com',    env[:url].host
-        assert_equal '1',          env[:params]['a']
-        assert_equal 'text/plain', env[:request_headers]['Accept']
+        assert_equal '/hello',     env.url.path
+        assert_equal 'foo.com',    env.url.host
+        assert_equal '1',          env.params['a']
+        assert_equal 'text/plain', env.request_headers['Accept']
         [200, {}, 'a']
       end
 
@@ -108,7 +108,7 @@ module Adapters
 
     def test_parses_params_with_default_encoder
       @stubs.get '/hello' do |env|
-        assert_equal '1', env[:params]['a']['b']
+        assert_equal '1', env.params['a']['b']
         [200, {}, 'a']
       end
 
@@ -117,7 +117,7 @@ module Adapters
 
     def test_parses_params_with_nested_encoder
       @stubs.get '/hello' do |env|
-        assert_equal '1', env[:params]['a']['b']
+        assert_equal '1', env.params['a']['b']
         [200, {}, 'a']
       end
 
@@ -127,7 +127,7 @@ module Adapters
 
     def test_parses_params_with_flat_encoder
       @stubs.get '/hello' do |env|
-        assert_equal '1', env[:params]['a[b]']
+        assert_equal '1', env.params['a[b]']
         [200, {}, 'a']
       end
 


### PR DESCRIPTION
## Description
This is probably the biggest refactoring for v1.0 and it's aimed to address a lot of issues that developers raised over time, from the request body being overridden (#517) to the Adapters acting as they were middlewares (#47).

* Adapters refactoring
  * They're now final endpoints. They don't call `@app.call` anymore.
* Env refactoring
  * Refactors `Env` by moving all response-related fields into the response. The response body doesn't override the request body anymore!
  * Ensures backwards compatibility by introducing getter methods in `Env`.
* Middlewares refactoring (mostly backwards compatible):
  * All middlewares inherit from the same `Faraday::Middleware` class.
  * Adds new `on_request` helper so basic middlewares (request and response) don't need to override `call` anymore.
  * Refactor existing middlewares to reflect this change.
* Updates UPGRADING.md with all breaking changes.

Fixes #47 once and for all!
Fixes #517

## Additional Notes
Review welcome from @olleolleolle 
Cc: @mislav (just in case you want to have a look 😄 