### PR TITLE
Rubocop style

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -83,17 +83,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 21
 
-# Offense count: 13
-# Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
-# AllowedNames: io, id, to, by, on, in, at, ip, db
-Naming/UncommunicativeMethodParamName:
-  Exclude:
-    - 'lib/faraday/error.rb'
-    - 'lib/faraday/utils.rb'
-    - 'lib/faraday/utils/headers.rb'
-    - 'script/generate_certs'
-    - 'spec/spec_helper.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Performance/RedundantBlockCall:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -83,12 +83,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 21
 
-# Offense count: 4
-Naming/ConstantName:
-  Exclude:
-    - 'lib/faraday/options/env.rb'
-    - 'lib/faraday/response/raise_error.rb'
-
 # Offense count: 2
 # Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist, MethodDefinitionMacros.
 # NamePrefix: is_, has_, have_

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -83,12 +83,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 21
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/RedundantBlockCall:
-  Exclude:
-    - 'lib/faraday/request/multipart.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Performance/StringReplacement:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -83,14 +83,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 21
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Performance/StringReplacement:
-  Exclude:
-    - 'lib/faraday/encoders/flat_params_encoder.rb'
-    - 'lib/faraday/encoders/nested_params_encoder.rb'
-    - 'lib/faraday/request/basic_authentication.rb'
-
 # Offense count: 13
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -126,16 +126,6 @@ Performance/StringReplacement:
     - 'lib/faraday/encoders/nested_params_encoder.rb'
     - 'lib/faraday/request/basic_authentication.rb'
 
-# Offense count: 9
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: prefer_alias, prefer_alias_method
-Style/Alias:
-  Exclude:
-    - 'lib/faraday/rack_builder.rb'
-    - 'lib/faraday/utils/headers.rb'
-    - 'lib/faraday/utils/params_hash.rb'
-
 # Offense count: 24
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -126,23 +126,6 @@ Performance/StringReplacement:
     - 'lib/faraday/encoders/nested_params_encoder.rb'
     - 'lib/faraday/request/basic_authentication.rb'
 
-# Offense count: 24
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, conditionals
-Style/AndOr:
-  Exclude:
-    - 'lib/faraday/adapter/em_http.rb'
-    - 'lib/faraday/adapter/net_http.rb'
-    - 'lib/faraday/adapter/patron.rb'
-    - 'lib/faraday/connection.rb'
-    - 'lib/faraday/request/multipart.rb'
-    - 'lib/faraday/request/url_encoded.rb'
-    - 'lib/faraday/utils.rb'
-    - 'spec/support/helper_methods.rb'
-    - 'test/adapters/em_http_test.rb'
-    - 'test/helper.rb'
-
 # Offense count: 13
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods.
@@ -452,11 +435,10 @@ Style/NilComparison:
     - 'lib/faraday/encoders/flat_params_encoder.rb'
     - 'lib/faraday/encoders/nested_params_encoder.rb'
 
-# Offense count: 2
+# Offense count: 1
 # Cop supports --auto-correct.
 Style/Not:
   Exclude:
-    - 'lib/faraday/adapter/em_http.rb'
     - 'lib/faraday/response.rb'
 
 # Offense count: 7

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -126,13 +126,6 @@ Performance/StringReplacement:
     - 'lib/faraday/encoders/nested_params_encoder.rb'
     - 'lib/faraday/request/basic_authentication.rb'
 
-# Offense count: 1
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: inline, group
-Style/AccessModifierDeclarations:
-  Exclude:
-    - 'lib/faraday/dependency_loader.rb'
-
 # Offense count: 9
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -83,18 +83,6 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 21
 
-# Offense count: 2
-# Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist, MethodDefinitionMacros.
-# NamePrefix: is_, has_, have_
-# NamePrefixBlacklist: is_, has_, have_
-# NameWhitelist: is_a?
-# MethodDefinitionMacros: define_method, define_singleton_method
-Naming/PredicateName:
-  Exclude:
-    - 'spec/**/*'
-    - 'lib/faraday/rack_builder.rb'
-    - 'lib/faraday/request/multipart.rb'
-
 # Offense count: 13
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: io, id, to, by, on, in, at, ip, db

