### PR TITLE
chore: RuboCop lint Style/P*

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -193,12 +193,6 @@ Style/ParenthesesAroundCondition:
   Exclude:
     - 'lib/faraday/request/multipart.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/PerlBackrefs:
-  Exclude:
-    - 'faraday.gemspec'
-
 # Offense count: 278
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -186,13 +186,6 @@ Style/ParallelAssignment:
     - 'test/adapters/integration.rb'
     - 'test/helper.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowSafeAssignment, AllowInMultilineConditions.
-Style/ParenthesesAroundCondition:
-  Exclude:
-    - 'lib/faraday/request/multipart.rb'
-
 # Offense count: 278
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -175,17 +175,6 @@ Style/NumericPredicate:
     - 'lib/faraday/upload_io.rb'
     - 'lib/faraday/utils/headers.rb'
 
-# Offense count: 7
-# Cop supports --auto-correct.
-Style/ParallelAssignment:
-  Exclude:
-    - 'lib/faraday/rack_builder.rb'
-    - 'script/server'
-    - 'spec/support/helper_methods.rb'
-    - 'spec/support/shared_examples/request_method.rb'
-    - 'test/adapters/integration.rb'
-    - 'test/helper.rb'
-
 # Offense count: 278
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -207,16 +207,6 @@ Style/PreferredHashMethods:
   Exclude:
     - 'lib/faraday/encoders/nested_params_encoder.rb'
 
-# Offense count: 11
-# Cop supports --auto-correct.
-Style/Proc:
-  Exclude:
-    - 'lib/faraday/connection.rb'
-    - 'lib/faraday/request/retry.rb'
-    - 'spec/faraday/request_spec.rb'
-    - 'spec/support/shared_examples/request_method.rb'
-    - 'test/adapters/integration.rb'
-
 # Offense count: 278
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -199,14 +199,6 @@ Style/PerlBackrefs:
   Exclude:
     - 'faraday.gemspec'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: short, verbose
