### PR TITLE
Gemspec: Required Ruby >=2.3

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/faraday'
   spec.licenses = ['MIT']
 
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
 


### PR DESCRIPTION
## Description

Ruby 2.2 was EOL in 2018.

We are already using safe navigation in some specs.

This PR changes the required Ruby version to 2.3.
