### PR TITLE
CI: yard junk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - checkout
       - run:
           name: Create test-results dir
-          command: mkdir -p ~/test-results/rspec
+          command: mkdir -p ~/test-results/rspec && mkdir -p ~/test-results/linting
           when: always
       - persist_to_workspace:
           root: .
@@ -69,11 +69,16 @@ jobs:
       - run:
           name: RuboCop
           command: |
+            echo "starting rubocop..."
+            ls -al ~/test-results
             gem install rubocop rubocop-junit_formatter  --no-document
             rubocop --require rubocop/formatter/junit_formatter \
                     --format progress \
                     --format RuboCop::Formatter::JUnitFormatter \
                     --out ~/test-results/linting/rubocop.xml
+            echo "rubocop finished..."
+            ls -al ~/test-results
+            ls -al ~/test-results/linting
           when: always
       - run:
           name: Yard-Junk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,17 +67,11 @@ jobs:
       - run:
           name: RuboCop
           command: |
-            echo "starting rubocop..."
-            ls -al ~
             gem install rubocop rubocop-junit_formatter  --no-document
             rubocop --require rubocop/formatter/junit_formatter \
                     --format progress \
                     --format RuboCop::Formatter::JUnitFormatter \
                     --out ~/test-results/linting/rubocop.xml
-            echo "rubocop finished..."
-            ls -al ~
-            ls -al ~/test-results
-            ls -al ~/test-results/linting
           when: always
       - run:
           name: Yard-Junk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,12 +53,15 @@ jobs:
       - checkout
       - run:
           name: Create test-results dir
-          command: mkdir -p ~/test-results/rspec && mkdir -p ~/test-results/linting
+          command: |
+            mkdir -p ~/test-results/rspec
+            mkdir -p ~/test-results/linting
           when: always
       - persist_to_workspace:
-          root: .
+          root: ~
           paths:
-            - .
+            - ./project
+            - ./test-results
 
   linting:
     docker:
@@ -77,6 +80,7 @@ jobs:
                     --format RuboCop::Formatter::JUnitFormatter \
                     --out ~/test-results/linting/rubocop.xml
             echo "rubocop finished..."
+            ls -al ~
             ls -al ~/test-results
             ls -al ~/test-results/linting
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,9 +99,9 @@ jobs:
             ls -al ~/test-results/yard
           when: always
       - store_test_results:
-          path: ~/test-results/yard
+          path: ~/test-results
       - store_artifacts:
-          path: ~/test-results/yard
+          path: ~/test-results
 
   ruby26:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ shared_ruby_steps: &shared_ruby_steps
                 curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
                 chmod +x ./cc-test-reporter
                 ./cc-test-reporter before-build
+    - run: mkdir -p ~/test-results/rspec
     - run:
         name: Run tests
         command: bundle exec rspec --require rspec_junit_formatter --format progress --format RspecJunitFormatter --out ~/test-results/rspec/results.xml
@@ -39,7 +40,7 @@ shared_ruby_steps: &shared_ruby_steps
         paths:
           - ./vendor/bundle
     - store_test_results:
-        path: ~/test-results
+        path: ~/test-results/rspec
     - persist_to_workspace:
         root: .
         paths:
@@ -51,11 +52,6 @@ jobs:
       - image: circleci/ruby:2.6
     steps:
       - checkout
-      - run:
-          name: Create test-results dir
-          command: |
-            mkdir -p ~/test-results/rspec
-          when: always
       - persist_to_workspace:
           root: .
           paths:
@@ -67,7 +63,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: mkdir ~/test-results/linting
+      - run: mkdir -p ~/test-results/linting
       - run:
           name: RuboCop
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,9 @@ jobs:
           command: |
             gem install yard-junk
             echo `pwd`
+            ls -al ~/test-results
             yard-junk --path lib --text ~/test-results/yard/results.log
+            ls -al ~/test-results/yard
           when: always
       - store_test_results:
           path: ~/test-results/yard

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,13 @@ jobs:
       - image: circleci/ruby:2.6
     steps:
       - checkout
