### PR TITLE
Fix Memoized w/o block

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -171,11 +171,11 @@ module Faraday
       @attribute_options ||= {}
     end
 
-    def self.memoized(key)
+    def self.memoized(key, &block)
       if !block_given?
         raise ArgumentError, "#memoized must be called with a block"
       end
-      memoized_attributes[key.to_sym] = Proc.new
+      memoized_attributes[key.to_sym] = block
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{key}() self[:#{key}]; end
       RUBY

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -172,9 +172,10 @@ module Faraday
     end
 
     def self.memoized(key, &block)
-      if !block_given?
-        raise ArgumentError, "#memoized must be called with a block"
+      unless block_given?
+        raise ArgumentError, '#memoized must be called with a block'
       end
+
       memoized_attributes[key.to_sym] = block
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{key}() self[:#{key}]; end

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -172,6 +172,9 @@ module Faraday
     end
 
     def self.memoized(key)
+      if !block_given?
+        raise ArgumentError, "#memoized must be called with a block"
+      end
       memoized_attributes[key.to_sym] = Proc.new
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{key}() self[:#{key}]; end

--- a/spec/faraday/options/options_spec.rb
+++ b/spec/faraday/options/options_spec.rb
@@ -253,9 +253,7 @@ RSpec.describe Faraday::Options do
     describe '#memoized' do
       subject(:options_class) { Class.new(ParentOptions) }
       it 'requires block' do
-        expect {
-          options_class.memoized(:a)
-        }.to raise_error(ArgumentError)
+        expect { options_class.memoized(:a) }.to raise_error(ArgumentError)
       end
 
       it 'accepts block' do

--- a/spec/faraday/options/options_spec.rb
+++ b/spec/faraday/options/options_spec.rb
@@ -250,6 +250,20 @@ RSpec.describe Faraday::Options do
       end
     end
 
+    describe '#memoized' do
+      subject(:options_class) { Class.new(ParentOptions) }
+      it 'requires block' do
+        expect {
+          options_class.memoized(:a)
+        }.to raise_error(ArgumentError)
+      end
+
+      it 'accepts block' do
+        options_class.memoized(:a) { :foo }
+        expect(options_class.new.a).to eql(:foo)
+      end
+    end
+
     describe '#fetch' do
       subject { SubOptions.new }
 


### PR DESCRIPTION
This fixes `Faraday::Options.memozied` so it stops warning on Ruby 2.7.0. `Proc.new` without an explicit block is now considered a warning: https://docs.ruby-lang.org/en/trunk/NEWS.html

Fixes #961

## Todos

* [ ] squash merge