--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -73,7 +73,7 @@ module Faraday
 
         # Reads out compression header settings from env into options
         def configure_compression(options, env)
-          if env[:method] == :get and not options[:head].key? 'accept-encoding'
+          if (env[:method] == :get) && !options[:head].key?('accept-encoding')
             options[:head]['accept-encoding'] = 'gzip, compressed'
           end
         end
@@ -168,7 +168,7 @@ module Faraday
       end
 
       def error_message(client)
-        client.error or 'request failed'
+        client.error || 'request failed'
       end
 
       def raise_error(msg)

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -39,7 +39,7 @@ module Faraday
       def call(env)
         super
         with_net_http_connection(env) do |http|
-          configure_ssl(http, env[:ssl]) if env[:url].scheme == 'https' and env[:ssl]
+          configure_ssl(http, env[:ssl]) if (env[:url].scheme == 'https') && env[:ssl]
           configure_request(http, env[:request])
 
           begin
@@ -103,7 +103,7 @@ module Faraday
       end
 
       def perform_request_with_wrapped_block(http, env, &block)
-        if :get == env[:method] and !env[:body]
+        if (:get == env[:method]) && !env[:body]
           # prefer `get` to `request` because the former handles gzip (ruby 1.9)
           request_via_get_method(http, env, &block)
         else

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -13,7 +13,7 @@ module Faraday
 
         session = ::Patron::Session.new
         @config_block.call(session) if @config_block
-        configure_ssl(session, env[:ssl]) if env[:url].scheme == 'https' and env[:ssl]
+        configure_ssl(session, env[:ssl]) if (env[:url].scheme == 'https') && env[:ssl]
 
         if (req = env[:request])
           session.timeout = session.connect_timeout = req[:timeout] if req[:timeout]

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -344,7 +344,7 @@ module Faraday
       @default_parallel_manager ||= begin
         adapter = @builder.adapter.klass if @builder.adapter
 
-        if adapter and adapter.respond_to?(:supports_parallel?) and adapter.supports_parallel?
+        if adapter && adapter.respond_to?(:supports_parallel?) && adapter.supports_parallel?
           adapter.setup_parallel_manager
         elsif block_given?
           yield
@@ -508,15 +508,15 @@ module Faraday
     #
     # @return [URI]
     def build_exclusive_url(url = nil, params = nil, params_encoder = nil)
-      url = nil if url.respond_to?(:empty?) and url.empty?
+      url = nil if url.respond_to?(:empty?) && url.empty?
       base = url_prefix
-      if url and base.path and base.path !~ /\/$/
+      if url && base.path && base.path !~ /\/$/
         base = base.dup
         base.path = base.path + '/' # ensure trailing slash
       end
       uri = url ? base + url : base
       uri.query = params.to_query(params_encoder || options.params_encoder) if params
-      uri.query = nil if uri.query and uri.query.empty?
+      uri.query = nil if uri.query && uri.query.empty?
       uri
     end
 
@@ -543,7 +543,7 @@ module Faraday
     # @return [void]
     # @api private
     def with_uri_credentials(uri)
-      if uri.user and uri.password
+      if uri.user && uri.password
         yield(Utils.unescape(uri.user), Utils.unescape(uri.password))
       end
     end

--- a/lib/faraday/dependency_loader.rb
+++ b/lib/faraday/dependency_loader.rb
@@ -2,8 +2,7 @@
 
 module Faraday
   module DependencyLoader
-    attr_accessor :load_error
-    private :load_error=
+    attr_reader :load_error
 
     # Executes a block which should try to require and reference dependent libraries
     def dependency(lib = nil)
@@ -26,5 +25,9 @@ module Faraday
       super
       subclass.send(:load_error=, load_error)
     end
+
+    private
+
+    attr_writer :load_error
   end
 end

--- a/lib/faraday/encoders/flat_params_encoder.rb
+++ b/lib/faraday/encoders/flat_params_encoder.rb
@@ -56,7 +56,7 @@ module Faraday
         pair[0] = unescape(pair[0])
         pair[1] = true if pair[1].nil?
         if pair[1].respond_to?(:to_str)
