### PR TITLE
Expand readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,15 +290,6 @@ Faraday is intended to be a generic interface between your code and the adapter.
 
 When that happens, you can pass a block when specifying the adapter to customize it. The block parameter will change based on the adapter you're using. See below for some examples.
 
-### Patron
-```ruby
-conn = Faraday.new(...) do |f|
-  f.adapter :patron do |session| # yields Patron::Session
-    session.max_redirects = 10
-  end
-end
-```
-
 ### HTTPClient
 ```ruby
 conn = Faraday.new(...) do |f|
@@ -379,7 +370,7 @@ See [LICENSE][] for details.
 [persistent]:   ./docs/adapters/net_http_persistent.md
 [travis]:       https://travis-ci.org/lostisland/faraday
 [excon]:        https://github.com/excon/excon#readme
-[patron]:       http://toland.github.io/patron/
+[patron]:       ./docs/adapters/patron.md
 [eventmachine]: https://github.com/igrigorik/em-http-request#readme
 [httpclient]:   https://github.com/nahi/httpclient
 [typhoeus]:     https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/adapters/faraday.rb

--- a/README.md
+++ b/README.md
@@ -290,16 +290,6 @@ Faraday is intended to be a generic interface between your code and the adapter.
 
 When that happens, you can pass a block when specifying the adapter to customize it. The block parameter will change based on the adapter you're using. See below for some examples.
 
-### HTTPClient
-```ruby
-conn = Faraday.new(...) do |f|
-  f.adapter :httpclient do |client| # yields HTTPClient
-    client.keep_alive_timeout = 20
-    client.ssl_config.timeout = 25
-  end
-end
-```
-
 ## Using Faraday for testing
 
 ```ruby
@@ -372,7 +362,7 @@ See [LICENSE][] for details.
 [excon]:        ./docs/adapters/excon.md
 [patron]:       ./docs/adapters/patron.md
 [eventmachine]: https://github.com/igrigorik/em-http-request#readme
-[httpclient]:   https://github.com/nahi/httpclient
+[httpclient]:   ./docs/adapters/httpclient.md
 [typhoeus]:     https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/adapters/faraday.rb
 [jruby]:        http://jruby.org/
 [rubinius]:     http://rubini.us/

--- a/README.md
+++ b/README.md
@@ -302,16 +302,6 @@ conn = Faraday.new(...) do |f|
 end
 ```
 
-### NetHttpPersistent
-```ruby
-conn = Faraday.new(...) do |f|
-  f.adapter :net_http_persistent, pool_size: 5 do |http| # yields Net::HTTP::Persistent
-    http.idle_timeout = 100
-    http.retry_change_requests = true
-  end
-end
-```
-
 ### Patron
 ```ruby
 conn = Faraday.new(...) do |f|
@@ -398,7 +388,7 @@ Copyright (c) 2009-2017 [Rick Olson](mailto:technoweenie@gmail.com), Zack Hobson
 See [LICENSE][] for details.
 
 [net_http]:     http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html
