### PR TITLE
Reuse Patron session with mutex

### DIFF
--- a/docs/adapters/patron.md
+++ b/docs/adapters/patron.md
@@ -18,6 +18,12 @@ conn = Faraday.new(...) do |f|
 end
 ```
 
+## Multithreading
+
+This adapter use a mutex around the patron session to be thread-safe.
+A [connection_pool](https://rubygems.org/gems/connection_pool) can be
+used to share multiple connections between threads.
+
 ## Links
 
 * [Gem RDoc][rdoc]

--- a/spec/faraday/adapter/patron_spec.rb
+++ b/spec/faraday/adapter/patron_spec.rb
@@ -15,4 +15,21 @@ RSpec.describe Faraday::Adapter::Patron do
 
     expect { conn.get('/') }.to raise_error(RuntimeError, 'Configuration block called')
   end
+
+  it 'reuses the patron session for keep-alive' do
+    last_session = nil
+    conn = Faraday.new do |f|
+      f.adapter :patron do |session|
+        if last_session
+          expect(session).to eq last_session
+        else
+          last_session = session
+        end
+      end
+    end
+
+    stub_request(:get, 'http://example.com')
+    conn.get('http://example.com/')
+    conn.get('http://example.com/')
+  end
 end


### PR DESCRIPTION
Reuse Patron session to support keep-alive/connection reuse and make
them thread-safe using a mutex.

## Description

This reverts the changes from PR #796 and reuse the patron session for keep-alive/connection reuse. To be thread safe, this adds a mutex around the patron session. See [persisted connections](https://github.com/toland/patron#persistent-connections]) and [Threads](https://github.com/toland/patron#persistent-connections) in the patron documentation for more details.

Fixes #1001 

## Todos

- [x] Tests
- [x] Documentation

