### PR TITLE
document both uses of Connection#options

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -212,14 +212,14 @@ module Faraday
       RUBY
     end
 
-    # @!method options(url = nil, params = nil, headers = nil)
-    # Makes an OPTIONS HTTP request without a body.
-    # @!scope class
+    # @overload options()
+    #   Returns current Connection options.
     #
-    # @param url [String] The optional String base URL to use as a prefix for
-    #            all requests.  Can also be the options Hash.
-    # @param params [Hash] Hash of URI query unencoded key/value pairs.
-    # @param headers [Hash] unencoded HTTP header key/value pairs.
+    # @overload options(url, params = nil, headers = nil)
+    #   Makes an OPTIONS HTTP request to the given URL.
+    #   @param url [String] String base URL to sue as a prefix for all requests.
+    #   @param params [Hash] Hash of URI query unencoded key/value pairs.
+    #   @param headers [Hash] unencoded HTTP header key/value pairs.
     #
     # @example
     #   conn.options '/items/1'


### PR DESCRIPTION
This fixes the `yard-junk` errors reported by #958 by using the `@overload` tag as [suggested by the yard author](https://github.com/lsegal/yard/issues/439#issuecomment-3292412). 

TODO:

* [x] Finalize #958 _without_ merging
* [x] Finish and merge this PR
* [ ] Merge #958