### PR TITLE
Docs: format Middleware code example to be visible without scrolling

### DIFF
--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -44,8 +44,10 @@ Examples:
 
 ```ruby
 # uploading a file:
-payload[:profile_pic] = Faraday::UploadIO.new('/path/to/avatar.jpg', 'image/jpeg')
+payload[:profile_pic] = Faraday::UploadIO.new('/path/to/avatar.jpg',
+                                              'image/jpeg')
 
-# "Multipart" middleware detects files and encodes with "multipart/form-data":
+# "Multipart" middleware detects files and encodes with
+# "multipart/form-data":
 conn.put '/profile', payload
 ```

--- a/docs/middleware/request/instrumentation.md
+++ b/docs/middleware/request/instrumentation.md
@@ -17,7 +17,8 @@ They default to `request.faraday` and `ActiveSupport::Notifications` respectivel
 
 ```ruby
 conn = Faraday.new(...) do |f|
-  f.request :instrumentation, name: 'custom_name', instrumenter: MyInstrumenter
+  f.request :instrumentation, name: 'custom_name',
+                              instrumenter: MyInstrumenter
   ...
 end
 ```
@@ -33,11 +34,16 @@ conn = Faraday.new('http://example.com') do |f|
   ...
 end
 
-ActiveSupport::Notifications.subscribe('request.faraday') do |name, starts, ends, _, env|
+ActiveSupport::Notifications.subscribe(
+  'request.faraday'
+) do |name, starts, ends, _, env|
   url = env[:url]
   http_method = env[:method].to_s.upcase
   duration = ends - starts
-  $stdout.puts '[%s] %s %s (%.3f s)' % [url.host, http_method, url.request_uri, duration]
+  $stdout.puts '[%s] %s %s (%.3f s)' % [url.host,
+                                        http_method,
+                                        url.request_uri,
+                                        duration]
 end
 
 conn.get('/search', { a: 1, b: 2 })

--- a/docs/middleware/request/retry.md
+++ b/docs/middleware/request/retry.md
@@ -105,7 +105,9 @@ For example, you might want to keep track of the response statuses:
 ```ruby
 response_statuses = []
 retry_options = {
-  retry_block: -> (env, options, retries, exc) { response_statuses << env.status }
+  retry_block: -> (env, options, retries, exc) {
+    response_statuses << env.status
+  }
 }
 ``` 
 


### PR DESCRIPTION
## Description

This screenshot shows the example going outside the box.

![image](https://user-images.githubusercontent.com/211/60834327-c6a4e980-a1c0-11e9-9806-b913d3da099b.png)

Here's another screenshot:

![image](https://user-images.githubusercontent.com/211/60835032-73339b00-a1c2-11e9-8c8f-98eaf65eb402.png)


I had to scroll to see code.

Solution: make the example visible without scrolling.
