### PR TITLE
Improves `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,6 @@ rvm:
   - 2.6
   - ruby-head
 
-before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
-
-after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-
 jobs:
   include:
     - stage: before build
@@ -30,7 +22,7 @@ jobs:
       script: gem install rubocop --no-document && rubocop
     - stage: after build
       rvm: 2.6
-      script: ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+      script: ./cc-test-reporter after-build
     - stage: release
       rvm: 2.6
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,28 +8,48 @@ rvm:
   - 2.6
   - ruby-head
 
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+
 jobs:
   include:
+    - stage: before build
+      rvm: 2.6
+      script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
     - stage: linting
       rvm: ruby-2.4.1 # Pre-installed on TravisCI
       install: true # Do not bundle install
       script: gem install rubocop --no-document && rubocop
+    - stage: after build
+      rvm: 2.6
+      script: ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+    - stage: release
+      rvm: 2.6
+      deploy:
+        provider: rubygems
+        api_key:
+          secure: EqbOu9BQp5jkivJ8qvTo89f3J49KOByBueU3XulrJ2Kqm/ov4RDFsmp9/uHAnSLdmKSkzZaeq79t1AUNfKGX1ZqkKgq/Nw2BKGFnh5ZOjrkrRZR1Vm09OHxqiViEbtg+jZ8VOLY/iDFEkNIzuj9/H3iHGXC0XiKH2LTHOFH63Bs=
+        gem: faraday
+        on:
+          tags: true
+          repo: lostisland/faraday
 
 stages:
+  - before build
   - linting
   - test
+  - after-build
+  - release
 
 branches:
   only:
     - master
     - 0.1x
-
-deploy:
-  provider: rubygems
-  api_key:
-    secure: EqbOu9BQp5jkivJ8qvTo89f3J49KOByBueU3XulrJ2Kqm/ov4RDFsmp9/uHAnSLdmKSkzZaeq79t1AUNfKGX1ZqkKgq/Nw2BKGFnh5ZOjrkrRZR1Vm09OHxqiViEbtg+jZ8VOLY/iDFEkNIzuj9/H3iHGXC0XiKH2LTHOFH63Bs=
-  gem: faraday
-  on:
-    tags: true
-    repo: lostisland/faraday
-    rvm: 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ stages:
   - before build
   - linting
   - test
-  - after-build
+  - after build
   - release
 
 branches:


### PR DESCRIPTION
## Description
* Test Coverage Report is sent to CodeClimate
* Gem release happens on a separate stage

I'm not a Travis CI expert so appreciate your feedback on these changes 😄.
The idea was that I wanted the code climate script to be downloaded and executed only one, not for all `rvm`s.
Also, deployment is currently limited to a singular version thanks to the `on` option, but moving that into a stage allows to use the stage `rvm` option to do the same.