### PR TITLE
chore: Rubocop lint Style/MissingRespondToMissing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -77,11 +77,6 @@ Style/GuardClause:
     - 'lib/faraday/utils/headers.rb'
 
 # Offense count: 1
-Style/MissingRespondToMissing:
-  Exclude:
-    - 'lib/faraday.rb'
-
-# Offense count: 1
 Style/MultipleComparison:
   Exclude:
     - 'lib/faraday/encoders/flat_params_encoder.rb'

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -102,7 +102,7 @@ module Faraday
       @default_adapter = adapter
     end
 
-    def respond_to?(symbol, include_private = false)
+    def respond_to_missing?(symbol, include_private = false)
       default_connection.respond_to?(symbol, include_private) || super
     end
 

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe Faraday do
       )
     end
 
+    it 'proxied methods can be accessed' do
+      allow(mock_conection).to receive(:this_should_be_proxied)
+
+      expect(Faraday.method(:this_should_be_proxied)).to be_a(Method)
+    end
+
     after do
       Faraday.default_connection = nil
     end

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -6,23 +6,26 @@ RSpec.describe Faraday do
   end
 
   context 'proxies to default_connection' do
-    it 'proxies methods that exist on the default_connection' do
-      mock_conection = double('Connection')
+    let(:mock_conection) { double('Connection') }
+    before do
       Faraday.default_connection = mock_conection
+    end
 
+    it 'proxies methods that exist on the default_connection' do
       expect(mock_conection).to receive(:this_should_be_proxied)
 
       Faraday.this_should_be_proxied
     end
 
     it 'uses method_missing on Farady if there is no proxyable method' do
-      mock_conection = double('Connection')
-      Faraday.default_connection = mock_conection
-
       expect { Faraday.this_method_does_not_exist }.to raise_error(
         NoMethodError,
         "undefined method `this_method_does_not_exist' for Faraday:Module"
       )
+    end
+
+    after do
+      Faraday.default_connection = nil
     end
   end
 end

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe Faraday do
   end
 
   context 'proxies to default_connection' do
-    let(:mock_conection) { double('Connection') }
+    let(:mock_connection) { double('Connection') }
     before do
-      Faraday.default_connection = mock_conection
+      Faraday.default_connection = mock_connection
     end
 
     it 'proxies methods that exist on the default_connection' do
-      expect(mock_conection).to receive(:this_should_be_proxied)
+      expect(mock_connection).to receive(:this_should_be_proxied)
 
       Faraday.this_should_be_proxied
     end
 
-    it 'uses method_missing on Farady if there is no proxyable method' do
+    it 'uses method_missing on Faraday if there is no proxyable method' do
       expect { Faraday.this_method_does_not_exist }.to raise_error(
         NoMethodError,
         "undefined method `this_method_does_not_exist' for Faraday:Module"
@@ -25,7 +25,7 @@ RSpec.describe Faraday do
     end
 
     it 'proxied methods can be accessed' do
-      allow(mock_conection).to receive(:this_should_be_proxied)
+      allow(mock_connection).to receive(:this_should_be_proxied)
 
       expect(Faraday.method(:this_should_be_proxied)).to be_a(Method)
     end


### PR DESCRIPTION
## Description
Fix for Rubocop lint Style/MissingRespondToMissing
This is part of the RuboCop Quest: #854 

Instead of adding a new `respond_to?` method, add `respond_to_missing?` which still provides the required `respond_to?` behaviour.


## Additional Notes
Includes the changes from #929 that fix a test ordering dependency issue.