-          pair[1] = unescape(pair[1].to_str.gsub(/\+/, ' '))
+          pair[1] = unescape(pair[1].to_str.tr('+', ' '))
         end
         if accu[pair[0]].kind_of?(Array)
           accu[pair[0]] << pair[1]

--- a/lib/faraday/encoders/nested_params_encoder.rb
+++ b/lib/faraday/encoders/nested_params_encoder.rb
@@ -87,7 +87,7 @@ module Faraday
 
         key, value = pair.split('=', 2)
         key = unescape(key)
-        value = unescape(value.gsub(/\+/, ' ')) if value
+        value = unescape(value.tr('+', ' ')) if value
 
         subkeys = key.scan(/[^\[\]]+(?:\]?\[\])?/)
         context = params

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -5,18 +5,18 @@ module Faraday
   class Error < StandardError
     attr_reader :response, :wrapped_exception
 
-    def initialize(ex, response = nil)
+    def initialize(exc, response = nil)
       @wrapped_exception = nil
       @response = response
 
-      if ex.respond_to?(:backtrace)
-        super(ex.message)
-        @wrapped_exception = ex
-      elsif ex.respond_to?(:each_key)
-        super("the server responded with status #{ex[:status]}")
-        @response = ex
+      if exc.respond_to?(:backtrace)
+        super(exc.message)
+        @wrapped_exception = exc
+      elsif exc.respond_to?(:each_key)
+        super("the server responded with status #{exc[:status]}")
+        @response = exc
       else
-        super(ex.to_s)
+        super(exc.to_s)
       end
     end
 
@@ -77,8 +77,8 @@ module Faraday
 
   # A unified client error for timeouts.
   class TimeoutError < ServerError
-    def initialize(ex = 'timeout', response = nil)
-      super(ex, response)
+    def initialize(exc = 'timeout', response = nil)
+      super(exc, response)
     end
   end
 

--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -49,9 +49,11 @@ module Faraday
                           :ssl, :parallel_manager, :params, :response, :response_headers, :status,
                           :reason_phrase, :response_body)
 
+    # rubocop:disable Naming/ConstantName
     ContentLength = 'Content-Length'
     StatusesWithoutBody = Set.new [204, 304]
     SuccessfulStatuses = 200..299
+    # rubocop:enable Naming/ConstantName
 
     # A Set of HTTP verbs that typically send a body.  If no body is set for
     # these requests, the Content-Length header is set to 0.

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -123,7 +123,7 @@ module Faraday
       @handlers.insert(index, handler)
     end
 
-    alias_method :insert_before, :insert
+    alias insert_before insert
 
     def insert_after(index, *args, &block)
       index = assert_index(index)

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -218,7 +218,7 @@ module Faraday
       !@adapter.nil?
     end
 
-    def is_adapter?(klass)
+    def is_adapter?(klass) # rubocop:disable Naming/PredicateName
       klass.ancestors.include?(Faraday::Adapter)
     end
 

--- a/lib/faraday/request/basic_authentication.rb
+++ b/lib/faraday/request/basic_authentication.rb
@@ -11,7 +11,7 @@ module Faraday
     # @return [String] a Basic Authentication header line
     def self.header(login, pass)
       value = Base64.encode64([login, pass].join(':'))
-      value.gsub!("\n", '')
+      value.delete!("\n")
       super(:Basic, value)
     end
   end

--- a/lib/faraday/request/multipart.rb
+++ b/lib/faraday/request/multipart.rb
@@ -24,9 +24,9 @@ module Faraday
     # @param env [Faraday::Env]
     def process_request?(env)
       type = request_type(env)
