### PR TITLE
add magic header keys to specify request body or url params

### DIFF
--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -587,10 +587,26 @@ RSpec.describe Faraday::Connection do
 
       it 'allows to override all params' do
         stubbed = stub_request(:get, 'http://example.com?b=b')
-        conn.get('?p=1&a=a', p: 2) do |req|
+        conn.get('?p=1&up=1&a=a', p: 2) do |req|
           expect(req.params[:a]).to eq('a')
           expect(req.params['c']).to eq(3)
           expect(req.params['p']).to eq(2)
+          req.params = { :b => 'b' }
+          expect(req.params['b']).to eq('b')
+        end
+        expect(stubbed).to have_been_made.once
+      end
+
+      it 'allows to override all params and headers' do
+        stubbed = stub_request(:get, 'http://example.com?b=b')
+        conn.get('?p=1&up=1&a=a', {p: 2, up: 2}, body: 'body', url_params: { up: 3 }) do |req|
+          expect(req.params[:a]).to eq('a')
+          expect(req.params['c']).to eq(3)
+          expect(req.params['p']).to eq(2)
+          expect(req.params['up']).to eq(3)
+          expect(req.params['body']).to be(nil)
+          expect(req.params['url_params']).to be(nil)
+          expect(req.body).to eq('body')
           req.params = { :b => 'b' }
           expect(req.params['b']).to eq('b')
         end


### PR DESCRIPTION
This implements this suggestion (https://github.com/lostisland/faraday/issues/693#issuecomment-305429333) to support a more convenient way to specify a request body for request verbs that typically do not have them (GET, DELETE, etc).

```ruby
conn = Faraday.new(...) # note no special config here
conn.get(path, url_params, body: {...})
# second parameter is URL PARAMS, optionally accept a named parameter for request body
# works the same for head and delete

conn = Faraday.new(...) # note no special config here
conn.post(path, body, url_params: {...})
# second parameter is REQUEST BODY, optionally accept a named parameter for url_params
# works the same for put and patch
```

I have some issues with this approach that I'll describe in code review comments. I don't like this approach, and would prefer people use the block syntax in these cases:

```ruby
conn.get(path) do |req|
  req.body = "BOOYA"
end

conn.post(path, body) do |req|
  req.params[:a] = 1
  req.params.update(params)
  # whatever makes sense for your usecase
end
```