### PR TITLE
Excon streaming

### DIFF
--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -20,8 +20,9 @@ module Faraday
 
         req = env[:request]
         if req&.stream_response?
-          req_opts[:response_block] = lambda do |chunk, _remain, total|
-            req.on_data.call(chunk, total)
+          total = 0
+          req_opts[:response_block] = lambda do |chunk|
+            req.on_data.call(chunk, total += chunk.size)
           end
         end
 

--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -21,7 +21,7 @@ module Faraday
         req = env[:request]
         if req&.stream_response?
           total = 0
-          req_opts[:response_block] = lambda do |chunk|
+          req_opts[:response_block] = lambda do |chunk, _remain, _total|
             req.on_data.call(chunk, total += chunk.size)
           end
         end

--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -15,20 +15,18 @@ module Faraday
         req_opts = {
           method: env[:method].to_s.upcase,
           headers: env[:request_headers],
-          body: read_body(env),
+          body: read_body(env)
         }
 
         req = env[:request]
-        is_streaming = req&.stream_response?
-        if is_streaming
+        if req&.stream_response?
           req_opts[:response_block] = lambda do |chunk, _remain, total|
             req.on_data.call(chunk, total)
           end
         end
 
         resp = conn.request(req_opts)
-        body = is_streaming ? nil : resp.body
-        save_response(env, resp.status.to_i, body, resp.headers,
+        save_response(env, resp.status.to_i, resp.body, resp.headers,
                       resp.reason_phrase)
 
         @app.call(env)


### PR DESCRIPTION
This implements streaming response bodies in Excon. Confirmed with https://github.com/technoweenie/faraday-live/pull/8, if you test this branch:

```ruby
$ FARADAY_GEM_REF=excon_streaming docker-compose build tests
$ TEST_PROTO=https TEST_ADAPTER=excon TEST_METHOD=get docker-compose run tests
```

Note: Excon [claims](https://github.com/excon/excon#streaming-responses) to yield the chunk, remaining bytes, and total bytes. In practice, it only seems to do this if the response came in as 1 chunk. Or maybe, it skips this on chunked responses that don't give the content size up front. Either way, Faraday has to maintain its own total byte count.

```
irb(main):003:0> Excon.get('http://geemus.com', response_block: lambda { |b,r,t| puts "RECV #{b.size}, rem #{r.to_i}/#{t.to_i} #{Digest::SHA1.hexdigest(b)}" });nil
RECV 3722, rem 0/3722 f5878b59cc37c7cc306a78cac34362ab52c72e46
=> nil
irb(main):004:0> Excon.get('https://jigsaw.w3.org/HTTP/ChunkedScript', response_block: lambda { |b,r,t| puts "RECV #{b.size}, rem #{r.to_i}/#{t.to_i} #{Digest::SHA1.hexdigest(b)}" });nil
RECV 9329, rem 0/0 61218bfa9a16320a916775562eece77bf4b82786
RECV 16304, rem 0/0 a547ac23bcd520b7c4fada5ac58aab3e781c7d07
RECV 2244, rem 0/0 25931bac8db4b27b866fd0d0ead8302a2d335c94
RECV 1428, rem 0/0 476afc2e63062d56f5e92fd5b167b06fd1c3e664
RECV 8560, rem 0/0 67dc7ba1c6123f67fde2dce96cd5e41cba317d6f
RECV 12836, rem 0/0 6bad2a8664449eae0bcf3bc6f0ae1b66c9584dc3
RECV 5712, rem 0/0 c011d596e925bf265f7660c12820499b3843b7dd
RECV 9980, rem 0/0 e92f6efb3d1e4e376580781cf04ea944bf5734d9
RECV 5807, rem 0/0 08e1d0def8b8a73542469fc95214049b9ffe6cec
```