### PR TITLE
Fix: Configure Travis to build branches only on master and 0.1x branches - this avoids double builds on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ stages:
   - linting
   - test
 
+branches:
+  only:
+    - master
+    - 0.1x
+
 deploy:
   provider: rubygems
   api_key:


### PR DESCRIPTION
## Description
Limits Travis builds to PRs and pushes/merges against master and 0.1x branches.
This should fix the double-build on all PRs.