### PR TITLE
Chore: RuboCop Style/MultilineIfModifier

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,7 +25,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 16
 
-# Offense count: 45
+# Offense count: 46
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
   Max: 65
@@ -125,16 +125,6 @@ Style/ModuleFunction:
   Exclude:
     - 'lib/faraday/utils.rb'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-Style/MultilineIfModifier:
-  Exclude:
-    - 'lib/faraday/adapter/em_http.rb'
-    - 'lib/faraday/adapter/em_synchrony.rb'
-    - 'lib/faraday/adapter/net_http_persistent.rb'
-    - 'test/adapters/em_http_test.rb'
-    - 'test/helper.rb'
-
 # Offense count: 1
 Style/MultipleComparison:
   Exclude:
@@ -155,7 +145,7 @@ Style/MutableConstant:
     - 'lib/faraday/response/raise_error.rb'
     - 'lib/faraday/utils.rb'
 
-# Offense count: 275
+# Offense count: 276
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:

--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -257,10 +257,12 @@ module Faraday
   end
 end
 
-begin
-  require 'openssl'
-rescue LoadError
-  warn 'Warning: no such file to load -- openssl. Make sure it is installed if you want HTTPS support'
-else
-  require 'faraday/adapter/em_http_ssl_patch'
-end if Faraday::Adapter::EMHttp.loaded?
+if Faraday::Adapter::EMHttp.loaded?
+  begin
+    require 'openssl'
+  rescue LoadError
+    warn 'Warning: no such file to load -- openssl. Make sure it is installed if you want HTTPS support'
+  else
+    require 'faraday/adapter/em_http_ssl_patch'
+  end
+end

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -110,10 +110,12 @@ end
 
 require 'faraday/adapter/em_synchrony/parallel_manager'
 
-begin
-  require 'openssl'
-rescue LoadError
-  warn 'Warning: no such file to load -- openssl. Make sure it is installed if you want HTTPS support'
-else
-  require 'faraday/adapter/em_http_ssl_patch'
-end if Faraday::Adapter::EMSynchrony.loaded?
+if Faraday::Adapter::EMSynchrony.loaded?
+  begin
+    require 'openssl'
+  rescue LoadError
+    warn 'Warning: no such file to load -- openssl. Make sure it is installed if you want HTTPS support'
+  else
+    require 'faraday/adapter/em_http_ssl_patch'
+  end
+end

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -29,10 +29,12 @@ module Faraday
           proxy_uri = proxy[:uri].is_a?(::URI::HTTP) ? proxy[:uri].dup : ::URI.parse(proxy[:uri].to_s)
           proxy_uri.user = proxy_uri.password = nil
           # awful patch for net-http-persistent 2.8 not unescaping user/password
-          (class << proxy_uri; self; end).class_eval do
-            define_method(:user) { proxy[:user] }
-            define_method(:password) { proxy[:password] }
-          end if proxy[:user]
+          if proxy[:user]
+            (class << proxy_uri; self; end).class_eval do
+              define_method(:user) { proxy[:user] }
+              define_method(:password) { proxy[:password] }
+            end
+          end
         end
         proxy_uri
       end

--- a/test/adapters/em_http_test.rb
+++ b/test/adapters/em_http_test.rb
@@ -8,17 +8,19 @@ module Adapters
       :em_http
     end
 
-    Integration.apply(self, :Parallel, :NonStreaming, :ParallelNonStreaming) do
-      # https://github.com/eventmachine/eventmachine/pull/289
-      undef :test_timeout
+    unless jruby? && ssl_mode?
+      Integration.apply(self, :Parallel, :NonStreaming, :ParallelNonStreaming) do
+        # https://github.com/eventmachine/eventmachine/pull/289
+        undef :test_timeout
 
-      def test_binds_local_socket
-        host = '1.2.3.4'
-        conn = create_connection request: { bind: { host: host } }
-        assert_equal host, conn.options[:bind][:host]
+        def test_binds_local_socket
+          host = '1.2.3.4'
+          conn = create_connection request: { bind: { host: host } }
+          assert_equal host, conn.options[:bind][:host]
+        end
       end
-    end unless jruby? && ssl_mode?
-    # https://github.com/eventmachine/eventmachine/issues/180
+      # https://github.com/eventmachine/eventmachine/issues/180
+    end
 
     def test_custom_adapter_config
       url = URI('https://example.com:1234')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -44,10 +44,6 @@ module Faraday
     extend LiveServerConfig
     self.live_server = ENV['LIVE']
 
-    def test_default
-      assert true
-    end unless defined? ::MiniTest
-
     def capture_warnings
       old = $stderr
       $stderr = StringIO.new


### PR DESCRIPTION
## Description

Part of [RuboCop Quest](https://github.com/lostisland/faraday/issues/854).

This change fixes all instances of `MultilineIfModifier`.

## Additional Notes

This introduces two more instances of `MethodLength` and `LineLength`, but since those are not addressed yet, I chose to focus on the linter at hand.
