### PR TITLE
Socks proxy support for net/http

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -168,6 +168,11 @@ module Faraday
         TCPSocket.socks_username = proxy[:user] if proxy[:user]
         TCPSocket.socks_password = proxy[:password] if proxy[:password]
         Net::HTTP::SOCKSProxy(proxy[:uri].host, proxy[:uri].port)
+      rescue NoMethodError => err
+        if err.to_s =~ /socks/i
+          raise "SOCKS proxy support requires the socksify gem ~> 1.7.1"
+        end
+        raise
       end
 
       def configure_ssl(http, ssl)


### PR DESCRIPTION
This patches in SOCKS proxy support for the net/http adapter, using this snippet by @yarafan: https://github.com/lostisland/faraday/issues/787#issuecomment-380717908.

I don't want to add the socksify gem as a required gem dependency for faraday. The net/http adapter attempts to load it, but only complains if you try to use a socks proxy:

```
$ irb -Ilib
>> require 'faraday'
=> true
>> Faraday.new(proxy: 'socks://127.0.0.1:6000').get('http://example.com').status
=> RuntimeError (SOCKS proxy support requires the socksify gem ~> 1.7.1)

$ gem install socksify
$ irb -Ilib
>> require 'faraday'
=> true
>> Faraday.new(proxy: 'socks://127.0.0.1:6000').get('http://example.com').status
Faraday::ConnectionFailed (Failed to open TCP connection to 127.0.0.1:6000 (Connection refused - connect(2) for "127.0.0.1" port 6000))
```

This behavior is difficult to test with rspec, so I tested this in the integration test suite [faraday-live](https://github.com/technoweenie/faraday-live/pull/7/files).

Fixes #787 
