### PR TITLE
Rubocop: use performance gem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,9 @@ jobs:
       - run:
           name: RuboCop
           command: |
-            gem install rubocop rubocop-junit_formatter  --no-document
+            gem install rubocop rubocop-junit_formatter rubocop-performance --no-document
             rubocop --require rubocop/formatter/junit_formatter \
+                    --require rubocop-performance \
                     --format progress \
                     --format RuboCop::Formatter::JUnitFormatter \
                     --out ~/test-results/rubocop/results.xml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: .rubocop_todo.yml
 
+require:
+  - rubocop-performance
+
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,8 @@ group :test do
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'
   gem 'rspec_junit_formatter', '~> 0.4'
-  gem 'rubocop', '~> 0.66.0'
+  gem 'rubocop', '~> 0.67.2'
+  gem 'rubocop-performance', '~> 1.0'
   gem 'simplecov'
   gem 'typhoeus', '~> 1.3', git: 'https://github.com/typhoeus/typhoeus.git',
                             require: 'typhoeus'

--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -135,16 +135,16 @@ module Faraday
           end
           raise_error(error) if error
         end
-      rescue EventMachine::Connectify::CONNECTError => err
-        if err.message.include?('Proxy Authentication Required')
+      rescue EventMachine::Connectify::CONNECTError => e
+        if e.message.include?('Proxy Authentication Required')
           raise Faraday::ConnectionFailed,
                 %(407 "Proxy Authentication Required ")
         end
 
-        raise Faraday::ConnectionFailed, err
-      rescue StandardError => err
-        if defined?(OpenSSL) && err.is_a?(OpenSSL::SSL::SSLError)
-          raise Faraday::SSLError, err
+        raise Faraday::ConnectionFailed, e
+      rescue StandardError => e
+        if defined?(OpenSSL) && e.is_a?(OpenSSL::SSL::SSLError)
+          raise Faraday::SSLError, e
         end
 
         raise

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -38,28 +38,28 @@ module Faraday
         @app.call env
       rescue Errno::ECONNREFUSED
         raise Faraday::ConnectionFailed, $ERROR_INFO
-      rescue EventMachine::Connectify::CONNECTError => err
-        if err.message.include?('Proxy Authentication Required')
+      rescue EventMachine::Connectify::CONNECTError => e
+        if e.message.include?('Proxy Authentication Required')
           raise Faraday::ConnectionFailed,
                 %(407 "Proxy Authentication Required")
         end
 
-        raise Faraday::ConnectionFailed, err
-      rescue Errno::ETIMEDOUT => err
-        raise Faraday::TimeoutError, err
-      rescue RuntimeError => err
-        if err.message == 'connection closed by server'
-          raise Faraday::ConnectionFailed, err
+        raise Faraday::ConnectionFailed, e
+      rescue Errno::ETIMEDOUT => e
+        raise Faraday::TimeoutError, e
+      rescue RuntimeError => e
+        if e.message == 'connection closed by server'
+          raise Faraday::ConnectionFailed, e
         end
 
-        if err.message.include?('timeout error')
-          raise Faraday::TimeoutError, err
+        if e.message.include?('timeout error')
+          raise Faraday::TimeoutError, e
         end
 
         raise
-      rescue StandardError => err
-        if defined?(OpenSSL) && err.is_a?(OpenSSL::SSL::SSLError)
-          raise Faraday::SSLError, err
+      rescue StandardError => e
+        if defined?(OpenSSL) && e.is_a?(OpenSSL::SSL::SSLError)
+          raise Faraday::SSLError, e
         end
 
         raise

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -52,9 +52,7 @@ module Faraday
           raise Faraday::ConnectionFailed, e
         end
 
-        if e.message.include?('timeout error')
-          raise Faraday::TimeoutError, e
-        end
+        raise Faraday::TimeoutError, e if e.message.include?('timeout error')
 
         raise
       rescue StandardError => e

--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -26,14 +26,14 @@ module Faraday
                       resp.reason_phrase)
 
         @app.call(env)
-      rescue ::Excon::Errors::SocketError => err
-        raise Faraday::TimeoutError, err if err.message =~ /\btimeout\b/
+      rescue ::Excon::Errors::SocketError => e
+        raise Faraday::TimeoutError, e if e.message =~ /\btimeout\b/
 
-        raise Faraday::SSLError, err if err.message =~ /\bcertificate\b/
+        raise Faraday::SSLError, e if e.message =~ /\bcertificate\b/
 
-        raise Faraday::ConnectionFailed, err
-      rescue ::Excon::Errors::Timeout => err
-        raise Faraday::TimeoutError, err
+        raise Faraday::ConnectionFailed, e
+      rescue ::Excon::Errors::Timeout => e
+        raise Faraday::TimeoutError, e
       end
 
       # @return [Excon]

--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -53,8 +53,8 @@ module Faraday
         @app.call env
       rescue ::HTTPClient::TimeoutError, Errno::ETIMEDOUT
         raise Faraday::TimeoutError, $ERROR_INFO
-      rescue ::HTTPClient::BadResponseError => err
-        if err.message.include?('status 407')
+      rescue ::HTTPClient::BadResponseError => e
+        if e.message.include?('status 407')
           raise Faraday::ConnectionFailed,
                 %(407 "Proxy Authentication Required ")
         end