-[persistent]:   https://github.com/drbrain/net-http-persistent
+[persistent]:   ./docs/adapters/net_http_persistent.md
 [travis]:       https://travis-ci.org/lostisland/faraday
 [excon]:        https://github.com/excon/excon#readme
 [patron]:       http://toland.github.io/patron/

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ But before you start coding, please read our [Contributing Guide](https://github
 Copyright (c) 2009-2017 [Rick Olson](mailto:technoweenie@gmail.com), Zack Hobson.
 See [LICENSE][] for details.
 
-[net_http]:     http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html
+[net_http]:     ./docs/adapters/net_http.md
 [persistent]:   ./docs/adapters/net_http_persistent.md
 [travis]:       https://travis-ci.org/lostisland/faraday
 [excon]:        https://github.com/excon/excon#readme

--- a/README.md
+++ b/README.md
@@ -290,18 +290,6 @@ Faraday is intended to be a generic interface between your code and the adapter.
 
 When that happens, you can pass a block when specifying the adapter to customize it. The block parameter will change based on the adapter you're using. See below for some examples.
 
-### NetHttp
-```ruby
-conn = Faraday.new(...) do |f|
-  f.adapter :net_http do |http| # yields Net::HTTP
-    http.idle_timeout = 100
-    http.verify_callback = lambda do | preverify_ok, cert_store |
-      # do something here...
-    end
-  end
-end
-```
-
 ### Patron
 ```ruby
 conn = Faraday.new(...) do |f|

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Faraday supports these adapters out of the box:
 * [Net::HTTP::Persistent][persistent]
 * [Excon][excon]
 * [Patron][patron]
-* [EventMachine][eventmachine]
+* [EM-Synchrony][em-synchrony]
 * [HTTPClient][httpclient]
 
 Adapters are slowly being moved into their own gems, or bundled with HTTP clients.
@@ -361,7 +361,7 @@ See [LICENSE][] for details.
 [travis]:       https://travis-ci.org/lostisland/faraday
 [excon]:        ./docs/adapters/excon.md
 [patron]:       ./docs/adapters/patron.md
-[eventmachine]: https://github.com/igrigorik/em-http-request#readme
+[em-synchrony]: ./docs/adapters/em-synchrony.md
 [httpclient]:   ./docs/adapters/httpclient.md
 [typhoeus]:     https://github.com/typhoeus/typhoeus/blob/master/lib/typhoeus/adapters/faraday.rb
 [jruby]:        http://jruby.org/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-### THIS IS FARADAY `master` BRANCH, WHICH CONTAINS VERSION 1.0
-VERSION 1.0 IS NOT OFFICIALLY RELEASED YET
-
-LATEST STABLE RELEASE v0.15 IS IN BRANCH [0.1x](https://github.com/lostisland/faraday/tree/0.1x)
-
 # Faraday
 
 [![Gem Version](https://badge.fury.io/rb/faraday.svg)](https://rubygems.org/gems/faraday)
@@ -12,7 +7,7 @@ LATEST STABLE RELEASE v0.15 IS IN BRANCH [0.1x](https://github.com/lostisland/fa
 [![Gitter](https://badges.gitter.im/lostisland/faraday.svg)](https://gitter.im/lostisland/faraday?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 
-Faraday is an HTTP client lib that provides a common interface over many
+Faraday is an HTTP client library that provides a common interface over many
 adapters (such as Net::HTTP) and embraces the concept of Rack middleware when
 processing the request/response cycle.
 
@@ -75,12 +70,12 @@ conn = Faraday.new(:url => 'http://sushi.com/api_key=s3cr3t') do |faraday|
 end
 
 # Override the log formatting on demand
- 
+
 class MyFormatter < Faraday::Response::Logger::Formatter
   def request(env)
-    info('Request', env)  
+    info('Request', env)
   end
-  
+
   def request(env)
     info('Response', env)
   end

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ See [LICENSE][] for details.
 [net_http]:     ./docs/adapters/net_http.md
 [persistent]:   ./docs/adapters/net_http_persistent.md
 [travis]:       https://travis-ci.org/lostisland/faraday
-[excon]:        https://github.com/excon/excon#readme
+[excon]:        ./docs/adapters/excon.md
 [patron]:       ./docs/adapters/patron.md
 [eventmachine]: https://github.com/igrigorik/em-http-request#readme
 [httpclient]:   https://github.com/nahi/httpclient

--- a/docs/adapters/em-http.md
+++ b/docs/adapters/em-http.md
@@ -1,0 +1,21 @@
+# EM-HTTP Adapter
+
+This Adapter uses the [em-http-request][rdoc] gem to make HTTP requests.
+
+```ruby
+conn = Faraday.new(...) do |f|
+  # no custom options available
+  f.adapter :em_http
+end
+```
+
+## Links
+
+* [Gem RDoc][rdoc]
+* [Gem source][src]
+* [Adapter RDoc][adapter_rdoc]
+* [EM-HTTP Adapter](./em-http.md)
+
+[rdoc]: https://www.rubydoc.info/gems/em-http-request
+[src]: https://github.com/igrigorik/em-http-request#readme
+[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/EMHttp

--- a/docs/adapters/em-synchrony.md
+++ b/docs/adapters/em-synchrony.md
@@ -1,0 +1,21 @@
+# EM-Synchrony Adapter
+
+This Adapter uses the [em-synchrony][rdoc] gem to make HTTP requests.
+
+```ruby
+conn = Faraday.new(...) do |f|
+  # no custom options available
+  f.adapter :em_synchrony
+end
+```
+
+## Links
+
+* [Gem RDoc][rdoc]
+* [Gem source][src]
+* [Adapter RDoc][adapter_rdoc]
+* [EM-HTTP Adapter](./em-http.md)
+
+[rdoc]: https://www.rubydoc.info/gems/em-synchrony
+[src]: https://github.com/igrigorik/em-synchrony
+[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/EMSynchrony

--- a/docs/adapters/excon.md
+++ b/docs/adapters/excon.md
@@ -1,0 +1,20 @@
+# Excon Adapter
+
+This Adapter uses the [excon][rdoc] gem to make HTTP requests.
+
+```ruby
+conn = Faraday.new(...) do |f|
+  # no custom options available
+  f.adapter :excon
+end
+```
+
+## Links
+
+* [Gem RDoc][rdoc]
+* [Gem source][src]
+* [Adapter RDoc][adapter_rdoc]
+
+[rdoc]: https://www.rubydoc.info/gems/excon
+[src]: https://github.com/excon/excon
+[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/Excon

--- a/docs/adapters/httpclient.md
+++ b/docs/adapters/httpclient.md
@@ -1,0 +1,23 @@
+# HTTPClient Adapter
+
+This Adapter uses the [httpclient][rdoc] gem to make HTTP requests.
+
+```ruby
+conn = Faraday.new(...) do |f|
+  f.adapter :httpclient do |client|
+    # yields HTTPClient
+    client.keep_alive_timeout = 20
+    client.ssl_config.timeout = 25
+  end
+end
+```
+
+## Links
+
+* [Gem RDoc][rdoc]
+* [Gem source][src]
+* [Adapter RDoc][adapter_rdoc]
+
+[rdoc]: https://www.rubydoc.info/gems/httpclient
+[src]: https://github.com/nahi/httpclient
+[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/HTTPClient

--- a/docs/adapters/net_http.md
+++ b/docs/adapters/net_http.md
@@ -1,0 +1,24 @@
+# Net::HTTP Adapter
+
+This Adapter uses the Net::HTTP client from the ruby standard library to make
+HTTP requests.
+
+```ruby
+conn = Faraday.new(...) do |f|
+  f.adapter :net_http do |http|
+    # yields Net::HTTP
+    http.idle_timeout = 100
+    http.verify_callback = lambda do |preverify, cert_store|
+      # do something here...
+    end
+  end
+end
+```
+
+## Links
+
+* [Net::HTTP RDoc][rdoc]
+* [Adapter RDoc][adapter_rdoc]
+
+[rdoc]: http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html
+[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/NetHttp

--- a/docs/adapters/net_http_persistent.md
+++ b/docs/adapters/net_http_persistent.md
@@ -1,0 +1,23 @@
+# Net::HTTP::Persistent
+
+This Adapter uses the [net-http-persistent][gem] gem to make HTTP requests.
+
+```ruby
+conn = Faraday.new(...) do |f|
+  f.adapter :net_http_persistent, pool_size: 5 do |http|
+    # yields Net::HTTP::Persistent
+    http.idle_timeout = 100
+    http.retry_change_requests = true
+  end
+end
+```
+
+## Links
+
+* [Gem][gem]
+* [Gem source code][src]
+* [Adapter rdoc][rdoc]
+
+[gem]: https://rubygems.org/gems/net-http-persistent/versions/2.9.4
+[src]: https://github.com/drbrain/net-http-persistent
+[rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/NetHttpPersistent

--- a/docs/adapters/net_http_persistent.md
+++ b/docs/adapters/net_http_persistent.md
@@ -1,6 +1,6 @@
-# Net::HTTP::Persistent
+# Net::HTTP::Persistent Adapter
 
-This Adapter uses the [net-http-persistent][gem] gem to make HTTP requests.
+This Adapter uses the [net-http-persistent][rdoc] gem to make HTTP requests.
 
 ```ruby
 conn = Faraday.new(...) do |f|
@@ -14,10 +14,10 @@ end
 
 ## Links
 
-* [Gem][gem]
-* [Gem source code][src]
-* [Adapter rdoc][rdoc]
+* [Gem RDoc][rdoc]
+* [Gem source][src]
+* [Adapter RDoc][adapter_rdoc]
 
-[gem]: https://rubygems.org/gems/net-http-persistent/versions/2.9.4
+[rdoc]: https://www.rubydoc.info/gems/net-http-persistent
 [src]: https://github.com/drbrain/net-http-persistent
-[rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/NetHttpPersistent
+[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/NetHttpPersistent

--- a/docs/adapters/patron.md
+++ b/docs/adapters/patron.md
@@ -1,0 +1,22 @@
+# Patron Adapter
+
+This Adapter uses the [patron][rdoc] gem to make HTTP requests.
+
+```ruby
+conn = Faraday.new(...) do |f|
+  f.adapter :patron do |session|
+    # yields Patron::Session
+    session.max_redirects = 10
+  end
+end
+```
+
+## Links
+
+* [Gem RDoc][rdoc]
+* [Gem source][src]
+* [Adapter RDoc][adapter_rdoc]
+
+[rdoc]: https://www.rubydoc.info/gems/patron
+[src]: https://github.com/toland/patron
+[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/Patron


### PR DESCRIPTION
I think the current Faraday readme is pretty long, containing:

* Description, 3rd party badges
* List of adapters
* Basic usage
* Parameter serialization
* Authentication
* Proxy support
* Advanced middleware
* Writing middleware
* Adhoc adapter customization
* Testing
* Supported ruby versions
* Contributing Guide
* Copyrights

This seems like it could be simultaneously overwhelming for new users, while frustratingly incomplete for experienced users. I'd like to extract most of this documentation to separate pages and sections under `./docs`. This gives us the room to expand on complicated topics that need it, while hiding some of the more uncommon use cases from the readme.

I started with the "Adhoc Adapter Customization" section. I ripped each one out to a separate page,  linked to from the adapter list at the top of the readme. I also added links to the 3rd party gem, its source, and the adapter class's rdoc. 

Also, we could probably update each adapter to yield its connection object. It doesn't make sense that adapters like Patron do it, when the Excon adapter doesn't. That'll be for another PR :)