-Style/PreferredHashMethods:
-  Exclude:
-    - 'lib/faraday/encoders/nested_params_encoder.rb'
-
 # Offense count: 278
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -3,7 +3,7 @@
 lib = 'faraday'
 lib_file = File.expand_path("../lib/#{lib}.rb", __FILE__)
 File.read(lib_file) =~ /\bVERSION\s*=\s*["'](.+?)["']/
-version = $1
+version = Regexp.last_match(1)
 
 Gem::Specification.new do |spec|
   spec.name    = lib

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -73,7 +73,7 @@ module Faraday
 
       @builder = options.builder || begin
         # pass an empty block to Builder so it doesn't assume default middleware
-        options.new_builder(block_given? ? Proc.new { |b| } : nil)
+        options.new_builder(block_given? ? proc { |b| } : nil)
       end
 
       self.url_prefix = url || 'http:/'

--- a/lib/faraday/encoders/nested_params_encoder.rb
+++ b/lib/faraday/encoders/nested_params_encoder.rb
@@ -106,7 +106,7 @@ module Faraday
           end
 
           if context.is_a?(Array) && !is_array
-            if !context.last.is_a?(Hash) || context.last.has_key?(subkey)
+            if !context.last.is_a?(Hash) || context.last.key?(subkey)
               context << {}
             end
             context = context.last

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -33,7 +33,8 @@ module Faraday
         if klass.respond_to?(:name)
           @@constants_mutex.synchronize { @@constants[@name] = klass }
         end
-        @args, @block = args, block
+        @args = args
+        @block = block
       end
 
       def klass

--- a/lib/faraday/request/multipart.rb
+++ b/lib/faraday/request/multipart.rb
@@ -38,7 +38,7 @@ module Faraday
       def has_multipart?(obj) # rubocop:disable Naming/PredicateName
         if obj.respond_to?(:each)
           (obj.respond_to?(:values) ? obj.values : obj).each do |val|
-            return true if (val.respond_to?(:content_type) || has_multipart?(val))
+            return true if val.respond_to?(:content_type) || has_multipart?(val)
           end
         end
         false

--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -73,7 +73,7 @@ module Faraday
         end
 
         def retry_block
-          self[:retry_block] ||= Proc.new {}
+          self[:retry_block] ||= proc {}
         end
 
         def retry_statuses

--- a/script/server
+++ b/script/server
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-old_verbose, $VERBOSE = $VERBOSE, nil
+old_verbose = $VERBOSE
+$VERBOSE = nil
 begin
   require File.expand_path('../test/live_server', __dir__)
 ensure

--- a/spec/faraday/request_spec.rb
+++ b/spec/faraday/request_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Faraday::Request do
   end
 
   context 'when setting the url on setup with a URI' do
-    let(:block) { Proc.new { |req| req.url URI.parse('foo.json?a=1') } }
+    let(:block) { proc { |req| req.url URI.parse('foo.json?a=1') } }
 
     it { expect(subject.path).to eq(URI.parse('foo.json')) }
     it { expect(subject.params).to eq('a' => '1') }
@@ -31,7 +31,7 @@ RSpec.describe Faraday::Request do
   end
 
   context 'when setting the url on setup with a string path and params' do
-    let(:block) { Proc.new { |req| req.url 'foo.json', 'a' => 1 } }
+    let(:block) { proc { |req| req.url 'foo.json', 'a' => 1 } }
 
     it { expect(subject.path).to eq('foo.json') }
     it { expect(subject.params).to eq('a' => 1) }
@@ -39,7 +39,7 @@ RSpec.describe Faraday::Request do
   end
 
   context 'when setting the url on setup with a path including params' do
-    let(:block) { Proc.new { |req| req.url 'foo.json?b=2&a=1#qqq' } }
+    let(:block) { proc { |req| req.url 'foo.json?b=2&a=1#qqq' } }
 
     it { expect(subject.path).to eq('foo.json') }
     it { expect(subject.params).to eq('a' => '1', 'b' => '2') }
@@ -47,7 +47,7 @@ RSpec.describe Faraday::Request do
   end
 
   context 'when setting a header on setup with []= syntax' do
-    let(:block) { Proc.new { |req| req['Server'] = 'Faraday' } }
+    let(:block) { proc { |req| req['Server'] = 'Faraday' } }
     let(:headers) { subject.to_env(conn).request_headers }
 
     it { expect(subject.headers['Server']).to eq('Faraday') }
@@ -56,7 +56,7 @@ RSpec.describe Faraday::Request do
   end
 
   context 'when setting the body on setup' do
-    let(:block) { Proc.new { |req| req.body = 'hi' } }
+    let(:block) { proc { |req| req.body = 'hi' } }
 
     it { expect(subject.body).to eq('hi') }
     it { expect(subject.to_env(conn).body).to eq('hi') }
@@ -79,7 +79,7 @@ RSpec.describe Faraday::Request do
 
     context 'and per-request options set' do
       let(:block) do
-        Proc.new do |req|
+        proc do |req|
           req.options.timeout = 10
           req.options.boundary = 'boo'
           req.options.oauth[:consumer_secret] = 'xyz'

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -74,7 +74,8 @@ module Faraday
     end
 
     def capture_warnings
-      old, $stderr = $stderr, StringIO.new
+      old = $stderr
+      $stderr = StringIO.new
       begin
         yield
         $stderr.string

--- a/spec/support/shared_examples/request_method.rb
+++ b/spec/support/shared_examples/request_method.rb
@@ -161,7 +161,8 @@ shared_examples 'a request method' do |http_method|
 
   on_feature :parallel do
     it 'handles parallel requests' do
-      resp1, resp2 = nil, nil
+      resp1 = nil
+      resp2 = nil
       payload1 = { a: '1' }
       payload2 = { b: '2' }
       request_stub.with(Hash[query_or_body, payload1])

--- a/spec/support/shared_examples/request_method.rb
+++ b/spec/support/shared_examples/request_method.rb
@@ -137,7 +137,7 @@ shared_examples 'a request method' do |http_method|
       context 'when response is empty' do
         it do
           conn.public_send(http_method, '/') do |req|
-            req.options.on_data = Proc.new { |*args| streamed << args }
+            req.options.on_data = proc { |*args| streamed << args }
           end
 
           expect(streamed).to eq([['', 0]])
@@ -149,7 +149,7 @@ shared_examples 'a request method' do |http_method|
 
         it 'handles streaming' do
           response = conn.public_send(http_method, '/') do |req|
-            req.options.on_data = Proc.new { |*args| streamed << args }
+            req.options.on_data = proc { |*args| streamed << args }
           end
 
           expect(response.body).to eq('')

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -44,8 +44,10 @@ module Adapters
 
     module ParallelNonStreaming
       def test_callback_is_called_in_parallel_with_no_streaming_support
-        resp1, resp2 = nil, nil
-        streamed1, streamed2 = nil, nil
+        resp1 = nil
+        resp2 = nil
+        streamed1 = nil
+        streamed2 = nil
 
         connection = create_connection
         err = capture_warnings do

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -121,7 +121,7 @@ module Adapters
         builder_block = if adapter == :default
                           nil
                         else
-                          Proc.new do |b|
+                          proc do |b|
                             b.request :multipart
                             b.request :url_encoded
                             b.adapter adapter, *adapter_options, &optional_connection_config_blk

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -49,7 +49,8 @@ module Faraday
     end unless defined? ::MiniTest
 
     def capture_warnings
-      old, $stderr = $stderr, StringIO.new
+      old = $stderr
+      $stderr = StringIO.new
       begin
         yield
         $stderr.string


### PR DESCRIPTION
## Description

See #854 - RuboCop linting

Fixes: 

* Style/Proc
* Style/PreferredHashMethods
* Style/PerlBackrefs
* Style/ParenthesesAroundCondition
* Style/ParallelAssignment
