### PR TITLE
implement #options.

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -163,12 +163,35 @@ module Faraday
     METHODS_WITH_QUERY.each do |method|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{method}(url = nil, params = nil, headers = nil)
-          run_request(:#{method}, url, nil, headers) { |request|
+          run_request(:#{method}, url, nil, headers) do |request|
             request.params.update(params) if params
-            yield(request) if block_given?
-          }
+            yield request if block_given?
+          end
         end
       RUBY
+    end
+
+    # @!method options(url = nil, params = nil, headers = nil)
+    # Makes an OPTIONS HTTP request without a body.
+    # @!scope class
+    #
+    # @param url [String] The optional String base URL to use as a prefix for all
+    #           requests.  Can also be the options Hash.
+    # @param params [Hash] Hash of URI query unencoded key/value pairs.
+    # @param headers [Hash] unencoded HTTP header key/value pairs.
+    #
+    # @example
+    #   conn.options '/items/1'
+    #
+    # @yield [Faraday::Request] for further request customizations
+    # @return [Faraday::Response]
+    def options(*args)
+      return @options if args.size.zero?
+      url, params, headers = *args
+      run_request(:options, url, nil, headers) do |request|
+        request.params.update(params) if params
+        yield request if block_given?
+      end
     end
 
     # @!method post(url = nil, body = nil, headers = nil)

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -611,6 +611,26 @@ RSpec.describe Faraday::Connection do
       end
     end
 
+    context 'with options' do
+      let(:url) { 'http://example.com' }
+
+      it 'returns connection options with no args' do
+        expect(conn.options).to be_a(Faraday::Options)
+      end
+
+      it 'makes request with path' do
+        stubbed = stub_request(:options, 'http://example.com/a?a=1')
+        conn.options('/a', a: 1)
+        expect(stubbed).to have_been_made.once
+      end
+
+      it 'makes request with nil path' do
+        stubbed = stub_request(:options, 'http://example.com')
+        conn.options(nil)
+        expect(stubbed).to have_been_made.once
+      end
+    end
+
     context 'with default params encoder' do
       let!(:stubbed) { stub_request(:get, 'http://example.com?color%5B%5D=red&color%5B%5D=blue') }
       after { expect(stubbed).to have_been_made.once }


### PR DESCRIPTION
This implements `Faraday::Connection#options` _almost_ as expected, fixing https://github.com/lostisland/faraday/issues/305.

We can't rename [the current `:options attr_reader`](https://github.com/lostisland/faraday/blob/63918ee8f00ab92f2c2ff7a434eb67e6ae151b76/lib/faraday/connection.rb#L30-L31) right now for backwards compatibility reasons. Instead, this overloads the method to support both use cases. Merging the two risks some clashing, but I can only think of one issue: the other request helpers like `#get` can be called with no arguments:

```ruby
conn = Faraday.new 'http://example.com'
conn.get # GET /
conn.options # oops!
```

You can get around this easily with `conn.options(nil)`. I think it's worth introducing this regardless of the risk, assuming we'll rip it out when v1.0 ships.