### PR TITLE
read timeout request option (part 2)

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -165,19 +165,16 @@ module Faraday
       end
 
       def configure_request(http, req)
-        if req[:timeout]
-          http.read_timeout = req[:timeout]
-          http.open_timeout = req[:timeout]
-          if http.respond_to?(:write_timeout=)
-            http.write_timeout = req[:timeout]
-          end
+        if sec = req.fetch_timeout(:read)
+          http.read_timeout = sec
         end
-        http.open_timeout = req[:open_timeout] if req[:open_timeout]
-        http.read_timeout = req[:read_timeout] if req[:read_timeout]
+        if sec = http.respond_to?(:write_timeout=) && req.fetch_timeout(:write)
+          http.write_timeout = sec
+        end
+        if sec = req.fetch_timeout(:open)
+          http.open_timeout = sec
+        end
 
-        if req[:write_timeout] && http.respond_to?(:write_timeout=)
-          http.write_timeout = req[:write_timeout]
-        end
         # Only set if Net::Http supports it, since Ruby 2.5.
         http.max_retries = 0 if http.respond_to?(:max_retries=)
 

--- a/lib/faraday/options/request_options.rb
+++ b/lib/faraday/options/request_options.rb
@@ -15,8 +15,28 @@ module Faraday
       end
     end
 
+    # Fetches either a read, write, or open timeout setting. Defaults to the
+    # :timeout value if a more specific one is not given.
+    #
+    # @param type [Symbol] Describes which timeout setting to get: :read,
+    #                      :write, or :open.
+    #
+    # @return [Integer, nil] Timeout duration in seconds, or nil if no timeout
+    #                        has been set.
+    def fetch_timeout(type)
+      unless TIMEOUT_TYPES.include?(type)
+        raise ArgumentError, "Expected :read, :write, :open. Got #{type.inspect} :("
+      end
+
+      self["#{type}_timeout".to_sym] || self[:timeout]
+    end
+
     def stream_response?
       on_data.is_a?(Proc)
     end
+
+    private
+
+    TIMEOUT_TYPES = Set.new([:read, :write, :open])
   end
 end

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -11,21 +11,25 @@ RSpec.describe Faraday::Adapter::NetHttp do
     let(:http) { adapter.send(:net_http_connection, url: url, request: {}) }
 
     it { expect(http.port).to eq(80) }
+
     it 'sets max_retries to 0' do
       adapter.send(:configure_request, http, {})
 
       expect(http.max_retries).to eq(0) if http.respond_to?(:max_retries=)
     end
+
     it 'supports write_timeout' do
       adapter.send(:configure_request, http, write_timeout: 10)
 
       expect(http.write_timeout).to eq(10) if http.respond_to?(:write_timeout=)
     end
+
     it 'supports open_timeout' do
       adapter.send(:configure_request, http, open_timeout: 10)
 
       expect(http.open_timeout).to eq(10)
     end
+
     it 'supports read_timeout' do
       adapter.send(:configure_request, http, read_timeout: 10)
 

--- a/spec/faraday/options/request_options_spec.rb
+++ b/spec/faraday/options/request_options_spec.rb
@@ -1,8 +1,50 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::RequestOptions do
+  subject(:options) { Faraday::RequestOptions.new }
+
+  context '#fetch_timeout' do
+    it 'gets :read timeout' do
+      expect(options.fetch_timeout(:read)).to eq(nil)
+
+      options[:timeout] = 5
+      options[:write_timeout] = 1
+
+      expect(options.fetch_timeout(:read)).to eq(5)
+
+      options[:read_timeout] = 2
+
+      expect(options.fetch_timeout(:read)).to eq(2)
+    end
+
+    it 'gets :open timeout' do
+      expect(options.fetch_timeout(:open)).to eq(nil)
+
+      options[:timeout] = 5
+      options[:write_timeout] = 1
+
+      expect(options.fetch_timeout(:open)).to eq(5)
+
+      options[:open_timeout] = 2
+
+      expect(options.fetch_timeout(:open)).to eq(2)
+    end
+
+    it 'gets :write timeout' do
+      expect(options.fetch_timeout(:write)).to eq(nil)
+
+      options[:timeout] = 5
+      options[:read_timeout] = 1
+
+      expect(options.fetch_timeout(:write)).to eq(5)
+
+      options[:write_timeout] = 2
+
+      expect(options.fetch_timeout(:write)).to eq(2)
+    end
+  end
+
   it 'allows to set the request proxy' do
-    options = Faraday::RequestOptions.new
     expect(options.proxy).to be_nil
 
     expect { options[:proxy] = { booya: 1 } }.to raise_error(NoMethodError)


### PR DESCRIPTION
This extends #1003 by adding `Faraday::RequestOptions#fetch_timeout` to clean up the logic of `#configure_request` in the net/http adapter. Instead of checking for `req[:timeout]` before the more specific timeout settings in the adapter, this happens in `#fetch_timeout`. 

If this pattern is okay, I'll update the other adapters to use `#fetch_timeout`, ensuring they all properly support the new `read_timeout` setting. I'm open to other ideas, or even just different names. 