### PR TITLE
Accurate test code coverage percentage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,10 @@ SimpleCov.start do
   minimum_coverage_by_file 70
 end
 
+# Ensure all /lib files are loaded
+# so they will be included in the test coverage report.
+Dir['./lib/**/*.rb'].each { |file| require file }
+
 require 'faraday'
 require 'pry'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,8 +25,8 @@ SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCo
 
 SimpleCov.start do
   add_filter '/spec/'
-  minimum_coverage 90
-  minimum_coverage_by_file 70
+  minimum_coverage 84
+  minimum_coverage_by_file 26
 end
 
 # Ensure all /lib files are loaded


### PR DESCRIPTION
## Description

The currently reported code coverage value of 93% is inaccurate due to there being ~250 lines of code that exist in the `/lib` directory which are never loaded by the test suite and thus never counted by SimpleCov when calculating the test coverage.

This patch adds a loop to require all the `.rb` files in the lib directory before the tests are run, which means the code coverage will more accurately reflect the code in the project.

The net result of this is a decrease in the coverage percentage, but the un-covered files can be more easily discovered in the code coverage report.

Before: `1644 / 1751 LOC (93.89%) covered.`

After: `1725 / 2030 LOC (84.98%) covered.`


## Additional Notes
The amount of lines covered in the "After" case has increased due to class and method definitions being considered as covered when they are loaded.

I have also adjusted the test coverage 'low water mark' downward to match the current coverage.
These should be gradually increased as test coverage is improved.
