### PR TITLE
rdoc: fix type info for SSLOptions

### DIFF
--- a/lib/faraday/options/ssl_options.rb
+++ b/lib/faraday/options/ssl_options.rb
@@ -13,7 +13,7 @@ module Faraday
   #   @return [String] CA path
   #
   # @!attribute verify_mode
-  #   @return [String] Any `OpenSSL::SSL::` constant (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL.html)
+  #   @return [Integer] Any `OpenSSL::SSL::` constant (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL.html)
   #
   # @!attribute cert_store
   #   @return [OpenSSL::X509::Store] certificate store


### PR DESCRIPTION
The `SSLOptions#verify_mode` property takes the value of an `OpenSSL::SSL::` constant, which happens to be an integer:

```
>> require 'openssl'
>> OpenSSL::SSL::VERIFY_PEER
=> 1
>> OpenSSL::SSL::VERIFY_NONE
=> 0
```

It only seems to be used in the net/http and httpclient libs:

### net_http adapter

https://github.com/lostisland/faraday/blob/b749408e0a2a233dc7911202f5d093eb3712fed5/lib/faraday/adapter/net_http.rb#L154

https://github.com/lostisland/faraday/blob/b749408e0a2a233dc7911202f5d093eb3712fed5/lib/faraday/adapter/net_http.rb#L194-L202

### net_http_persistent

(reuses `#ssl_verify_mode` from the net_http adapter)

https://github.com/lostisland/faraday/blob/b749408e0a2a233dc7911202f5d093eb3712fed5/lib/faraday/adapter/net_http_persistent.rb#L76

### httpclient

https://github.com/lostisland/faraday/blob/b749408e0a2a233dc7911202f5d093eb3712fed5/lib/faraday/adapter/httpclient.rb#L92

https://github.com/lostisland/faraday/blob/b749408e0a2a233dc7911202f5d093eb3712fed5/lib/faraday/adapter/httpclient.rb#L138-L147

