### PR TITLE
chore: RuboCop lint Style/Globalvars

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,12 +48,6 @@ Style/Documentation:
     - 'lib/faraday/response/raise_error.rb'
     - 'lib/faraday/utils.rb'
 
-# Offense count: 2
-# Configuration parameters: AllowedVariables.
-Style/GlobalVars:
-  Exclude:
-    - 'script/generate_certs'
-
 # Offense count: 1
 Style/MultipleComparison:
   Exclude:

--- a/script/generate_certs
+++ b/script/generate_certs
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Usage: generate_certs
+# Usage: generate_certs [options]
+#   options:
+#     -s     Display shell exports that link env variables to filenames
 # Generate test certs for testing Faraday with SSL
 
 require 'openssl'

--- a/script/generate_certs
+++ b/script/generate_certs
@@ -7,8 +7,6 @@
 require 'openssl'
 require 'fileutils'
 
-$shell = ARGV.include? '-s'
-
 # Adapted from WEBrick::Utils. Skips cert extensions so it
 # can be used as a CA bundle
 def create_self_signed_cert(bits, cname, _comment)
@@ -29,7 +27,7 @@ end
 def write(file, contents, env_var)
   FileUtils.mkdir_p(File.dirname(file))
   File.open(file, 'w') { |f| f.puts(contents) }
-  puts %(export #{env_var}="#{file}") if $shell
+  puts %(export #{env_var}="#{file}") if ARGV.include? '-s'
 end
 
 # One cert / CA for ease of testing when ignoring verification


### PR DESCRIPTION
## Description
Fix for Rubocop lint Style/Globalvars
This is part of the RuboCop Quest: #854

## Additional Notes
`script/generate_certs` is untested.

It is used by `scripts/test` which seems be [related to adapter tests](https://github.com/lostisland/faraday/blob/master/.github/CONTRIBUTING.md#contributing)

Are these still relevant?
