### PR TITLE
Add exception for conflict response code

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -61,6 +61,10 @@ module Faraday
   class ProxyAuthError < ClientError
   end
 
+  # Raised by Faraday::Response::RaiseError in case of a 409 response.
+  class ConflictError < ClientError
+  end
+
   # Raised by Faraday::Response::RaiseError in case of a 422 response.
   class UnprocessableEntityError < ClientError
   end

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -24,6 +24,8 @@ module Faraday
           # mimic the behavior that we get with proxy requests with HTTPS
           msg = %(407 "Proxy Authentication Required")
           raise Faraday::ProxyAuthError.new(msg, response_values(env))
+        when 409
+          raise Faraday::ConflictError, response_values(env)
         when 422
           raise Faraday::UnprocessableEntityError, response_values(env)
         when ClientErrorStatuses

--- a/spec/faraday/response/raise_error_spec.rb
+++ b/spec/faraday/response/raise_error_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Faraday::Response::RaiseError do
         stub.get('forbidden') { [403, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('not-found') { [404, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('proxy-error') { [407, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('conflict') { [409, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('unprocessable-entity') { [422, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('4xx') { [499, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('server-error') { [500, { 'X-Error' => 'bailout' }, 'fail'] }
@@ -53,6 +54,13 @@ RSpec.describe Faraday::Response::RaiseError do
   it 'raises Faraday::ProxyAuthError for 407 responses' do
     expect { conn.get('proxy-error') }.to raise_error(Faraday::ProxyAuthError) do |ex|
       expect(ex.message).to eq('407 "Proxy Authentication Required"')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::ConflictError for 409 responses' do
+    expect { conn.get('conflict') }.to raise_error(Faraday::ConflictError) do |ex|
+      expect(ex.message).to eq('the server responded with status 409')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
     end
   end


### PR DESCRIPTION
## Description
I wanted to rescue an exception for 409 response code and I noticed that it was not implemented yet. So, here it is 😄 
