### PR TITLE
CI: Send CodeClimate test reports, deploy to RubyGems on tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ rvm:
   - ruby-head
 
 matrix:
-  include: # Include latest supported Ruby version separately, so we can run custom before/after scripts.
-    - rvm: 2.6
+  include:
+    - rvm: 2.6 # Include latest supported Ruby version separately, so we can run custom before/after scripts.
       before_script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,6 @@ rvm:
   - 2.6
   - ruby-head
 
-before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
-
-after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-
 jobs:
   include:
     - stage: before build
@@ -30,7 +22,7 @@ jobs:
       script: gem install rubocop --no-document && rubocop
     - stage: after build
       rvm: 2.6
-      script: ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+      script: ./cc-test-reporter after-build
     - stage: release
       rvm: 2.6
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,12 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - ruby-head
 
 matrix:
   include:
-    - rvm: 2.6 # Include latest supported Ruby version separately, so we can run custom before/after scripts.
+    - rvm: 2.6 # Run custom before/after scripts for latest supported Ruby version.
       before_script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jobs:
   include:
     - stage: before build
       rvm: 2.6
+      install: true # Do not bundle install
       script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
         - chmod +x ./cc-test-reporter
@@ -22,9 +23,11 @@ jobs:
       script: gem install rubocop --no-document && rubocop
     - stage: after build
       rvm: 2.6
+      install: true # Do not bundle install
       script: ./cc-test-reporter after-build
     - stage: release
       rvm: 2.6
+      install: true # Do not bundle install
       deploy:
         provider: rubygems
         api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 cache:
   bundler: true
-  directories:
-    - tools
 
 rvm:
   - 2.3
@@ -11,27 +9,24 @@ rvm:
   - 2.6
   - ruby-head
 
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+
 jobs:
   include:
-    - stage: before build
-      rvm: 2.6
-      install: true # Do not bundle install
-      script:
-        - mkdir -p tools
-        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > tools/cc-test-reporter
-        - chmod +x tools/cc-test-reporter
-        - tools/cc-test-reporter before-build
     - stage: linting
       rvm: ruby-2.4.1 # Pre-installed on TravisCI
       install: true # Do not bundle install
       script: gem install rubocop --no-document && rubocop
-    - stage: after build
-      rvm: 2.6
-      install: true # Do not bundle install
-      script: tools/cc-test-reporter after-build
     - stage: release
       rvm: 2.6
       install: true # Do not bundle install
+      script: skip
       deploy:
         provider: rubygems
         api_key:
@@ -42,10 +37,8 @@ jobs:
           repo: lostisland/faraday
 
 stages:
-  - before build
   - linting
   - test
-  - after build
   - release
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,17 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-  - 2.6
   - ruby-head
 
-before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
-
-after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+matrix:
+  include: # Include latest supported Ruby version separately, so we can run custom before/after scripts.
+    - rvm: 2.6
+      before_script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
+      after_script:
+        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
       rvm: 2.6
       install: true # Do not bundle install
       script: skip
+      if: tag IS present
       deploy:
         provider: rubygems
         api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
-cache:
-  bundler: true
+cache: bundler
 
 rvm:
   - 2.3
@@ -22,7 +21,7 @@ jobs:
     - stage: latest
       rvm: 2.6 # Run custom before/after scripts for latest supported Ruby version.
       before_script:
-        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - curl -o ./cc-test-reporter -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
         - chmod +x ./cc-test-reporter
         - ./cc-test-reporter before-build
       after_script: ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,28 +8,48 @@ rvm:
   - 2.6
   - ruby-head
 
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+
 jobs:
   include:
+    - stage: before build
+      rvm: 2.6
+      script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
     - stage: linting
       rvm: ruby-2.4.1 # Pre-installed on TravisCI
       install: true # Do not bundle install
       script: gem install rubocop --no-document && rubocop
