### PR TITLE
Net::OpenTimeout is a Faraday::ConnectionFailed and not a Faraday::Ti…

### DIFF
--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -54,7 +54,9 @@ module Faraday
       rescue Errno::ETIMEDOUT => e
         raise Faraday::TimeoutError, e
       rescue Net::HTTP::Persistent::Error => e
-        raise Faraday::TimeoutError, e if e.message.include? 'Timeout'
+        if e.message.include? 'Timeout' && !e.message.include?("Net::OpenTimeout")
+          raise Faraday::TimeoutError, e
+        end
 
         if e.message.include? 'connection refused'
           raise Faraday::ConnectionFailed, e


### PR DESCRIPTION
…meoutError

according to https://github.com/lostisland/faraday/blob/a217471dc69cfd56604ae79f40de71086f7f5561/lib/faraday/adapter/net_http.rb#L34 open timeout is considered a failed connection, so let's make net-http-persistent behave like net-http ... or I can open the opposite PR to make both raise timeout 🤷‍♂ 

In general I'd think it would be nice to consider Net::OpenTimeout a timeout so that the retry middleware handles it by default, it was added in https://github.com/lostisland/faraday/pull/438

@mislav @iMacTia @mike-bourgeous @rusikf