### PR TITLE
Adds em-synchrony adapter to RSpec tests

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Offense count: 38
 Metrics/AbcSize:
-  Max: 79
+  Max: 82
 
 # Offense count: 5
 # Configuration parameters: CountComments.
@@ -22,7 +22,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 42
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
-  Max: 56
+  Max: 57
 
 # Offense count: 13
 Metrics/PerceivedComplexity:
@@ -65,7 +65,7 @@ Style/MultipleComparison:
   Exclude:
     - 'lib/faraday/encoders/flat_params_encoder.rb'
 
-# Offense count: 297
+# Offense count: 303
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -88,6 +88,8 @@ module Faraday
       rescue RuntimeError => err
         raise Faraday::ConnectionFailed, err if err.message == 'connection closed by server'
 
+        raise Faraday::TimeoutError, err if err.message.include?('timeout error')
+
         raise
       rescue StandardError => err
         raise Faraday::SSLError, err if defined?(OpenSSL) && err.is_a?(OpenSSL::SSL::SSLError)

--- a/spec/faraday/adapter/em_http_spec.rb
+++ b/spec/faraday/adapter/em_http_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Faraday::Adapter::EMHttp do
 
   it 'allows to provide adapter specific configs' do
     url = URI('https://example.com:1234')
-    adapter = Faraday::Adapter::EMHttp.new nil, inactivity_timeout: 20
+    adapter = described_class.new nil, inactivity_timeout: 20
     req = adapter.create_request(url: url, request: {})
 
     expect(req.connopts.inactivity_timeout).to eq(20)

--- a/spec/faraday/adapter/em_http_spec.rb
+++ b/spec/faraday/adapter/em_http_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Faraday::Adapter::EMHttp do
   features :request_body_on_query_methods, :reason_phrase_parse, :trace_method, :connect_method,
-           :skip_response_body_on_head, :parallel
+           :skip_response_body_on_head, :parallel, :local_socket_binding
 
   it_behaves_like 'an adapter'
 

--- a/spec/faraday/adapter/em_synchrony_spec.rb
+++ b/spec/faraday/adapter/em_synchrony_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Faraday::Adapter::EMSynchrony do
+  features :request_body_on_query_methods, :reason_phrase_parse, :skip_response_body_on_head, :parallel
+
+  it_behaves_like 'an adapter'
+
+  it 'allows to provide adapter specific configs' do
+    url = URI('https://example.com:1234')
+    adapter = Faraday::Adapter::EMSynchrony.new nil, inactivity_timeout: 20
+    req = adapter.create_request(url: url, request: {})
+
+    expect(req.connopts.inactivity_timeout).to eq(20)
+  end
+end

--- a/spec/faraday/adapter/em_synchrony_spec.rb
+++ b/spec/faraday/adapter/em_synchrony_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::Adapter::EMSynchrony do
-  features :request_body_on_query_methods, :reason_phrase_parse, :skip_response_body_on_head, :parallel
+  features :request_body_on_query_methods, :reason_phrase_parse,
+           :skip_response_body_on_head, :parallel, :local_socket_binding
 
   it_behaves_like 'an adapter'
 

--- a/spec/faraday/adapter/em_synchrony_spec.rb
+++ b/spec/faraday/adapter/em_synchrony_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Faraday::Adapter::EMSynchrony do
 
   it 'allows to provide adapter specific configs' do
     url = URI('https://example.com:1234')
-    adapter = Faraday::Adapter::EMSynchrony.new nil, inactivity_timeout: 20
+    adapter = described_class.new nil, inactivity_timeout: 20
     req = adapter.create_request(url: url, request: {})
 
     expect(req.connopts.inactivity_timeout).to eq(20)

--- a/spec/faraday/adapter/excon_spec.rb
+++ b/spec/faraday/adapter/excon_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Faraday::Adapter::Excon do
   it 'allows to provide adapter specific configs' do
     url = URI('https://example.com:1234')
 
-    adapter = Faraday::Adapter::Excon.new(nil, debug_request: true)
+    adapter = described_class.new(nil, debug_request: true)
 
     conn = adapter.create_connection({ url: url }, {})
 

--- a/spec/faraday/adapter/httpclient_spec.rb
+++ b/spec/faraday/adapter/httpclient_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Faraday::Adapter::HTTPClient do
   it_behaves_like 'an adapter'
 
   it 'allows to provide adapter specific configs' do
-    adapter = Faraday::Adapter::HTTPClient.new do |client|
+    adapter = described_class.new do |client|
       client.keep_alive_timeout = 20
       client.ssl_config.timeout = 25
     end

