### PR TITLE
Fix rubocop issues from #861

### DIFF
--- a/spec/support/shared_examples/adapter.rb
+++ b/spec/support/shared_examples/adapter.rb
@@ -79,7 +79,7 @@ shared_examples 'adapter examples' do |**options|
   end
 
   describe '#options' do
-   let(:http_method) { :options }
+    let(:http_method) { :options }
 
     it_behaves_like 'a request method', :options
   end
@@ -104,7 +104,7 @@ shared_examples 'adapter examples' do |**options|
 
   on_feature :trace_method do
     describe '#trace' do
-     let(:http_method) { :trace }
+      let(:http_method) { :trace }
 
       it_behaves_like 'a request method', :trace
     end


### PR DESCRIPTION
Goal is to fix the rubocop failures in master that came from #861:

```
spec/support/shared_examples/request_method.rb:53:9: C: Layout/IndentationWidth: Use 2 (not -4) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
        conn.public_send(http_method, '/', 'test')
        ^^^^
spec/support/shared_examples/request_method.rb:54:7: C: Layout/ElseAlignment: Align else with if.
      else
      ^^^^
spec/support/shared_examples/request_method.rb:58:7: W: Layout/EndAlignment: end at 58, 6 is not aligned with if at 52, 12.
      end
      ^^^
spec/support/shared_examples/adapter.rb:82:3: C: Layout/IndentationWidth: Use 2 (not 1) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
   let(:http_method) { :options }
  ^
spec/support/shared_examples/adapter.rb:84:5: C: Layout/IndentationConsistency: Inconsistent indentation detected. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
    it_behaves_like 'a request method', :options
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/support/shared_examples/adapter.rb:107:5: C: Layout/IndentationWidth: Use 2 (not 1) spaces for indentation. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
     let(:http_method) { :trace }
    ^
spec/support/shared_examples/adapter.rb:109:7: C: Layout/IndentationConsistency: Inconsistent indentation detected. (https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation)
      it_behaves_like 'a request method', :trace
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```