### PR TITLE
Replace nil values with blank strings in application/x-www-form-urlencoded body

### DIFF
--- a/spec/faraday/request/url_encoded_spec.rb
+++ b/spec/faraday/request/url_encoded_spec.rb
@@ -67,4 +67,11 @@ RSpec.describe Faraday::Request::UrlEncoded do
     response = conn.post('/echo', 'a' => { 'b' => { 'c' => ['d'] } })
     expect(response.body).to eq('a%5Bb%5D%5Bc%5D%5B%5D=d')
   end
+
+  it 'replaces nil values with blank strings' do
+    response = conn.post('/echo', str: nil, fruit: ['apple', nil], user: { name: 'Mislav', web: nil })
+    expect(response.headers['Content-Type']).to eq('application/x-www-form-urlencoded')
+    expected = { 'str' => '', 'fruit' => ['apple', ''], 'user' => { 'name' => 'Mislav', 'web' => '' } }
+    expect(Faraday::Utils.parse_nested_query(response.body)).to eq(expected)
+  end
 end


### PR DESCRIPTION
From what I can tell, params in `application/x-www-form-urlencoded` [must have](https://url.spec.whatwg.org/#urlencoded-serializing) `=` characters in order to be valid, even if their values are `nil`. We initially discovered this in a project of ours that was `POST`-ing data to a Microsoft IIS 8.5 server - it couldn't parse the request body without the `=` characters.

This PR fixes the issue by replacing any `nil` values in the request body with blank strings - which causes the `to_query` method to include `=` characters.