### PR TITLE
This fixes warnings on Ruby 2.7

### DIFF
--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -229,11 +229,11 @@ module Faraday
           @running
         end
 
-        def add
+        def add(&block)
           if running?
             perform_request { yield }
           else
-            @registered_procs << Proc.new
+            @registered_procs << block
           end
           @num_registered += 1
         end

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -79,7 +79,7 @@ module Faraday
         if !args.empty?
           send(key_setter, args.first)
         elsif block_given?
-          send(key_setter, Proc.new.call(key))
+          send(key_setter, yield(key))
         else
           raise self.class.fetch_error_class, "key not found: #{key.inspect}"
         end

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -55,9 +55,9 @@ module Faraday
       !!env
     end
 
-    def on_complete
+    def on_complete(&block)
       if !finished?
-        @on_complete_callbacks << Proc.new
+        @on_complete_callbacks << block
       else
         yield(env)
       end


### PR DESCRIPTION
Ruby 2.7 issues warnings for `Proc.new` without a block:

```
warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```

This patch converts the `Proc.new` calls in to `&block`
