### PR TITLE
document missing `:retry_statuses` argument

### DIFF
--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -115,6 +115,10 @@ module Faraday
       # @option options [Block] :retry_block block that is executed after
       #   every retry. Request environment, middleware options, current number
       #   of retries and the exception is passed to the block as parameters.
+      # @option options [Array] :retry_statuses Array of Integer HTTP status
+      #   codes or a single Integer value that deterimines whether to raise
+      #   a Faraday::RetriableResponse exception based on the HTTP status code
+      #   of an HTTP response.
       def initialize(app, options = nil)
         super(app)
         @options = Options.from(options)

--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -116,7 +116,7 @@ module Faraday
       #   every retry. Request environment, middleware options, current number
       #   of retries and the exception is passed to the block as parameters.
       # @option options [Array] :retry_statuses Array of Integer HTTP status
-      #   codes or a single Integer value that deterimines whether to raise
+      #   codes or a single Integer value that determines whether to raise
       #   a Faraday::RetriableResponse exception based on the HTTP status code
       #   of an HTTP response.
       def initialize(app, options = nil)


### PR DESCRIPTION
This documents a missing argument for the Retry middleware. Open to suggestions on the wording and yard syntax.

/cc #955