### PR TITLE
Website Navigation Fix

### DIFF
--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -1,7 +1,7 @@
 ---
 layout: documentation
 title: "Adapters"
-permalink: /adapters
+permalink: /adapters/
 order: 2
 ---
 

--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -1,7 +1,7 @@
 ---
 layout: documentation
 title: "Middleware"
-permalink: /middleware
+permalink: /middleware/
 next_name: Available Middleware
 next_link: ./list
 order: 3

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,7 +1,7 @@
 ---
 layout: documentation
 title: "Usage"
-permalink: /usage
+permalink: /usage/
 next_name: Customizing the Request
 next_link: ./customize
 order: 1


### PR DESCRIPTION
## Description
Fixes website navigation by adding trailing slashes to /index.md files.
See https://stackoverflow.com/questions/54727643/trailing-slashes-in-jekyll-github-pages-site-cause-404

## Additional Notes
Tested locally and works (but it was working before the change as well.
Hard to say if it will work on GitHub Pages, but we can't really test before merging