### PR TITLE
release v0.16.0

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -19,7 +19,7 @@ require 'faraday/dependency_loader'
 #   conn.get '/'
 #
 module Faraday
-  VERSION = '1.0.0-rc1'
+  VERSION = '0.16.0'
   METHODS_WITH_QUERY = %w[get head delete connect trace].freeze
   METHODS_WITH_BODY = %w[post put patch].freeze
 


### PR DESCRIPTION
This ships v0.16.0. 

/cc @lostisland/faraday-maintainers: the [draft release notes](https://github.com/lostisland/faraday/releases/tag/untagged-fb142f3212c09a4a87c0).