### PR TITLE
remove some unused gems from Bundler group: :test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,18 +13,15 @@ group :development, :test do
 end
 
 group :test do
-  gem 'addressable', '< 2.4.0'
   gem 'coveralls', :require => false
   gem 'em-http-request', '>= 1.1', :require => 'em-http'
   gem 'em-synchrony', '>= 1.0.3', :require => ['em-synchrony', 'em-synchrony/em-http']
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
-  gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
   gem 'minitest', '>= 5.0.5'
   gem 'net-http-persistent'
   gem 'patron', '>= 0.4.2', :platforms => :ruby
   gem 'rack-test', '>= 0.6', :require => 'rack/test'
-  gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]
   gem 'rspec', '~> 3.7'
   gem 'rubocop', '~> 0.65.0'
   gem 'simplecov'
@@ -34,4 +31,3 @@ group :test do
 end
 
 gemspec
-


### PR DESCRIPTION
This removes some unused gems from `Gemfile` that are still test dependencies of Faraday for some reason.

* `addressable` is a dependency of webmock and EM HTTP Client so it'll still be used in tests.
* `mime-types` isn't used anymore.
* `rest-client` isn't used anymore, AND has a security issue in the version specified in Gemfile.