### PR TITLE
Differentiate request vs. response body

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -292,9 +292,32 @@ module Faraday
       env
     end
 
+    def request_body
+      if defined?(@request_body)
+        @request_body
+      else
+        body
+      end
+    end
+
+    def response_body
+      if defined?(@request_body)
+        body
+      else
+        nil
+      end
+    end
+
+    def status=(value)
+      @request_body = self[:body] unless defined?(@request_body)
+      super
+    end
+
     # Public
     def [](key)
-      if in_member_set?(key)
+      if key == :request_body || key == :response_body
+        send(key)
+      elsif in_member_set?(key)
         super(key)
       else
         custom_members[key]
@@ -303,7 +326,9 @@ module Faraday
 
     # Public
     def []=(key, value)
-      if in_member_set?(key)
+      if key == :status
+        send(:status=, value)
+      elsif in_member_set?(key)
         super(key, value)
       else
         custom_members[key] = value


### PR DESCRIPTION
After `status` has been written for the first time, treat `env[:body]` as response body and save the previous value as request body.

```
$ RUBYLIB=./lib irb -rfaraday
>> env = Faraday::Env.from :body => 'REQUEST'
>> p env.request_body; env.response_body
"REQUEST"
nil
>> env[:status] = 200
>> env[:body] = 'RESPONSE'
>> p env.request_body; env.response_body
"REQUEST"
"RESPONSE"
```