### PR TITLE
remove test/unit related gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 ruby RUBY_VERSION
 
-gem 'ffi-ncurses', '~> 0.3', platforms: :jruby
 gem 'jruby-openssl', '~> 0.8.8', platforms: :jruby
 gem 'rake'
 
@@ -18,7 +17,6 @@ group :test do
   gem 'em-synchrony', '>= 1.0.3', require: %w[em-synchrony em-synchrony/em-http]
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
-  gem 'minitest', '>= 5.0.5'
   gem 'net-http-persistent'
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack-test', '>= 0.6', require: 'rack/test'


### PR DESCRIPTION
While investigating whether jruby ci builds would be helpful, I tracked the `ffi-ncurses` gem to https://github.com/lostisland/faraday/commit/21a92c6eb3b36f81da12244c5910066c16e7088e. It looks like it was needed to improve the display of test results. Now that we're 100% on rspec, this and the minitests gems are both unused when running the test suite.