### PR TITLE
Setup CodeClimate TestReporter on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ shared_ruby_steps: &shared_ruby_steps
         steps:
           - run:
               name: Run Code Climate test-reporter
-              command: ./cc-test-reporter after-build --coverage-input-type clover --exit-code $?
+              command: ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
     - save_cache:
         key: "{{ .Environment.CACHE_KEY_PREFIX }}-v1-bundler-deps-{{ .Branch }}"
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,10 @@ version: 2.1
 # Share Steps: glued in using the YAML alias
 # See https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 shared_ruby_steps: &shared_ruby_steps
+  parameters:
+    run-cc-reporter:
+      type: boolean
+      default: false
   steps:
     - attach_workspace:
         at: .
@@ -12,9 +16,24 @@ shared_ruby_steps: &shared_ruby_steps
     - run:
         name: Bundle Install
         command: bundle install --path vendor/bundle --jobs 7 --retry 15
+    - when:
+        condition: << parameters.run-cc-reporter >>
+        steps:
+          - run:
+              name: Setup Code Climate test-reporter
+              command: |
+                curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+                chmod +x ./cc-test-reporter
+                ./cc-test-reporter before-build
     - run:
         name: Run tests
         command: bundle exec rspec --require rspec_junit_formatter --format progress --format RspecJunitFormatter --out ~/test-results/rspec/results.xml
+    - when:
+        condition: << parameters.run-cc-reporter >>
+        steps:
+          - run:
+              name: Run Code Climate test-reporter
+              command: ./cc-test-reporter after-build --coverage-input-type clover --exit-code $?
     - save_cache:
         key: "{{ .Environment.CACHE_KEY_PREFIX }}-v1-bundler-deps-{{ .Branch }}"
         paths:
@@ -112,6 +131,7 @@ workflows:
       - ruby26:
           requires:
             - linting
+          run-cc-reporter: true
       - ruby25:
           requires:
             - linting


### PR DESCRIPTION
## Description
CircleCI should run again CodeClimate TestReporter only on Ruby2.6
This was working fine in TravisCI but was left out while migrating to CircleCI
