### PR TITLE
use multipart-parser gem in multipart tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :test do
   gem 'em-synchrony', '>= 1.0.3', require: %w[em-synchrony em-synchrony/em-http]
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
+  gem 'multipart-parser'
   gem 'net-http-persistent'
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack-test', '>= 0.6', require: 'rack/test'

--- a/spec/faraday/request/multipart_spec.rb
+++ b/spec/faraday/request/multipart_spec.rb
@@ -10,65 +10,67 @@ RSpec.describe Faraday::Request::Multipart do
       b.adapter :test do |stub|
         stub.post('/echo') do |env|
           posted_as = env[:request_headers]['Content-Type']
-          [200, { 'Content-Type' => posted_as }, env[:body]]
+          expect(env[:body]).to be_a_kind_of(Faraday::CompositeReadIO)
+          [200, { 'Content-Type' => posted_as }, env[:body].read]
         end
       end
     end
   end
 
   shared_examples 'a multipart request' do
-    it 'forms a multipart request' do
-      response = conn.post('/echo', payload)
-
-      expect(response.body).to be_a_kind_of(Faraday::CompositeReadIO)
-      match = format(
-        'multipart/form-data; boundary=%<boundary>s',
-        boundary: Faraday::Request::Multipart::DEFAULT_BOUNDARY_PREFIX
-      )
-      expect(response.headers['Content-Type']).to start_with(match)
-
-      response.body.send(:ios).map(&:read).each do |io|
-        re = regexes.detect { |r| io =~ r }
-        regexes.delete(re) if re
-      end
-      expect(regexes).to eq([])
-    end
-
     it 'generates a unique boundary for each request' do
       response1 = conn.post('/echo', payload)
       response2 = conn.post('/echo', payload)
-      expect(response1.headers['Content-Type']).not_to eq(
-        response2.headers['Content-Type']
-      )
+
+      b1 = parse_multipart_boundary(response1.headers['Content-Type'])
+      b2 = parse_multipart_boundary(response2.headers['Content-Type'])
+      expect(b1).to_not eq(b2)
     end
   end
 
   context 'when multipart objects in param' do
-    let(:regexes) do
-      [/name\=\"a\"/,
-       /name=\"b\[c\]\"\; filename\=\"multipart_spec\.rb\"/,
-       /name=\"b\[d\]\"/]
-    end
-
     let(:payload) do
       {
         a: 1,
         b: {
-          c: Faraday::UploadIO.new(__FILE__, 'text/x-ruby'),
+          c: Faraday::UploadIO.new(__FILE__, 'text/x-ruby', nil,
+                                   'Content-Disposition' => 'form-data; foo=1'),
           d: 2
         }
       }
     end
     it_behaves_like 'a multipart request'
+
+    it 'forms a multipart request' do
+      response = conn.post('/echo', payload)
+
+      boundary = parse_multipart_boundary(response.headers['Content-Type'])
+      result = parse_multipart(boundary, response.body)
+      expect(result[:errors]).to be_empty
+
+      part_a, body_a = result.part('a')
+      expect(part_a).to_not be_nil
+      expect(part_a.filename).to be_nil
+      expect(body_a).to eq('1')
+
+      part_bc, body_bc = result.part('b[c]')
+      expect(part_bc).to_not be_nil
+      expect(part_bc.filename).to eq('multipart_spec.rb')
+      expect(part_bc.headers['content-disposition']).to eq(
+        'form-data; foo=1; name="b[c]"; filename="multipart_spec.rb"'
+      )
+      expect(part_bc.headers['content-type']).to eq('text/x-ruby')
+      expect(part_bc.headers['content-transfer-encoding']).to eq('binary')
+      expect(body_bc).to eq(File.read(__FILE__))
+
+      part_bd, body_bd = result.part('b[d]')
+      expect(part_bd).to_not be_nil
+      expect(part_bd.filename).to be_nil
+      expect(body_bd).to eq('2')
+    end
   end
 
   context 'when multipart objects in array param' do
-    let(:regexes) do
-      [/name\=\"a\"/,
-       /name=\"b\[\]\[c\]\"\; filename\=\"multipart_spec\.rb\"/,
-       /name=\"b\[\]\[d\]\"/]
-    end
-
     let(:payload) do
       {
         a: 1,
@@ -78,6 +80,35 @@ RSpec.describe Faraday::Request::Multipart do
         }]
       }
     end
+
     it_behaves_like 'a multipart request'
+
+    it 'forms a multipart request' do
+      response = conn.post('/echo', payload)
+
+      boundary = parse_multipart_boundary(response.headers['Content-Type'])
+      result = parse_multipart(boundary, response.body)
+      expect(result[:errors]).to be_empty
+
+      part_a, body_a = result.part('a')
+      expect(part_a).to_not be_nil
+      expect(part_a.filename).to be_nil
+      expect(body_a).to eq('1')
+
+      part_bc, body_bc = result.part('b[][c]')
+      expect(part_bc).to_not be_nil
+      expect(part_bc.filename).to eq('multipart_spec.rb')
+      expect(part_bc.headers['content-disposition']).to eq(
+        'form-data; name="b[][c]"; filename="multipart_spec.rb"'
+      )
+      expect(part_bc.headers['content-type']).to eq('text/x-ruby')
+      expect(part_bc.headers['content-transfer-encoding']).to eq('binary')
+      expect(body_bc).to eq(File.read(__FILE__))
+
+      part_bd, body_bd = result.part('b[][d]')
+      expect(part_bd).to_not be_nil
+      expect(part_bd.filename).to be_nil
+      expect(body_bd).to eq('2')
+    end
   end
 end

--- a/spec/faraday/request/multipart_spec.rb
+++ b/spec/faraday/request/multipart_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-Faraday::CompositeReadIO.class_eval { attr_reader :ios }
-
 RSpec.describe Faraday::Request::Multipart do
   let(:conn) do
     Faraday.new do |b|

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'multipart_parser/reader'
+
 module Faraday
   module HelperMethods
     def self.included(base)
@@ -86,6 +88,37 @@ module Faraday
 
     def multipart_file
       Faraday::UploadIO.new(__FILE__, 'text/x-ruby')
+    end
+
+    # parse boundary out of a Content-Type header like:
+    #   Content-Type: multipart/form-data; boundary=gc0p4Jq0M2Yt08jU534c0p
+    def parse_multipart_boundary(ctype)
+      MultipartParser::Reader.extract_boundary_value(ctype)
+    end
+
+    # parse a multipart MIME message, returning a hash of any multipart errors
+    def parse_multipart(boundary, body)
+      reader = MultipartParser::Reader.new(boundary)
+      result = { errors: [], parts: [] }
+      def result.part(name)
+        hash = self[:parts].detect { |h| h[:part].name == name }
+        [hash[:part], hash[:body].join]
+      end
+
+      reader.on_part do |part|
+        result[:parts] << thispart = {
+          part: part,
+          body: []
+        }
+        part.on_data do |chunk|
+          thispart[:body] << chunk
+        end
+      end
+      reader.on_error do |msg|
+        result[:errors] << msg
+      end
+      reader.write(body)
+      result
     end
 
     def method_with_body?(method)


### PR DESCRIPTION
This updates the multipart tests to use the [multipart-parser](https://github.com/danabr/multipart-parser) gem. This decouples the tests from the multipart middleware implementation. The tests can also check on other specific details of the multipart message, such as Content-Disposition.