### PR TITLE
chore: RuboCop lint Style/MethodMissingSuper

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -83,11 +83,6 @@ Style/GuardClause:
     - 'lib/faraday/utils/headers.rb'
 
 # Offense count: 1
-Style/MethodMissingSuper:
-  Exclude:
-    - 'lib/faraday.rb'
-
-# Offense count: 1
 Style/MissingRespondToMissing:
   Exclude:
     - 'lib/faraday.rb'

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -111,7 +111,11 @@ module Faraday
     # Internal: Proxies method calls on the Faraday constant to
     # .default_connection.
     def method_missing(name, *args, &block)
-      default_connection.send(name, *args, &block)
+      if default_connection.respond_to?(name)
+        default_connection.send(name, *args, &block)
+      else
+        super
+      end
     end
   end
 

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -4,4 +4,25 @@ RSpec.describe Faraday do
   it 'has a version number' do
     expect(Faraday::VERSION).not_to be nil
   end
+
+  context 'proxies to default_connection' do
+    it 'proxies methods that exist on the default_connection' do
+      mock_conection = double('Connection')
+      Faraday.default_connection = mock_conection
+
+      expect(mock_conection).to receive(:this_should_be_proxied)
+
+      Faraday.this_should_be_proxied
+    end
+
+    it 'uses method_missing on Farady if there is no proxyable method' do
+      mock_conection = double('Connection')
+      Faraday.default_connection = mock_conection
+
+      expect { Faraday.this_method_does_not_exist }.to raise_error(
+        NoMethodError,
+        "undefined method `this_method_does_not_exist' for Faraday:Module"
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Description
Fix for Rubocop lint Style/MethodMissingSuper
This is part of the RuboCop Quest: #854 

## Additional Notes
Adds unit test coverage for the `Faraday#method_missing` method.
