### PR TITLE
Add support for setting Ruby Net::HTTP `read_timeout` option separately

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -173,6 +173,8 @@ module Faraday
           end
         end
         http.open_timeout = req[:open_timeout] if req[:open_timeout]
+        http.read_timeout = req[:read_timeout] if req[:read_timeout]
+
         if req[:write_timeout] && http.respond_to?(:write_timeout=)
           http.write_timeout = req[:write_timeout]
         end

--- a/lib/faraday/options/request_options.rb
+++ b/lib/faraday/options/request_options.rb
@@ -3,8 +3,9 @@
 module Faraday
   # RequestOptions contains the configurable properties for a Faraday request.
   class RequestOptions < Options.new(:params_encoder, :proxy, :bind,
-                                     :timeout, :open_timeout, :write_timeout,
-                                     :boundary, :oauth, :context, :on_data)
+                                     :timeout, :open_timeout, :read_timeout,
+                                     :write_timeout, :boundary, :oauth,
+                                     :context, :on_data)
 
     def []=(key, value)
       if key && key.to_sym == :proxy

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Faraday::Adapter::NetHttp do
 
       expect(http.write_timeout).to eq(10) if http.respond_to?(:write_timeout=)
     end
+    it 'supports open_timeout' do
+      adapter.send(:configure_request, http, open_timeout: 10)
+
+      expect(http.open_timeout).to eq(10)
+    end
+    it 'supports read_timeout' do
+      adapter.send(:configure_request, http, read_timeout: 10)
+
+      expect(http.read_timeout).to eq(10)
+    end
 
     context 'with https url' do
       let(:url) { URI('https://example.com') }


### PR DESCRIPTION
## Description
Right now `timeout` setting sets all the timeout values (`read`, `open` & `write` if available). To unify the API with `Net::HTTP` one (which has a dedicated method for `read_timeout` as well) I propose extending the `RequestOptions` by `read_timeout`.