@@ -62,9 +62,9 @@ module Faraday
         raise Faraday::ClientError, $ERROR_INFO
       rescue Errno::EADDRNOTAVAIL, Errno::ECONNREFUSED, IOError, SocketError
         raise Faraday::ConnectionFailed, $ERROR_INFO
-      rescue StandardError => err
-        if defined?(OpenSSL) && err.is_a?(OpenSSL::SSL::SSLError)
-          raise Faraday::SSLError, err
+      rescue StandardError => e
+        if defined?(OpenSSL) && e.is_a?(OpenSSL::SSL::SSLError)
+          raise Faraday::SSLError, e
         end
 
         raise

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -50,12 +50,12 @@ module Faraday
 
           begin
             http_response = perform_request(http, env)
-          rescue *NET_HTTP_EXCEPTIONS => err
-            if defined?(OpenSSL) && err.is_a?(OpenSSL::SSL::SSLError)
-              raise Faraday::SSLError, err
+          rescue *NET_HTTP_EXCEPTIONS => e
+            if defined?(OpenSSL) && e.is_a?(OpenSSL::SSL::SSLError)
+              raise Faraday::SSLError, e
             end
 
-            raise Faraday::ConnectionFailed, err
+            raise Faraday::ConnectionFailed, e
           end
 
           save_response(env, http_response.code.to_i,

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -51,13 +51,13 @@ module Faraday
 
       def perform_request(http, env)
         http.request env[:url], create_request(env)
-      rescue Errno::ETIMEDOUT => error
-        raise Faraday::TimeoutError, error
-      rescue Net::HTTP::Persistent::Error => error
-        raise Faraday::TimeoutError, error if error.message.include? 'Timeout'
+      rescue Errno::ETIMEDOUT => e
+        raise Faraday::TimeoutError, e
+      rescue Net::HTTP::Persistent::Error => e
+        raise Faraday::TimeoutError, e if e.message.include? 'Timeout'
 
-        if error.message.include? 'connection refused'
-          raise Faraday::ConnectionFailed, error
+        if e.message.include? 'connection refused'
+          raise Faraday::ConnectionFailed, e
         end
 
         raise

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -53,19 +53,19 @@ module Faraday
                       response.headers, reason_phrase)
 
         @app.call env
-      rescue ::Patron::TimeoutError => err
-        if connection_timed_out_message?(err.message)
-          raise Faraday::ConnectionFailed, err
+      rescue ::Patron::TimeoutError => e
+        if connection_timed_out_message?(e.message)
+          raise Faraday::ConnectionFailed, e
         end
 
-        raise Faraday::TimeoutError, err
-      rescue ::Patron::Error => err
-        if err.message.include?('code 407')
+        raise Faraday::TimeoutError, e
+      rescue ::Patron::Error => e
+        if e.message.include?('code 407')
           raise Faraday::ConnectionFailed,
                 %(407 "Proxy Authentication Required ")
         end
 
-        raise Faraday::ConnectionFailed, err
+        raise Faraday::ConnectionFailed, e
       end
 
       if loaded? && defined?(::Patron::Request::VALID_ACTIONS)

--- a/lib/faraday/dependency_loader.rb
+++ b/lib/faraday/dependency_loader.rb
@@ -9,8 +9,8 @@ module Faraday
     # libraries
     def dependency(lib = nil)
       lib ? require(lib) : yield
-    rescue LoadError, NameError => error
-      self.load_error = error
+    rescue LoadError, NameError => e
+      self.load_error = e
     end
 
     def new(*)

--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -150,20 +150,20 @@ module Faraday
               raise Faraday::RetriableResponse.new(nil, resp)
             end
           end
-        rescue @errmatch => exception
-          if retries.positive? && retry_request?(env, exception)
+        rescue @errmatch => e
+          if retries.positive? && retry_request?(env, e)
             retries -= 1
             rewind_files(request_body)
-            @options.retry_block.call(env, @options, retries, exception)
+            @options.retry_block.call(env, @options, retries, e)
             if (sleep_amount = calculate_sleep_amount(retries + 1, env))
               sleep sleep_amount
               retry
             end
           end
 
-          raise unless exception.is_a?(Faraday::RetriableResponse)
+          raise unless e.is_a?(Faraday::RetriableResponse)
 
-          exception.response
+          e.response
         end
       end
 

--- a/spec/faraday/request/instrumentation_spec.rb
+++ b/spec/faraday/request/instrumentation_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Faraday::Request::Instrumentation do
   it 'defaults to ActiveSupport::Notifications' do
     begin
       res = options.instrumenter
-    rescue NameError => err
-      expect(err.to_s).to match('ActiveSupport')
+    rescue NameError => e
+      expect(e.to_s).to match('ActiveSupport')
     else
       expect(res).to eq(ActiveSupport::Notifications)
     end


### PR DESCRIPTION
## Description

This PR fixes the build.

- Rubocop configuration: add rubocop-performance gem and require it (in CI and in development mode as a configuration in the `.rubocop.yml`)
- Lint fixes, including [RescueExceptionsVariableName](https://rubocop.readthedocs.io/en/latest/cops_naming/#namingrescuedexceptionsvariablename)