-      - run: "mkdir -p ~/test-results/rspec && mkdir -p ~/test-results/rubocop"
+      - run:
+          name: Create test-results dir
+          command: |
+            mkdir -p ~/test-results/rspec
+            mkdir -p ~/test-results/rubocop
+            mkdir -p ~/test-results/yard
+          when: always
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           name: RuboCop
           command: |
             echo "starting rubocop..."
-            ls -al ~/test-results
+            ls -al ~
             gem install rubocop rubocop-junit_formatter  --no-document
             rubocop --require rubocop/formatter/junit_formatter \
                     --format progress \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
           command: |
             gem install rubocop rubocop-junit_formatter  --no-document
             echo `pwd`
-            ls -al ~/test-results
             rubocop --require rubocop/formatter/junit_formatter \
                     --format progress \
                     --format RuboCop::Formatter::JUnitFormatter \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,10 +73,13 @@ jobs:
           name: RuboCop
           command: |
             gem install rubocop rubocop-junit_formatter  --no-document
+            echo `pwd`
+            ls -al ~/test-results
             rubocop --require rubocop/formatter/junit_formatter \
                     --format progress \
                     --format RuboCop::Formatter::JUnitFormatter \
                     --out ~/test-results/rubocop/results.xml
+            ls -al ~/test-results/rubocop
           when: always
       - store_test_results:
           path: ~/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,7 @@ jobs:
       - checkout
       - run:
           name: Create test-results dir
-          command: |
-            mkdir -p ~/test-results/rspec
-            mkdir -p ~/test-results/rubocop
-            mkdir -p ~/test-results/yard
+          command: mkdir -p ~/test-results/rspec
           when: always
       - persist_to_workspace:
           root: .
@@ -73,32 +70,16 @@ jobs:
           name: RuboCop
           command: |
             gem install rubocop rubocop-junit_formatter  --no-document
-            echo `pwd`
             rubocop --require rubocop/formatter/junit_formatter \
                     --format progress \
                     --format RuboCop::Formatter::JUnitFormatter \
-                    --out ~/test-results/rubocop/results.xml
-            ls -al ~/test-results/rubocop
+                    --out ~/test-results/linting/rubocop.xml
           when: always
-      - store_test_results:
-          path: ~/test-results
-      - store_artifacts:
-          path: ~/test-results
-
-  yard:
-    docker:
-      - image: circleci/ruby:2.6
-    steps:
-      - attach_workspace:
-          at: .
       - run:
           name: Yard-Junk
           command: |
-            gem install yard-junk
-            echo `pwd`
-            ls -al ~/test-results
-            yard-junk --path lib --text ~/test-results/yard/results.log
-            ls -al ~/test-results/yard
+            gem install yard-junk --no-document
+            yard-junk --path lib --text ~/test-results/linting/yard.log
           when: always
       - store_test_results:
           path: ~/test-results
@@ -156,9 +137,6 @@ workflows:
       - linting:
           requires:
             - checkout_code
-      - yard:
-          requires:
-            - checkout_code
       - ruby26:
           requires:
             - linting
@@ -174,7 +152,6 @@ workflows:
             - linting
       - deploy:
           requires:
-            - yard
             - ruby23
             - ruby24
             - ruby25

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           name: Yard-Junk
           command: |
             gem install yard-junk --no-document
-            yard-junk --path lib --text ~/test-results/linting/yard.log
+            yard-junk --path lib
           when: always
       - store_test_results:
           path: ~/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,13 +55,11 @@ jobs:
           name: Create test-results dir
           command: |
             mkdir -p ~/test-results/rspec
-            mkdir -p ~/test-results/linting
           when: always
       - persist_to_workspace:
-          root: ~
+          root: .
           paths:
-            - ./project
-            - ./test-results
+            - .
 
   linting:
     docker:
@@ -69,6 +67,7 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - run: mkdir ~/test-results/linting
       - run:
           name: RuboCop
           command: |
@@ -91,9 +90,9 @@ jobs:
             yard-junk --path lib
           when: always
       - store_test_results:
-          path: ~/test-results
+          path: ~/test-results/linting
       - store_artifacts:
