### PR TITLE
Create PartParams class to allow multipart posts with JSON content and file upload at the same time

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -160,7 +160,7 @@ module Faraday
 
   require_libs 'utils', 'options', 'connection', 'rack_builder', 'parameters',
                'middleware', 'adapter', 'request', 'response', 'upload_io',
-               'error'
+               'error', 'param_part'
 
   require_lib 'autoload' unless ENV['FARADAY_NO_AUTOLOAD']
 end

--- a/lib/faraday/param_part.rb
+++ b/lib/faraday/param_part.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Faraday
+  # Allows multipart posts while specifying headers of a part
+  class ParamPart
+    def initialize(value, content_type, content_id = nil)
+      @value = value
+      @content_type = content_type
+      @content_id = content_id
+    end
+
+    def to_part(boundary, key)
+      Faraday::Parts::Part.new(boundary, key, value, headers)
+    end
+
+    def headers
+      {
+        'Content-Type' => content_type,
+        'Content-ID' => content_id
+      }
+    end
+
+    attr_reader :value, :content_type, :content_id
+  end
+end

--- a/lib/faraday/request/multipart.rb
+++ b/lib/faraday/request/multipart.rb
@@ -52,13 +52,21 @@ module Faraday
       def create_multipart(env, params)
         boundary = env.request.boundary
         parts = process_params(params) do |key, value|
-          Faraday::Parts::Part.new(boundary, key, value)
+          part(boundary, key, value)
         end
         parts << Faraday::Parts::EpiloguePart.new(boundary)
 
         body = Faraday::CompositeReadIO.new(parts)
         env.request_headers[Faraday::Env::ContentLength] = body.length.to_s
         body
+      end
+
+      def part(boundary, key, value)
+        if value.respond_to?(:to_part)
+          value.to_part(boundary, key)
+        else
+          Faraday::Parts::Part.new(boundary, key, value)
+        end
       end
 
       # @return [String]

--- a/spec/faraday/request/multipart_spec.rb
+++ b/spec/faraday/request/multipart_spec.rb
@@ -68,6 +68,45 @@ RSpec.describe Faraday::Request::Multipart do
     end
   end
 
+  context 'when providing json and IO content in the same payload' do
+    let(:io) { StringIO.new('io-content') }
+    let(:json) do
+      {
+        b: 1,
+        c: 2
+      }.to_json
+    end
+
+    let(:payload) do
+      {
+        json: Faraday::ParamPart.new(json, 'application/json'),
+        io: Faraday::UploadIO.new(io, 'application/pdf')
+      }
+    end
+
+    it_behaves_like 'a multipart request'
+
+    it 'forms a multipart request' do
+      response = conn.post('/echo', payload)
+
+      boundary = parse_multipart_boundary(response.headers['Content-Type'])
+      result = parse_multipart(boundary, response.body)
+      expect(result[:errors]).to be_empty
+
+      part_json, body_json = result.part('json')
+      expect(part_json).to_not be_nil
+      expect(part_json.mime).to eq('application/json')
+      expect(part_json.filename).to be_nil
+      expect(body_json).to eq(json)
+
+      part_io, body_io = result.part('io')
+      expect(part_io).to_not be_nil
+      expect(part_io.mime).to eq('application/pdf')
+      expect(part_io.filename).to eq('local.path')
+      expect(body_io).to eq(io.string)
+    end
+  end
+
   context 'when multipart objects in array param' do
     let(:payload) do
       {


### PR DESCRIPTION
## Description
This PR aims to make it possible to multipart POST an IO and a JSON payload at the same time.
Fixes https://github.com/lostisland/faraday/issues/769

Opened after discussions in https://github.com/lostisland/faraday/pull/1014

## Additional Notes
Example of API which requires this :
https://developer.concur.com/api-reference/receipts/endpoints.html#endpoint-post-a-receipt

cURL data and image:

```
curl -v -k -X POST https://us.api.concursolutions.com/receipts/v4/users/{USER ID FROM YOUR ID TOKEN} \
-H "Authorization: Bearer {YOUR ACCESS TOKEN}" \
-H "Content-Type:multipart/form-data" \
-H "link: <http://schema.concursolutions.com/{VALIDATION SCHEMA FROM SCHEMA ENDPOINT}.schema.json>;rel=describedBy" \
-F "receipt=<{PATH TO YOUR RECEIPT JSON};type=application/json" \
-F "image=@{PATH TO YOUR IMAGE};type={FILE MIME TYPE OF YOUR IMAGE}"
```