### PR TITLE
teach #inspect how to build string without appending to a frozen string

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -151,9 +151,9 @@ module Faraday
         value = send(member)
         values << "#{member}=#{value.inspect}" if value
       end
-      values = values.empty? ? ' (empty)' : (' ' << values.join(', '))
+      values = values.empty? ? '(empty)' : values.join(', ')
 
-      %(#<#{self.class}#{values}>)
+      %(#<#{self.class} #{values}>)
     end
 
     # Internal

--- a/spec/faraday/options/proxy_options_spec.rb
+++ b/spec/faraday/options/proxy_options_spec.rb
@@ -11,11 +11,13 @@ RSpec.describe Faraday::ProxyOptions do
       expect(options.port).to eq(80)
       expect(options.host).to eq('example.org')
       expect(options.scheme).to eq('http')
+      expect(options.inspect).to match('#<Faraday::ProxyOptions uri=')
     end
 
     it 'works with nil' do
       options = Faraday::ProxyOptions.from nil
       expect(options).to be_a_kind_of(Faraday::ProxyOptions)
+      expect(options.inspect).to eq('#<Faraday::ProxyOptions (empty)>')
     end
 
     it 'works with no auth' do

--- a/spec/faraday/options/request_options_spec.rb
+++ b/spec/faraday/options/request_options_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Faraday::RequestOptions do
 
     options.proxy = nil
     expect(options.proxy).to be_nil
-    expect(options.inspect).to be_nil
-    expect(options.inspect).to eq('#<Faraday::RequestOptions (empty)>)')
+    expect(options.inspect).to eq('#<Faraday::RequestOptions (empty)>')
   end
 end

--- a/spec/faraday/options/request_options_spec.rb
+++ b/spec/faraday/options/request_options_spec.rb
@@ -13,5 +13,7 @@ RSpec.describe Faraday::RequestOptions do
 
     options.proxy = nil
     expect(options.proxy).to be_nil
+    expect(options.inspect).to be_nil
+    expect(options.inspect).to eq('#<Faraday::RequestOptions (empty)>)')
   end
 end


### PR DESCRIPTION
The Rubocop effort included (#868) taking advantage of [an optimization that makes all string literals immutable](https://www.mikeperham.com/2018/02/28/ruby-optimization-with-one-magic-comment/). However, it turns out we don't test `#inspect` on the `Faraday::Options` types.

You can trigger this bug easily with the current `master` branch:

```
irb(main):003:0> Faraday.get "http://example.com"
Traceback (most recent call last):
        5: from /Users/rick/.rbenv/versions/2.5.3/bin/irb:11:in `<main>'
        4: from /Users/rick/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/faraday-1.0.0.pre.rc1/lib/faraday/options/env.rb:151:in `inspect'
        3: from /Users/rick/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/faraday-1.0.0.pre.rc1/lib/faraday/options/env.rb:151:in `each'
        2: from /Users/rick/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/faraday-1.0.0.pre.rc1/lib/faraday/options/env.rb:153:in `block in inspect'
        1: from /Users/rick/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/faraday-1.0.0.pre.rc1/lib/faraday/options.rb:154:in `inspect'
FrozenError (can't modify frozen String)
```