### PR TITLE
Explain Absolute path behaviour in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ stack and default adapter (see [Faraday::RackBuilder#initialize](https://github.
 A more flexible way to use Faraday is to start with a Connection object. If you want to keep the same defaults, you can use this syntax:
 
 ```ruby
-conn = Faraday.new(:url => 'http://www.example.com')
-response = conn.get '/users'                 # GET http://www.example.com/users'
+conn = Faraday.new(:url => 'http://www.example.com/api')
+response = conn.get 'users'                 # GET http://www.example.com/api/users'
+
+# You can override the path from the connection initializer by using an absolute path
+response = conn.get '/users'                # GET http://www.example.com/users'
 ```
 
 Connections can also take an options hash as a parameter or be configured by using a block. Checkout the section called [Advanced middleware usage](#advanced-middleware-usage) for more details about how to use this block for configurations.


### PR DESCRIPTION
## Description
Updates the REAME to explain how the absolute path overrides the one provided while initialising the connection.
Fixes #976

## Additional notes
Once approved, will need to apply the same to v1.0