### PR TITLE
expose the gemfile.lock file in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,12 @@ shared_ruby_steps: &shared_ruby_steps
           - ./vendor/bundle
     - store_test_results:
         path: ~/test-results/rspec
+    - store_artifacts:
+        path: ./Gemfile.lock
     - persist_to_workspace:
         root: .
         paths:
           - ./vendor/bundle
-          - ./Gemfile.lock
 
 jobs:
   checkout_code:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ shared_ruby_steps: &shared_ruby_steps
         root: .
         paths:
           - ./vendor/bundle
+          - ./Gemfile.lock
 
 jobs:
   checkout_code:


### PR DESCRIPTION
This exposes the Gemfile.lock in CI so we can see the _exact_ ruby gems its using while debugging failures [like this one](https://circleci.com/gh/lostisland/faraday/355).