### PR TITLE
Backport #1009

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -64,8 +64,7 @@ module Faraday
     #     :params => {:page => 1}
     #
     # Returns a Faraday::Connection.
-    def new(url = nil, options = nil)
-      block = block_given? ? Proc.new : nil
+    def new(url = nil, options = nil, &block)
       options = options ? default_connection_options.merge(options) : default_connection_options
       Faraday::Connection.new(url, options, &block)
     end

--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -193,11 +193,11 @@ module Faraday
 
         def running?() @running end
 
-        def add
+        def add(&block)
           if running?
             perform_request { yield }
           else
-            @registered_procs << Proc.new
+            @registered_procs << block
           end
           @num_registered += 1
         end

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -162,8 +162,8 @@ module Faraday
       @attribute_options ||= {}
     end
 
-    def self.memoized(key)
-      memoized_attributes[key.to_sym] = Proc.new
+    def self.memoized(key, &block)
+      memoized_attributes[key.to_sym] = block
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{key}() self[:#{key}]; end
       RUBY

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -72,7 +72,7 @@ module Faraday
         if args.size > 0
           send(key_setter, args.first)
         elsif block_given?
-          send(key_setter, Proc.new.call(key))
+          send(key_setter, yield(key))
         else
           raise self.class.fetch_error_class, "key not found: #{key.inspect}"
         end

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -49,10 +49,10 @@ module Faraday
       end
     end
 
-    def initialize(handlers = [])
+    def initialize(handlers = [], &block)
       @handlers = handlers
       if block_given?
-        build(&Proc.new)
+        build(&block)
       elsif @handlers.empty?
         # default stack, if nothing else is configured
         self.request :url_encoded

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -54,9 +54,9 @@ module Faraday
       !!env
     end
 
-    def on_complete
+    def on_complete(&block)
       if not finished?
-        @on_complete_callbacks << Proc.new
+        @on_complete_callbacks << block
       else
         yield(env)
       end


### PR DESCRIPTION
## Description
This backports #1009 to v0.15.x. I'm not sure what the base branch should be since versions are just tags, so I left it as `master`. I just cherry-picked 27d9c93f3ab622e17893320d02a36251e9b110d1 onto `v0.15.4`.

## Rationale
We use many third-party gems that effectively specify `faraday < 1`, so this allows us to continue to use those gems without warnings on Ruby 2.7 (assuming it's included in a `v0.15.5` release).