### PR TITLE
Configure Jekyll plugin jekyll-remote-theme to support Docker usage

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,8 +23,10 @@ theme_settings:
 # BUILD SETTINGS
 markdown: kramdown
 remote_theme: rohanchandra/type-theme
+
 plugins:
   - jekyll-feed
+  - jekyll-remote-theme
 
 # GitHub settings
 lsi: false


### PR DESCRIPTION
## Description

I tried to build with Jekyll 3.6.x (`jekyll/jekyll:latest`). It went badly.

```
Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/main.scss':
                    File to import not found or unreadable: type-theme. Load paths: /faraday/docs/_sass /usr/local/bundle/gems/jekyll-theme-primer-0.5.2/_sass on line 2
```

By following the author guide https://github.com/benbalter/jekyll-remote-theme I noticed we were missing an entry.

After this things work for me.

## Todos

- [ ] Tests
- [ ] Documentation

## Additional Notes

I am using docker to build docs.
