### PR TITLE
Skip tests that do not run on JRuby

### DIFF
--- a/spec/faraday/adapter/em_http_spec.rb
+++ b/spec/faraday/adapter/em_http_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Faraday::Adapter::EMHttp do
+RSpec.describe Faraday::Adapter::EMHttp, unless: defined?(JRUBY_VERSION) do
   features :request_body_on_query_methods, :reason_phrase_parse, :trace_method,
            :skip_response_body_on_head, :parallel, :local_socket_binding
 

--- a/spec/faraday/adapter/em_synchrony_spec.rb
+++ b/spec/faraday/adapter/em_synchrony_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Faraday::Adapter::EMSynchrony do
+RSpec.describe Faraday::Adapter::EMSynchrony, unless: defined?(JRUBY_VERSION) do
   features :request_body_on_query_methods, :reason_phrase_parse,
            :skip_response_body_on_head, :parallel, :local_socket_binding
 

--- a/spec/faraday/adapter/patron_spec.rb
+++ b/spec/faraday/adapter/patron_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Faraday::Adapter::Patron do
+RSpec.describe Faraday::Adapter::Patron, unless: defined?(JRUBY_VERSION) do
   features :reason_phrase_parse
 
   it_behaves_like 'an adapter'

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Faraday::RackBuilder do
 
     it 'raises an error while making a request' do
       expect { conn.get('/') }.to raise_error(RuntimeError) do |err|
-        expect(err.message).to eq('missing dependency for Broken: cannot load such file -- zomg/i_dont/exist')
+        expect(err.message).to match(%r{missing dependency for Broken: .+ -- zomg/i_dont/exist})
       end
     end
   end


### PR DESCRIPTION
Add RSpec skips to test cases that can not run on JRuby.

## Description

There are adapters that do not support JRuby.

This is about investigating a JRuby build for the CI.

We do not have a maintainer which can work focused with JRuby, right now, so we want to keep it in there, but not as a _required_ job.



<details>

## Todos

- [x] Be sure that the desired behavior is achieved.
- [x] Investigate and write up `Invalid header type`
- [x] Turn this into GitHub Action format (future)

</details>