### PR TITLE
update multipart docs to mention ParamPart class

### DIFF
--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -44,7 +44,7 @@ Examples:
 
 ```ruby
 # uploading a file:
-payload[:profile_pic] = Faraday::UploadIO.new('/path/to/avatar.jpg', 'image/jpeg')
+payload[:profile_pic] = Faraday::FilePart.new('/path/to/avatar.jpg', 'image/jpeg')
 
 # "Multipart" middleware detects files and encodes with "multipart/form-data":
 conn.put '/profile', payload

--- a/docs/middleware/request/multipart.md
+++ b/docs/middleware/request/multipart.md
@@ -61,8 +61,8 @@ payload[:file_with_header] = Faraday::FilePart.new(__FILE__,
 payload[:raw_data] = Faraday::ParamPart.new({a: 1}.to_json, 'application/json')
 
 # optionally sets Content-ID too
-payload[:raw_with_id] = Faraday::ParamPart.new({a: 1}.to_json, "application/json",
-                          "foo-123")
+payload[:raw_with_id] = Faraday::ParamPart.new({a: 1}.to_json, 'application/json',
+                          'foo-123')
 
 conn.post('/', payload)
 ```

--- a/docs/middleware/request/multipart.md
+++ b/docs/middleware/request/multipart.md
@@ -40,21 +40,29 @@ end
 Payload can be a mix of POST data and multipart values.
 
 ```ruby
-payload = {
-  string: "value",
-  file: Faraday::FilePart.new(__FILE__, "text/x-ruby"),
+# regular POST form value
+payload = { string: 'value' }
 
-  file_with_name: Faraday::FilePart.new(__FILE__, "text/x-ruby", "copy.rb"),
+# filename for this value is File.basename(__FILE__)
+payload[:file] = Faraday::FilePart.new(__FILE__, 'text/x-ruby')
 
-  file_with_header: Faraday::FilePart.new(File.open(__FILE__), "text/x-ruby",
-                      File.basename(__FILE__),
-                      'Content-Disposition' => 'form-data; foo=1'),
+# specify filename because IO object doesn't know it
+payload[:file_with_name] = Faraday::FilePart.new(File.open(__FILE__), 
+                             'text/x-ruby', 
+                             File.basename(__FILE__))
 
-  raw_data: Faraday::ParamPart.new({a: 1}.to_json, "application/json")
+# Sets a custom Content-Disposition:
+# nil filename still defaults to File.basename(__FILE__)
+payload[:file_with_header] = Faraday::FilePart.new(__FILE__, 
+                               'text/x-ruby', nil,
+                               'Content-Disposition' => 'form-data; foo=1')
 
-  raw_with_id: Faraday::ParamPart.new({a: 1}.to_json, "application/json",
-                 "foo-123")
-}
+# Upload raw json with content type
+payload[:raw_data] = Faraday::ParamPart.new({a: 1}.to_json, 'application/json')
+
+# optionally sets Content-ID too
+payload[:raw_with_id] = Faraday::ParamPart.new({a: 1}.to_json, "application/json",
+                          "foo-123")
 
 conn.post('/', payload)
 ```

--- a/docs/middleware/request/multipart.md
+++ b/docs/middleware/request/multipart.md
@@ -14,16 +14,19 @@ top_link: ./list
 The `Multipart` middleware converts a `Faraday::Request#body` Hash of key/value
 pairs into a multipart form request, but only under these conditions:
 
-* The Content-Type is "multipart/form-data"
+* The request's Content-Type is "multipart/form-data"
 * Content-Type is unspecified, AND one of the values in the Body responds to
 `#content_type`.
 
 Faraday contains a couple helper classes for multipart values:
 
-* `Faraday::UploadIO` wraps file data with a Content-Type. The file data can be
-specified with a String path to a local file, or an IO object.
-* `Faraday::ParamsPart` wraps a String value with a Content-Type, and optionally
+* `Faraday::FilePart` wraps binary file data with a Content-Type. The file data
+can be specified with a String path to a local file, or an IO object.
+* `Faraday::ParamPart` wraps a String value with a Content-Type, and optionally
 a Content-ID.
+
+Note: `Faraday::ParamPart` was added in Faraday v0.16.0. Before that, 
+`Faraday::FilePart` was called `Faraday::UploadIO`.
 
 ### Example Usage
 
@@ -39,16 +42,17 @@ Payload can be a mix of POST data and multipart values.
 ```ruby
 payload = {
   string: "value",
-  file: Faraday::UploadIO.new(__FILE__, "text/x-ruby"),
+  file: Faraday::FilePart.new(__FILE__, "text/x-ruby"),
 
-  file_with_name: Faraday::UploadIO.new(__FILE__, "text/x-ruby", "copy.rb"),
+  file_with_name: Faraday::FilePart.new(__FILE__, "text/x-ruby", "copy.rb"),
 
-  file_with_header: Faraday::UploadIO.new(__FILE__, "text/x-ruby", nil,
+  file_with_header: Faraday::FilePart.new(File.open(__FILE__), "text/x-ruby",
+                      File.basename(__FILE__),
                       'Content-Disposition' => 'form-data; foo=1'),
 
-  raw_data: Faraday::ParamsPart.new({a: 1}.to_json, "application/json")
+  raw_data: Faraday::ParamPart.new({a: 1}.to_json, "application/json")
 
-  raw_with_id: Faraday::ParamsPart.new({a: 1}.to_json, "application/json",
+  raw_with_id: Faraday::ParamPart.new({a: 1}.to_json, "application/json",
                  "foo-123")
 }
 


### PR DESCRIPTION
This updates the multipart documentation on the site. It was rewritten to include `ParamsPart` from #1017, while providing other important details and example usage.

* [x] Await final class names for `Faraday::UploadIO` and `Faraday::ParamsPart` before merging