### PR TITLE
Rubocop 0.66

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :test do
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'
   gem 'rspec_junit_formatter', '~> 0.4'
-  gem 'rubocop', '~> 0.65.0'
+  gem 'rubocop', '~> 0.66.0'
   gem 'simplecov'
   gem 'typhoeus', '~> 1.3', git: 'https://github.com/typhoeus/typhoeus.git',
                             require: 'typhoeus'

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ group :test do
   gem 'rspec_junit_formatter', '~> 0.4'
   gem 'rubocop', '~> 0.65.0'
   gem 'simplecov'
-  gem 'sinatra', '~> 1.3'
   gem 'typhoeus', '~> 1.3', git: 'https://github.com/typhoeus/typhoeus.git',
                             require: 'typhoeus'
   gem 'webmock', '~> 3.4'

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -538,7 +538,9 @@ module Faraday
       if params
         uri.query = params.to_query(params_encoder || options.params_encoder)
       end
-      uri.query = nil if uri.query&.empty?
+      # rubocop:disable Style/SafeNavigation
+      uri.query = nil if uri.query && uri.query.empty?
+      # rubocop:enable Style/SafeNavigation
       uri
     end
 

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -3,8 +3,10 @@
 module Faraday
   class Response
     class RaiseError < Middleware
+      # rubocop:disable Naming/ConstantName
       ClientErrorStatuses = (400...500).freeze
       ServerErrorStatuses = (500...600).freeze
+      # rubocop:enable Naming/ConstantName
 
       def on_complete(env)
         case env[:status]


### PR DESCRIPTION
I noticed CI for #948 and #951 stalling because of some rubocop failures. Turns out that CI is loading rubocop v0.66, while bundler will only let us use rubocop v0.65 locally. It also turns out that Rubocop v0.66 either introduces for fixes some bugs with the [failing offenses](https://circleci.com/gh/lostisland/faraday/88):

```
lib/faraday/response/raise_error.rb:8:7: C: Naming/ConstantName: Use SCREAMING_SNAKE_CASE for constants. (https://github.com/rubocop-hq/ruby-style-guide#screaming-snake-case)
      ClientErrorStatuses = (400...500).freeze
      ^^^^^^^^^^^^^^^^^^^
lib/faraday/response/raise_error.rb:9:7: C: Naming/ConstantName: Use SCREAMING_SNAKE_CASE for constants. (https://github.com/rubocop-hq/ruby-style-guide#screaming-snake-case)
      ServerErrorStatuses = (500...600).freeze
      ^^^^^^^^^^^^^^^^^^^
lib/faraday/connection.rb:541:7: W: Lint/SafeNavigationWithEmpty: Avoid calling empty? with the safe navigation operator in conditionals.
      uri.query = nil if uri.query&.empty?
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This removes an old Sinatra reference, updates Rubocop to v0.66 in the Gemfile, and fixes the rubocop offenses. Applying this should fix builds for #948 and #951.