### PR TITLE
chore: RuboCop lint Style/M*

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -118,14 +118,6 @@ Style/MissingRespondToMissing:
     - 'lib/faraday.rb'
 
 # Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, Autocorrect.
-# SupportedStyles: module_function, extend_self
-Style/ModuleFunction:
-  Exclude:
-    - 'lib/faraday/utils.rb'
-
-# Offense count: 1
 Style/MultipleComparison:
   Exclude:
     - 'lib/faraday/encoders/flat_params_encoder.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -130,21 +130,6 @@ Style/MultipleComparison:
   Exclude:
     - 'lib/faraday/encoders/flat_params_encoder.rb'
 
-# Offense count: 11
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: literals, strict
-Style/MutableConstant:
-  Exclude:
-    - 'lib/faraday.rb'
-    - 'lib/faraday/adapter/net_http.rb'
-    - 'lib/faraday/adapter/rack.rb'
-    - 'lib/faraday/options/env.rb'
-    - 'lib/faraday/request/retry.rb'
-    - 'lib/faraday/response/logger.rb'
-    - 'lib/faraday/response/raise_error.rb'
-    - 'lib/faraday/utils.rb'
-
 # Offense count: 276
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -20,8 +20,8 @@ require 'faraday/dependency_loader'
 #
 module Faraday
   VERSION = '0.15.3'
-  METHODS_WITH_QUERY = %w[get head delete connect trace]
-  METHODS_WITH_BODY = %w[post put patch]
+  METHODS_WITH_QUERY = %w[get head delete connect trace].freeze
+  METHODS_WITH_BODY = %w[post put patch].freeze
 
   class << self
     # The root path that Faraday is being loaded from.

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -12,7 +12,7 @@ module Faraday
   class Adapter
     # Net::HTTP adapter.
     class NetHttp < Faraday::Adapter
-      NET_HTTP_EXCEPTIONS = [
+      exceptions = [
         IOError,
         Errno::ECONNABORTED,
         Errno::ECONNREFUSED,
@@ -28,8 +28,10 @@ module Faraday
         Zlib::GzipFile::Error
       ]
 
-      NET_HTTP_EXCEPTIONS << OpenSSL::SSL::SSLError if defined?(OpenSSL)
-      NET_HTTP_EXCEPTIONS << Net::OpenTimeout if defined?(Net::OpenTimeout)
+      exceptions << OpenSSL::SSL::SSLError if defined?(OpenSSL)
+      exceptions << Net::OpenTimeout if defined?(Net::OpenTimeout)
+
+      NET_HTTP_EXCEPTIONS = exceptions.freeze
 
       def initialize(app = nil, opts = {}, &block)
         @ssl_cert_store = nil

--- a/lib/faraday/adapter/rack.rb
+++ b/lib/faraday/adapter/rack.rb
@@ -19,7 +19,7 @@ module Faraday
       dependency 'rack/test'
 
       # not prefixed with "HTTP_"
-      SPECIAL_HEADERS = %w[CONTENT_LENGTH CONTENT_TYPE]
+      SPECIAL_HEADERS = %w[CONTENT_LENGTH CONTENT_TYPE].freeze
 
       def initialize(faraday_app, rack_app)
         super(faraday_app)

--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -52,7 +52,7 @@ module Faraday
     # rubocop:disable Naming/ConstantName
     ContentLength = 'Content-Length'
     StatusesWithoutBody = Set.new [204, 304]
-    SuccessfulStatuses = 200..299
+    SuccessfulStatuses = (200..299).freeze
     # rubocop:enable Naming/ConstantName
 
     # A Set of HTTP verbs that typically send a body.  If no body is set for

--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -24,7 +24,7 @@ module Faraday
     # interval that is random between 0.1 and 0.15.
     class Retry < Faraday::Middleware
       DEFAULT_EXCEPTIONS = [Errno::ETIMEDOUT, 'Timeout::Error', Faraday::TimeoutError, Faraday::RetriableResponse].freeze
-      IDEMPOTENT_METHODS = %i[delete get head options put]
+      IDEMPOTENT_METHODS = %i[delete get head options put].freeze
 
       class Options < Faraday::Options.new(:max, :interval, :max_interval, :interval_randomness,
                                            :backoff_factor, :exceptions, :methods, :retry_if, :retry_block,

--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -7,7 +7,7 @@ module Faraday
     class Logger < Middleware
       extend Forwardable
 
-      DEFAULT_OPTIONS = { headers: true, bodies: false }
+      DEFAULT_OPTIONS = { headers: true, bodies: false }.freeze
 
       def initialize(app, logger = nil, options = {})
         super(app)

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -3,8 +3,8 @@
 module Faraday
   class Response
     class RaiseError < Middleware
-      ClientErrorStatuses = 400...500 # rubocop:disable Naming/ConstantName
-      ServerErrorStatuses = 500...600 # rubocop:disable Naming/ConstantName
+      ClientErrorStatuses = (400...500).freeze
+      ServerErrorStatuses = (500...600).freeze
 
       def on_complete(env)
         case env[:status]

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -15,7 +15,7 @@ module Faraday
       NestedParamsEncoder.encode(params)
     end
 
-    ESCAPE_RE = /[^a-zA-Z0-9 .~_-]/
+    ESCAPE_RE = /[^a-zA-Z0-9 .~_-]/.freeze
 
     def escape(str)
       str.to_s.gsub(ESCAPE_RE) do |match|
@@ -27,7 +27,7 @@ module Faraday
       CGI.unescape str.to_s
     end
 
-    DEFAULT_SEP = /[&;] */n
+    DEFAULT_SEP = /[&;] */n.freeze
 
     # Adapted from Rack
     def parse_query(query)

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -5,7 +5,7 @@ require 'faraday/utils/params_hash'
 
 module Faraday
   module Utils
-    extend self
+    module_function
 
     def build_query(params)
       FlatParamsEncoder.encode(params)
@@ -99,8 +99,6 @@ module Faraday
     def deep_merge(source, hash)
       deep_merge!(source.dup, hash)
     end
-
-    protected
 
     def sort_query_params(query)
       query.split('&').sort.join('&')


### PR DESCRIPTION
## Description

See #854 - RuboCop linting

Fixes: 

* Style/MutableConstant
* Style/ModuleFunction

## Additional Notes
Style/MutableConstant: I had to re-enable a disabled cop because of this RuboCop bug https://github.com/rubocop-hq/rubocop/issues/6808

Style/ModuleFunction: I had to make a `protected` function `public` (but it's no big deal for this particular case, IMHO) because of differences between `extend self` and `module_function` https://github.com/rubocop-hq/ruby-style-guide/issues/556