### PR TITLE
Fix test order dependency in default_connection proxy test

### DIFF
--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Faraday do
     end
 
     it 'proxies methods that exist on the default_connection' do
-      expect(mock_conection).to receive(:this_should_be_proxied)
+      expect(mock_connection).to receive(:this_should_be_proxied)
 
       Faraday.this_should_be_proxied
     end

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Faraday do
       Faraday.this_should_be_proxied
     end
 
-    it 'uses method_missing on Farady if there is no proxyable method' do
+    it 'uses method_missing on Faraday if there is no proxyable method' do
       expect { Faraday.this_method_does_not_exist }.to raise_error(
         NoMethodError,
         "undefined method `this_method_does_not_exist' for Faraday:Module"

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -6,23 +6,26 @@ RSpec.describe Faraday do
   end
 
   context 'proxies to default_connection' do
-    it 'proxies methods that exist on the default_connection' do
-      mock_conection = double('Connection')
+    let(:mock_conection) { double('Connection') }
+    before do
       Faraday.default_connection = mock_conection
+    end
 
+    it 'proxies methods that exist on the default_connection' do
       expect(mock_conection).to receive(:this_should_be_proxied)
 
       Faraday.this_should_be_proxied
     end
 
     it 'uses method_missing on Farady if there is no proxyable method' do
-      mock_conection = double('Connection')
-      Faraday.default_connection = mock_conection
-
       expect { Faraday.this_method_does_not_exist }.to raise_error(
         NoMethodError,
         "undefined method `this_method_does_not_exist' for Faraday:Module"
       )
+    end
+
+    after do
+      Faraday.default_connection = nil
     end
   end
 end

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Faraday do
   context 'proxies to default_connection' do
     let(:mock_connection) { double('Connection') }
     before do
-      Faraday.default_connection = mock_conection
+      Faraday.default_connection = mock_connection
     end
 
     it 'proxies methods that exist on the default_connection' do

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Faraday do
   end
 
   context 'proxies to default_connection' do
-    let(:mock_conection) { double('Connection') }
+    let(:mock_connection) { double('Connection') }
     before do
       Faraday.default_connection = mock_conection
     end


### PR DESCRIPTION
## Description
Fixes a test order dependency issue with the test suite introduced by #928

## Details

The assignment to the mock connection:

`Faraday.default_connection = mock_connection`

was persisting throughout the tests.

If the random number generator is unlucky the following error occurs:

```
#<Double "Connection"> was originally created in one example but has leaked into another example and can no longer be used.  rspec-mocks' doubles are designed to only last for one example, and you need to create a new one in each example you wish to use it for.
```

This commit fixes the issue by explicitly setting the default_connection
back to `nil` in an `after` block after the tests have run.

Subsequent calls to `default_connection` within the test suite then
behave as previously expected irrespective of the random test ordering.
