### PR TITLE
CI: RuboCop as a Build Stage before tests run

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,4 @@
 version: "2"
 plugins:
   rubocop:
-    enabled: true
-
+    enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,24 @@
 language: ruby
 cache: bundler
+
 rvm:
   - 2.3
   - 2.4
   - 2.5
   - 2.6
   - ruby-head
+
+jobs:
+  include:
+    - stage: linting
+      rvm: ruby-2.4.1 # Pre-installed on TravisCI
+      install: true # Do not bundle install
+      script: gem install rubocop --no-document && rubocop
+
+stages:
+  - linting
+  - test
+
 deploy:
   provider: rubygems
   api_key:
@@ -15,4 +28,3 @@ deploy:
     tags: true
     repo: lostisland/faraday
     rvm: 2.5
-

--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,10 @@
 
 require 'rake/testtask'
 
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
+
 task :default => :test
 
 desc "Run all tests"
-task :test do
-  exec 'rspec'
-end
+task :test => [:spec]


### PR DESCRIPTION
## Description

~This PR frontloads RuboCop checks onto the default Rake task.~

This PR adds a TravisCI Build Stage `linting`, which installs `rubocop` and runs it.

If that stage fails, no virtual machines with the RSpec tests are even booted.

We use this way, in order to keep up with latest RuboCop releases, since CodeClimate's built-in is a good few versions behind.