--- a/spec/faraday/adapter/httpclient_spec.rb
+++ b/spec/faraday/adapter/httpclient_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::Adapter::HTTPClient do
-  features :request_body_on_query_methods, :reason_phrase_parse, :compression, :trace_method, :connect_method
+  features :request_body_on_query_methods, :reason_phrase_parse, :compression,
+           :trace_method, :connect_method, :local_socket_binding
 
   it_behaves_like 'an adapter'
 
@@ -16,20 +17,5 @@ RSpec.describe Faraday::Adapter::HTTPClient do
 
     expect(client.keep_alive_timeout).to eq(20)
     expect(client.ssl_config.timeout).to eq(25)
-  end
-
-  it 'binds local socket' do
-    stub_request(:get, 'http://example.com')
-
-    host = '1.2.3.4'
-    port = 1234
-    conn = Faraday.new('http://example.com', request: { bind: { host: host, port: port } }) do |f|
-      f.adapter :httpclient
-    end
-
-    conn.get('/')
-
-    expect(conn.options[:bind][:host]).to eq(host)
-    expect(conn.options[:bind][:port]).to eq(port)
   end
 end

--- a/spec/faraday/adapter/net_http_persistent_spec.rb
+++ b/spec/faraday/adapter/net_http_persistent_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
   it 'allows to provide adapter specific configs' do
     url = URI('https://example.com')
 
-    adapter = Faraday::Adapter::NetHttpPersistent.new do |http|
+    adapter = described_class.new do |http|
       http.idle_timeout = 123
     end
 
@@ -21,7 +21,7 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
   it 'sets max_retries to 0' do
     url = URI('http://example.com')
 
-    adapter = Faraday::Adapter::NetHttpPersistent.new
+    adapter = described_class.new
 
     http = adapter.send(:net_http_connection, url: url, request: {})
     adapter.send(:configure_request, http, {})
@@ -33,7 +33,7 @@ RSpec.describe Faraday::Adapter::NetHttpPersistent do
   it 'allows to set pool_size on initialize' do
     url = URI('https://example.com')
 
-    adapter = Faraday::Adapter::NetHttpPersistent.new(nil, pool_size: 5)
+    adapter = described_class.new(nil, pool_size: 5)
 
     http = adapter.send(:net_http_connection, url: url, request: {})
 

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Faraday::Adapter::NetHttp do
 
   context 'checking http' do
     let(:url) { URI('http://example.com') }
-    let(:adapter) { Faraday::Adapter::NetHttp.new }
+    let(:adapter) { described_class.new }
     let(:http) { adapter.send(:net_http_connection, url: url, request: {}) }
 
     it { expect(http.port).to eq(80) }
@@ -36,7 +36,7 @@ RSpec.describe Faraday::Adapter::NetHttp do
 
     context 'with custom adapter config' do
       let(:adapter) do
-        Faraday::Adapter::NetHttp.new do |http|
+        described_class.new do |http|
           http.continue_timeout = 123
         end
       end

--- a/spec/support/shared_examples/adapter.rb
+++ b/spec/support/shared_examples/adapter.rb
@@ -10,7 +10,7 @@ shared_examples 'an adapter' do |**options|
 
   context 'with SSL disabled' do
     before { ENV['SSL'] = 'no' }
-    include_examples 'adapter examples'
+    include_examples 'adapter examples', options
   end
 end
 

--- a/spec/support/shared_examples/request_method.rb
+++ b/spec/support/shared_examples/request_method.rb
@@ -37,6 +37,21 @@ shared_examples 'a request method' do |http_method|
     expect { conn.public_send(http_method, 'http://localhost:4') }.to raise_error(Faraday::ConnectionFailed)
   end
 
+  on_feature :local_socket_binding do
+    it 'binds local socket' do
+      stub_request(http_method, 'http://example.com')
+
+      host = '1.2.3.4'
+      port = 1234
+      conn_options[:request] = { bind: { host: host, port: port } }
+
+      conn.public_send(http_method, '/')
+
+      expect(conn.options[:bind][:host]).to eq(host)
+      expect(conn.options[:bind][:port]).to eq(port)
+    end
+  end
+
   # context 'when wrong ssl certificate is provided' do
   #   let(:ca_file_path) { 'tmp/faraday-different-ca-cert.crt' }
   #   before { conn_options.merge!(ssl: { ca_file: ca_file_path }) }


### PR DESCRIPTION
## Description
Covers em-synchrony adapter with RSpec
No support for `trace` and `connect` methods, unfortunately 😢.

## Additional Notes
Back to over 90% test coverage 💪 🎉 !