+    - stage: after build
+      rvm: 2.6
+      script: ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+    - stage: release
+      rvm: 2.6
+      deploy:
+        provider: rubygems
+        api_key:
+          secure: EqbOu9BQp5jkivJ8qvTo89f3J49KOByBueU3XulrJ2Kqm/ov4RDFsmp9/uHAnSLdmKSkzZaeq79t1AUNfKGX1ZqkKgq/Nw2BKGFnh5ZOjrkrRZR1Vm09OHxqiViEbtg+jZ8VOLY/iDFEkNIzuj9/H3iHGXC0XiKH2LTHOFH63Bs=
+        gem: faraday
+        on:
+          tags: true
+          repo: lostisland/faraday
 
 stages:
+  - before build
   - linting
   - test
+  - after-build
+  - release
 
 branches:
   only:
     - master
     - 0.1x
-
-deploy:
-  provider: rubygems
-  api_key:
-    secure: EqbOu9BQp5jkivJ8qvTo89f3J49KOByBueU3XulrJ2Kqm/ov4RDFsmp9/uHAnSLdmKSkzZaeq79t1AUNfKGX1ZqkKgq/Nw2BKGFnh5ZOjrkrRZR1Vm09OHxqiViEbtg+jZ8VOLY/iDFEkNIzuj9/H3iHGXC0XiKH2LTHOFH63Bs=
-  gem: faraday
-  on:
-    tags: true
-    repo: lostisland/faraday
-    rvm: 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,10 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-  - 2.6
   - ruby-head
 
 matrix:
-  fast_finish: true
-  include:
-    - rvm: 2.6 # Run custom before/after scripts for latest supported Ruby version.
-      before_script: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        chmod +x ./cc-test-reporter
-        ./cc-test-reporter before-build
-      after_script: ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  fast_finish: true # do not wait for ruby-head to mark the build as finished
   allow_failures:
     - ruby-head
 
@@ -27,6 +19,13 @@ jobs:
       rvm: ruby-2.4.1 # Pre-installed on TravisCI
       install: true # Do not bundle install
       script: gem install rubocop --no-document && rubocop
+    - stage: latest
+      rvm: 2.6 # Run custom before/after scripts for latest supported Ruby version.
+      before_script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
+      after_script: ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
     - stage: release
       rvm: 2.6
       install: true # Do not bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ stages:
   - before build
   - linting
   - test
-  - after-build
+  - after build
   - release
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,16 @@ rvm:
   - ruby-head
 
 matrix:
+  fast_finish: true
   include:
     - rvm: 2.6 # Run custom before/after scripts for latest supported Ruby version.
-      before_script:
-        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        - chmod +x ./cc-test-reporter
-        - ./cc-test-reporter before-build
-      after_script:
-        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+      before_script: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        chmod +x ./cc-test-reporter
+        ./cc-test-reporter before-build
+      after_script: ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  allow_failures:
+    - ruby-head
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
-cache: bundler
+cache:
+  bundler: true
+  directories:
+    - tools
 
 rvm:
   - 2.3
@@ -14,9 +17,10 @@ jobs:
       rvm: 2.6
       install: true # Do not bundle install
       script:
-        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        - chmod +x ./cc-test-reporter
-        - ./cc-test-reporter before-build
+        - mkdir -p tools
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > tools/cc-test-reporter
+        - chmod +x tools/cc-test-reporter
+        - tools/cc-test-reporter before-build
     - stage: linting
       rvm: ruby-2.4.1 # Pre-installed on TravisCI
       install: true # Do not bundle install
@@ -24,7 +28,7 @@ jobs:
     - stage: after build
       rvm: 2.6
       install: true # Do not bundle install
-      script: ./cc-test-reporter after-build
+      script: tools/cc-test-reporter after-build
     - stage: release
       rvm: 2.6
       install: true # Do not bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
 stages:
   - linting
   - test
+  - latest
   - release
 
 branches:


### PR DESCRIPTION
## Description
* Test Coverage Report is sent to CodeClimate
* Gem release happens on a separate stage

I'm not a Travis CI expert so appreciate your feedback on these changes 😄.
The idea was that I wanted the code climate script to be downloaded and executed only one, not for all `rvm`s.
Also, deployment is currently limited to a singular version thanks to the `on` option, but moving that into a stage allows to use the stage `rvm` option to do the same.
