### PR TITLE
Introduces Connection pool in compatible adapters

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
+  spec.add_dependency 'connection_pool', '~> 2.2'
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
 
   spec.require_paths = %w[lib spec/external_adapters]

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'faraday/adapter/concerns/connection_pooling'
+
 module Faraday
   # Base class for all Faraday adapters. Adapters are
   # responsible for fulfilling a Faraday request.
@@ -40,10 +42,14 @@ module Faraday
     extend Parallelism
     self.supports_parallel = false
 
+    include ConnectionPooling
+    self.supports_pooling = false
+
     def initialize(_app = nil, opts = {}, &block)
       @app = ->(env) { env.response }
       @connection_options = opts
       @config_block = block
+      initialize_pool(opts[:pool] || {}) if self.class.supports_pooling
     end
 
     def call(env)

--- a/lib/faraday/adapter/concerns/connection_pooling.rb
+++ b/lib/faraday/adapter/concerns/connection_pooling.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# This module marks an Adapter as supporting connection pooling.
+module ConnectionPooling
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  # Class methods injected into the class including this module.
+  module ClassMethods
+    attr_accessor :supports_pooling
+
+    def inherited(subclass)
+      super
+      subclass.supports_pooling = supports_pooling
+    end
+  end
+
+  attr_reader :pool
+
+  MISSING_CONNECTION_ERROR = 'You need to define a `connection` method' \
+    'in order to support connection pooling!'
+
+  # Initializes the connection pool.
+  #
+  # @param opts [Hash] the options to pass to `ConnectionPool` initializer.
+  def initialize_pool(opts = {})
+    ensure_connection_defined!
+    @pool = ConnectionPool.new(opts, &method(:connection))
+  end
+
+  # Checks if `connection` method exists and raises an error otherwise.
+  def ensure_connection_defined!
+    return if self.class.method_defined?(:connection)
+
+    raise NoMethodError, MISSING_CONNECTION_ERROR
+  end
+end

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -86,7 +86,6 @@ module Faraday
 
         begin
           data = env[:body] ? env[:body].to_s : nil
-          puts "start request... #{pool.available}"
           session.request(env[:method], env[:url].to_s,
                           env[:request_headers], data: data)
         rescue Errno::ECONNREFUSED, ::Patron::ConnectionFailed

--- a/spec/faraday/adapter/patron_spec.rb
+++ b/spec/faraday/adapter/patron_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::Adapter::Patron do
-  features :reason_phrase_parse
+  features :reason_phrase_parse, :pooling
 
   it_behaves_like 'an adapter'
 

--- a/spec/support/shared_examples/request_method.rb
+++ b/spec/support/shared_examples/request_method.rb
@@ -239,11 +239,10 @@ shared_examples 'a request method' do |http_method|
         pool ||= m.call(*args)
       end
 
-      request_stub.to_return do |req|
-        nested = (req.headers['Nested'] || 1).to_i
-        return if nested >= pool.size
-        expect(pool.available).to eq(pool.size - nested)
-        conn.public_send(http_method, '/', nil, nested: nested + 1)
+      # Injects expectation on request execution
+      request_stub.to_return do |_|
+        expect(pool.available).to eq(pool.size - 1)
+        { body: '' }
       end
 
       conn.public_send(http_method, '/')


### PR DESCRIPTION
## Description
Attempt to introduce a `ConnectionPool` in compatible adapters.

## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests: Can we write better tests? I tried executing a request before the previous one was completed, but the number of available connections in the pool was not decreasing (see https://github.com/lostisland/faraday/commit/596d420adc8d7e75ad6d78d2827f9ca91ff49dc2)
- [ ] There's a strange error popping up only sometimes, possibly a race condition. Any help on finding the actual cause would be welcome:
```
NoMethodError:
    undefined method `+' for nil:NilClass
    # /Users/mattiagiuffrida/.rvm/gems/ruby-2.5.1/gems/connection_pool-2.2.2/lib/connection_pool.rb:89:in `checkout'
    # /Users/mattiagiuffrida/.rvm/gems/ruby-2.5.1/gems/connection_pool-2.2.2/lib/connection_pool.rb:62:in `block in with'
    # /Users/mattiagiuffrida/.rvm/gems/ruby-2.5.1/gems/connection_pool-2.2.2/lib/connection_pool.rb:61:in `handle_interrupt'
    # /Users/mattiagiuffrida/.rvm/gems/ruby-2.5.1/gems/connection_pool-2.2.2/lib/connection_pool.rb:61:in `with'
    # ./lib/faraday/adapter/patron.rb:19:in `call'
    # ./lib/faraday/response.rb:11:in `call'
    # ./lib/faraday/request/url_encoded.rb:23:in `call'
    # ./lib/faraday/request/multipart.rb:25:in `call'
    # ./lib/faraday/rack_builder.rb:153:in `build_response'
    # ./lib/faraday/connection.rb:504:in `run_request'
    # ./lib/faraday/connection.rb:233:in `options'
    # ./spec/support/shared_examples/request_method.rb:94:in `public_send'
    # ./spec/support/shared_examples/request_method.rb:94:in `block (2 levels) in <top (required)>'
```

## Additional Notes
I've only added the connection pool to Patron for now, trying to address #1001.
`Net::HTTP` adapter is actually incompatible by design, because we create a different object based on the `env`, so there's no way to reuse connections unless we first refactor that bit.
I'll have a look at the other adapters after receiving some preliminary feedbacks (cc @technoweenie @olleolleolle @julik)