### PR TITLE
Separate Request and Response bodies

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,6 +13,10 @@ Please note `Faraday::ClientError` was previously used for both.
   * Faraday::ProxyAuthError (407). Please note this raised a `Faraday::ConnectionFailed` before.
   * Faraday::UnprocessableEntityError (422)
 
+### Custom adapters
+If you have written a custom adapter, please be aware that `env.body` is now an alias to the two new properties `request_body` and `response_body`.
+This should work without you noticing if your adapter inherits from `Faraday::Adapter` and calls `save_response`, but if it doesn't, then please ensure you set the `status` BEFORE the `body` while processing the response.
+
 ### Others
 * Dropped support for jruby and Rubinius.
 * Officially supports Ruby 2.3+

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -81,7 +81,7 @@ module Faraday
 
     # because @on_complete_callbacks cannot be marshalled
     def marshal_dump
-      !finished? ? nil : to_hash
+      finished? ? to_hash : nil
     end
 
     def marshal_load(env)

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -31,8 +31,6 @@ module Faraday
 
     attr_reader :env
 
-    def_delegators :env, :to_hash
-
     def status
       finished? ? env.status : nil
     end
@@ -74,12 +72,16 @@ module Faraday
       finished? && env.success?
     end
 
+    def to_hash
+      {
+        :status => env.status, :body => env.body,
+        :response_headers => env.response_headers
+      }
+    end
+
     # because @on_complete_callbacks cannot be marshalled
     def marshal_dump
-      !finished? ? nil : {
-        :status => @env.status, :body => @env.body,
-        :response_headers => @env.response_headers
-      }
+      !finished? ? nil : to_hash
     end
 
     def marshal_load(env)

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Faraday::Adapter::NetHttp do
-  # features :body_on_get, :reason_phrase_parse, :compression, :streaming
+  features :body_on_get, :reason_phrase_parse, :compression, :streaming
 
   it_behaves_like 'an adapter'
 

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Faraday::Adapter::NetHttp do
-  features :body_on_get, :reason_phrase_parse, :compression, :streaming
+  # features :body_on_get, :reason_phrase_parse, :compression, :streaming
 
   it_behaves_like 'an adapter'
 

--- a/spec/faraday/options/env_spec.rb
+++ b/spec/faraday/options/env_spec.rb
@@ -1,20 +1,22 @@
 RSpec.describe Faraday::Env do
+  subject(:env) { described_class.new }
+
   it 'allows to access members' do
-    expect(subject.method).to be_nil
-    subject.method = :get
-    expect(subject.method).to eq(:get)
+    expect(env.method).to be_nil
+    env.method = :get
+    expect(env.method).to eq(:get)
   end
 
   it 'allows to access symbol non members' do
-    expect(subject[:custom]).to be_nil
-    subject[:custom] = :boom
-    expect(subject[:custom]).to eq(:boom)
+    expect(env[:custom]).to be_nil
+    env[:custom] = :boom
+    expect(env[:custom]).to eq(:boom)
   end
 
   it 'allows to access string non members' do
-    expect(subject['custom']).to be_nil
-    subject['custom'] = :boom
-    expect(subject['custom']).to eq(:boom)
+    expect(env['custom']).to be_nil
+    env['custom'] = :boom
+    expect(env['custom']).to eq(:boom)
   end
 
   it 'ignores false when fetching' do
@@ -24,42 +26,42 @@ RSpec.describe Faraday::Env do
   end
 
   it 'retains custom members' do
-    subject[:foo] = "custom 1"
-    subject[:bar] = :custom_2
-    env2 = Faraday::Env.from(subject)
+    env[:foo] = "custom 1"
+    env[:bar] = :custom_2
+    env2 = Faraday::Env.from(env)
     env2[:baz] = "custom 3"
 
     expect(env2[:foo]).to eq("custom 1")
     expect(env2[:bar]).to eq(:custom_2)
-    expect(subject[:baz]).to be_nil
+    expect(env[:baz]).to be_nil
   end
 
   describe '#body' do
-    subject { Faraday::Env.from(body: { foo: 'bar' }) }
+    subject(:env) { described_class.from(body: { foo: 'bar' }) }
 
     context 'when response is not finished yet' do
       it 'returns the request body' do
-        expect(subject.body).to eq({ foo: 'bar' })
+        expect(env.body).to eq({ foo: 'bar' })
       end
     end
 
     context 'when response is finished' do
       before do
-        subject.status = 200
-        subject.body = { bar: 'foo' }
-        subject.response = Faraday::Response.new(subject)
+        env.status = 200
+        env.body = { bar: 'foo' }
+        env.response = Faraday::Response.new(env)
       end
 
       it 'returns the response body' do
-        expect(subject.body).to eq({ bar: 'foo' })
+        expect(env.body).to eq({ bar: 'foo' })
       end
 
       it 'allows to access request_body' do
-        expect(subject.request_body).to eq({ foo: 'bar' })
+        expect(env.request_body).to eq({ foo: 'bar' })
       end
 
       it 'allows to access response_body' do
-        expect(subject.response_body).to eq({ bar: 'foo' })
+        expect(env.response_body).to eq({ bar: 'foo' })
       end
     end
   end

--- a/spec/faraday/options/env_spec.rb
+++ b/spec/faraday/options/env_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe Faraday::Env do
-  subject { Faraday::Env.new }
   it 'allows to access members' do
     expect(subject.method).to be_nil
     subject.method = :get
@@ -33,5 +32,35 @@ RSpec.describe Faraday::Env do
     expect(env2[:foo]).to eq("custom 1")
     expect(env2[:bar]).to eq(:custom_2)
     expect(subject[:baz]).to be_nil
+  end
+
+  describe '#body' do
+    subject { Faraday::Env.from(body: { foo: 'bar' }) }
+
+    context 'when response is not finished yet' do
+      it 'returns the request body' do
+        expect(subject.body).to eq({ foo: 'bar' })
+      end
+    end
+
+    context 'when response is finished' do
+      before do
+        subject.status = 200
+        subject.body = { bar: 'foo' }
+        subject.response = Faraday::Response.new(subject)
+      end
+
+      it 'returns the response body' do
+        expect(subject.body).to eq({ bar: 'foo' })
+      end
+
+      it 'allows to access request_body' do
+        expect(subject.request_body).to eq({ foo: 'bar' })
+      end
+
+      it 'allows to access response_body' do
+        expect(subject.response_body).to eq({ bar: 'foo' })
+      end
+    end
   end
 end

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe Faraday::Response do
     let(:hash) { subject.to_hash }
 
     it { expect(hash).to be_a(Hash) }
-    it { expect(hash).to eq(env.to_hash) }
     it { expect(hash[:status]).to eq(subject.status) }
     it { expect(hash[:response_headers]).to eq(subject.headers) }
     it { expect(hash[:body]).to eq(subject.body) }

--- a/spec/support/shared_examples/request_method.rb
+++ b/spec/support/shared_examples/request_method.rb
@@ -167,7 +167,6 @@ shared_examples 'a request method' do |http_method|
   it 'handles requests with proxy' do
     conn_options[:proxy] = 'http://google.co.uk'
 
-    # binding.pry
     res = conn.public_send(http_method, '/')
     expect(res.status).to eq(200)
   end


### PR DESCRIPTION
## Description
Separates request and response bodies in `Faraday::Env`.
Adds methods and hacks for backwards compatibility.
Fixes #517