-          path: ~/test-results
+          path: ~/test-results/linting
 
   ruby26:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,23 @@ jobs:
       - store_artifacts:
           path: ~/test-results
 
+  yard:
+    docker:
+      - image: circleci/ruby:2.6
+    steps:
+      - attach_workspace:
+        at: .
+      - run:
+        name: Yard-Junk
+        command: |
+          gem install yard-junk
+          yard-junk --path lib --text ~/test-results/yard/results.log
+        when: always
+      - store_test_results:
+          path: ~/test-results/yard
+      - store_artifacts:
+          path: ~/test-results/yard
+
   ruby26:
     docker:
       - image: circleci/ruby:2.6
@@ -128,6 +145,9 @@ workflows:
       - linting:
           requires:
             - checkout_code
+      - yard:
+          requires:
+            - checkout_code
       - ruby26:
           requires:
             - linting
@@ -143,6 +163,7 @@ workflows:
             - linting
       - deploy:
           requires:
+            - yard
             - ruby23
             - ruby24
             - ruby25

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,13 +82,13 @@ jobs:
       - image: circleci/ruby:2.6
     steps:
       - attach_workspace:
-        at: .
+          at: .
       - run:
-        name: Yard-Junk
-        command: |
-          gem install yard-junk
-          yard-junk --path lib --text ~/test-results/yard/results.log
-        when: always
+          name: Yard-Junk
+          command: |
+            gem install yard-junk
+            yard-junk --path lib --text ~/test-results/yard/results.log
+          when: always
       - store_test_results:
           path: ~/test-results/yard
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
           name: Yard-Junk
           command: |
             gem install yard-junk
+            echo `pwd`
             yard-junk --path lib --text ~/test-results/yard/results.log
           when: always
       - store_test_results:


### PR DESCRIPTION
This PR **fails CI builds if `yard-junk` returns any issues**.

Some questions though:

* Do we really care about _all_ issues that yard-junk reports?
* Is there a way to ignore certain issues?
* Are there things that yard-junk misses that we would want when verifying code docs?

My approach is to add a new step to the `linting` job that runs yard-junk. It currently fails on Faraday with:

```
lib/faraday/connection.rb:219: [UnknownParam] @param tag has unknown parameter name: url
lib/faraday/connection.rb:221: [UnknownParam] @param tag has unknown parameter name: params
lib/faraday/connection.rb:222: [UnknownParam] @param tag has unknown parameter name: headers
```

However, it doesn't seem to complain if new code is added without documentation. That should be caught by rubocop though. Locally, it looks like this:

```sh
$ bundle exec rubocop
Inspecting 97 files
.................................................C...............................................

Offenses:

lib/faraday/foo.rb:1:1: C: Style/FrozenStringLiteralComment: Missing magic comment # frozen_string_literal: true.
module Faraday
^
lib/faraday/foo.rb:2:3: C: Style/Documentation: Missing top-level class documentation comment.
  class Foo
  ^^^^^
lib/faraday/foo.rb:3:5: C: Style/EmptyMethod: Put empty method definitions on a single line. (https://github.com/rubocop-hq/ruby-style-guide#no-single-line-methods)
    def initialize(a, b = nil) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/faraday/foo.rb:3:20: C: Naming/UncommunicativeMethodParamName: Method parameter must be at least 3 characters long.
    def initialize(a, b = nil)
                   ^
lib/faraday/foo.rb:3:23: C: Naming/UncommunicativeMethodParamName: Method parameter must be at least 3 characters long.
    def initialize(a, b = nil)
                      ^

97 files inspected, 5 offenses detected

$ yard-junk --path=lib
Running YardJunk janitor (version 0.0.7)...


Problems
--------
mistyped tags or other typos in documentation

lib/faraday/connection.rb:219: [UnknownParam] @param tag has unknown parameter name: url
lib/faraday/connection.rb:221: [UnknownParam] @param tag has unknown parameter name: params
lib/faraday/connection.rb:222: [UnknownParam] @param tag has unknown parameter name: headers

0 failures, 3 problems (2 seconds to run)
```

TODO

* [x] Squash commit those bad messages away