-      env.body.respond_to?(:each_key) and !env.body.empty? and (
-        (type.empty? and has_multipart?(env.body)) or
-        type == self.class.mime_type
+      env.body.respond_to?(:each_key) && !env.body.empty? && (
+        (type.empty? && has_multipart?(env.body)) ||
+        (type == self.class.mime_type)
       )
     end
 

--- a/lib/faraday/request/multipart.rb
+++ b/lib/faraday/request/multipart.rb
@@ -76,7 +76,9 @@ module Faraday
         when Hash
           process_params(value, key, all, &block)
         else
+          # rubocop:disable Performance/RedundantBlockCall
           all << block.call(key, value)
+          # rubocop:enable Performance/RedundantBlockCall
         end
       end
     end

--- a/lib/faraday/request/multipart.rb
+++ b/lib/faraday/request/multipart.rb
@@ -34,7 +34,7 @@ module Faraday
     #
     # @param obj [Object]
     # @return [Boolean]
-    def has_multipart?(obj)
+    def has_multipart?(obj) # rubocop:disable Naming/PredicateName
       if obj.respond_to?(:each)
         (obj.respond_to?(:values) ? obj.values : obj).each do |val|
           return true if (val.respond_to?(:content_type) || has_multipart?(val))

--- a/lib/faraday/request/url_encoded.rb
+++ b/lib/faraday/request/url_encoded.rb
@@ -37,7 +37,7 @@ module Faraday
     #                   urlencoded.
     def process_request?(env)
       type = request_type(env)
-      env.body and (type.empty? or type == self.class.mime_type)
+      env.body && (type.empty? || (type == self.class.mime_type))
     end
 
     # @param env [Faraday::Env]

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -2,8 +2,8 @@
 
 module Faraday
   class Response::RaiseError < Response::Middleware
-    ClientErrorStatuses = 400...500
-    ServerErrorStatuses = 500...600
+    ClientErrorStatuses = 400...500 # rubocop:disable Naming/ConstantName
+    ServerErrorStatuses = 500...600 # rubocop:disable Naming/ConstantName
 
     def on_complete(env)
       case env[:status]

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -19,13 +19,13 @@ module Faraday
 
     ESCAPE_RE = /[^a-zA-Z0-9 .~_-]/
 
-    def escape(s)
-      s.to_s.gsub(ESCAPE_RE) { |match|
+    def escape(str)
+      str.to_s.gsub(ESCAPE_RE) { |match|
         '%' + match.unpack('H2' * match.bytesize).join('%').upcase
       }.tr(' ', '+')
     end
 
-    def unescape(s) CGI.unescape s.to_s end
+    def unescape(str) CGI.unescape str.to_s end
 
     DEFAULT_SEP = /[&;] */n
 

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -86,7 +86,7 @@ module Faraday
     # Recursive hash update
     def deep_merge!(target, hash)
       hash.each do |key, value|
-        if Hash === value and Hash === target[key]
+        if (Hash === value) && (Hash === target[key])
           target[key] = deep_merge(target[key], value)
         else
           target[key] = value

--- a/lib/faraday/utils/headers.rb
+++ b/lib/faraday/utils/headers.rb
@@ -49,35 +49,35 @@ module Faraday
       end
       KeyMap[:etag] = 'ETag'
 
-      def [](k)
-        k = KeyMap[k]
-        super(k) || super(@names[k.downcase])
+      def [](key)
+        key = KeyMap[key]
+        super(key) || super(@names[key.downcase])
       end
 
-      def []=(k, v)
-        k = KeyMap[k]
-        k = (@names[k.downcase] ||= k)
+      def []=(key, val)
+        key = KeyMap[key]
+        key = (@names[key.downcase] ||= key)
         # join multiple values with a comma
-        v = v.to_ary.join(', ') if v.respond_to? :to_ary
-        super(k, v)
+        val = val.to_ary.join(', ') if val.respond_to?(:to_ary)
+        super(key, val)
       end
 
-      def fetch(k, *args, &block)
-        k = KeyMap[k]
-        key = @names.fetch(k.downcase, k)
+      def fetch(key, *args, &block)
+        key = KeyMap[key]
+        key = @names.fetch(key.downcase, key)
         super(key, *args, &block)
       end
 
-      def delete(k)
-        k = KeyMap[k]
-        if (k = @names[k.downcase])
-          @names.delete k.downcase
-          super(k)
+      def delete(key)
+        key = KeyMap[key]
+        if (key = @names[key.downcase])
+          @names.delete key.downcase
+          super(key)
         end
       end
 
-      def include?(k)
-        @names.include? k.downcase
+      def include?(key)
+        @names.include? key.downcase
       end
 
       alias has_key? include?

--- a/lib/faraday/utils/headers.rb
+++ b/lib/faraday/utils/headers.rb
@@ -80,16 +80,16 @@ module Faraday
         @names.include? k.downcase
       end
 
-      alias_method :has_key?, :include?
-      alias_method :member?, :include?
-      alias_method :key?, :include?
+      alias has_key? include?
+      alias member? include?
+      alias key? include?
 
       def merge!(other)
         other.each { |k, v| self[k] = v }
         self
       end
 
-      alias_method :update, :merge!
+      alias update merge!
 
       def merge(other)
         hash = dup

--- a/lib/faraday/utils/params_hash.rb
+++ b/lib/faraday/utils/params_hash.rb
@@ -20,9 +20,9 @@ module Faraday
         super(convert_key(key))
       end
 
-      alias_method :has_key?, :include?
-      alias_method :member?, :include?
-      alias_method :key?, :include?
+      alias has_key? include?
+      alias member? include?
+      alias key? include?
 
       def update(params)
         params.each do |key, value|
@@ -30,7 +30,7 @@ module Faraday
         end
         self
       end
-      alias_method :merge!, :update
+      alias merge! update
 
       def merge(params)
         dup.update(params)

--- a/script/generate_certs
+++ b/script/generate_certs
@@ -11,12 +11,12 @@ $shell = ARGV.include? '-s'
 
 # Adapted from WEBrick::Utils. Skips cert extensions so it
 # can be used as a CA bundle
-def create_self_signed_cert(bits, cn, comment)
+def create_self_signed_cert(bits, cname, comment)
   rsa = OpenSSL::PKey::RSA.new(bits)
   cert = OpenSSL::X509::Certificate.new
   cert.version = 2
   cert.serial = 1
-  name = OpenSSL::X509::Name.new(cn)
+  name = OpenSSL::X509::Name.new(cname)
   cert.subject = name
   cert.issuer = name
   cert.not_before = Time.now

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,10 +120,10 @@ end
 
 # Extends RSpec DocumentationFormatter to hide skipped tests.
 module FormatterOverrides
-  def example_pending(_)
+  def example_pending(_arg)
   end
 
-  def dump_pending(_)
+  def dump_pending(_arg)
   end
 
   RSpec::Core::Formatters::DocumentationFormatter.prepend self

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -15,7 +15,7 @@ module Faraday
         if @features.nil?
           superclass.on_feature(name, &block) if superclass.respond_to?(:on_feature)
         else
-          yield if block_given? and @features.include?(name)
+          yield if block_given? && @features.include?(name)
         end
       end
 

--- a/test/adapters/em_http_test.rb
+++ b/test/adapters/em_http_test.rb
@@ -15,7 +15,7 @@ module Adapters
         conn = create_connection request: { bind: { host: host } }
         assert_equal host, conn.options[:bind][:host]
       end
-    end unless jruby? and ssl_mode?
+    end unless jruby? && ssl_mode?
     # https://github.com/eventmachine/eventmachine/issues/180
 
     def test_custom_adapter_config

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -36,7 +36,7 @@ module Faraday
 
     # Returns an object that responds to `host` and `port`.
     def live_server
-      live_server? and @@live_server
+      live_server? && @@live_server
     end
   end
 
@@ -59,11 +59,11 @@ module Faraday
     end
 
     def self.jruby?
-      defined? RUBY_ENGINE and 'jruby' == RUBY_ENGINE
+      defined? RUBY_ENGINE && ('jruby' == RUBY_ENGINE)
     end
 
     def self.rbx?
-      defined? RUBY_ENGINE and 'rbx' == RUBY_ENGINE
+      defined? RUBY_ENGINE && ('rbx' == RUBY_ENGINE)
     end
 
     def self.ruby_22_plus?


### PR DESCRIPTION
* Style/AccessModifierDeclarations
* Style/Alias
* Style/AndOr
* Naming/ConstantName
* Naming/PredicateName
* Naming/UncommunicativeMethodParamName
* Performance/StringReplacement
* Performance/RedundantBlockCall

I cheated on a few of these that complain about method or class names. They're disabled in specific spots now, and should probably be fixed up post v1. Let me know if you want me to break this apart for easy reviewing. Each commit is pretty isolated right now.
