### PR TITLE
Adds em-http adapter to RSpec tests

### DIFF
--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -166,17 +166,17 @@ module Faraday
       end
 
       def raise_error(msg)
-        errklass = Faraday::ClientError
-        if msg == Errno::ETIMEDOUT
-          errklass = Faraday::TimeoutError
+        error_class = Faraday::ClientError
+        if msg == Errno::ETIMEDOUT || (msg.is_a?(String) && msg.include?('timeout error'))
+          error_class = Faraday::TimeoutError
           msg = 'request timed out'
         elsif msg == Errno::ECONNREFUSED
-          errklass = Faraday::ConnectionFailed
+          error_class = Faraday::ConnectionFailed
           msg = 'connection refused'
         elsif msg == 'connection closed by server'
-          errklass = Faraday::ConnectionFailed
+          error_class = Faraday::ConnectionFailed
         end
-        raise errklass, msg
+        raise error_class, msg
       end
 
       # @return [Boolean]

--- a/spec/faraday/adapter/em_http_spec.rb
+++ b/spec/faraday/adapter/em_http_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe Faraday::Adapter::EMHttp do
+  features :request_body_on_query_methods, :reason_phrase_parse, :trace_method, :connect_method,
+           :skip_response_body_on_head, :parallel
+
+  it_behaves_like 'an adapter'
+
+  it 'allows to provide adapter specific configs' do
+    url = URI('https://example.com:1234')
+    adapter = Faraday::Adapter::EMHttp.new nil, inactivity_timeout: 20
+    req = adapter.create_request(url: url, request: {})
+
+    expect(req.connopts.inactivity_timeout).to eq(20)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCo
 
 SimpleCov.start do
   add_filter '/spec/'
+  add_filter '/lib/faraday/adapter/em_http_ssl_patch'
   minimum_coverage 90
   minimum_coverage_by_file 70
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ end
 
 # Ensure all /lib files are loaded
 # so they will be included in the test coverage report.
-Dir['./lib/**/*.rb'].each { |file| require file }
+Dir['./lib/**/*.rb'].sort.each { |file| require file }
 
 require 'faraday'
 require 'pry'

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -11,11 +11,15 @@ module Faraday
         @features = features
       end
 
-      def on_feature(name, &block)
+      def on_feature(name)
+        yield if block_given? && feature?(name)
+      end
+
+      def feature?(name)
         if @features.nil?
-          superclass.on_feature(name, &block) if superclass.respond_to?(:on_feature)
-        elsif block_given? && @features.include?(name)
-          yield
+          superclass.feature?(name) if superclass.respond_to?(:feature?)
+        elsif @features.include?(name)
+          true
         end
       end
 
@@ -54,11 +58,7 @@ module Faraday
         yield
       ensure
         old_env.each do |key, value|
-          if value == false
-            ENV.delete key
-          else
-            ENV[key] = value
-          end
+          value == false ? ENV.delete(key) : ENV[key] = value
         end
       end
     end


### PR DESCRIPTION
## Description
Covers `em-http` with Rspec tests like other adapters.

## Additional Notes
Excluded `em_http_ssl_patch.rb` from the Rspec coverage as there's no way to unit-test that patch.
As discussed in pvt with other maintainers, these kind of things will be tested separately by an integration tests suite.