### PR TITLE
Restore backward-compatibility layer for errors

### DIFF
--- a/lib/faraday/deprecated_constant.rb
+++ b/lib/faraday/deprecated_constant.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Faraday
+  # Allows for the deprecation of constants between versions of Faraday
+  #
+  # rubocop:disable Style/MethodMissingSuper, Style/MissingRespondToMissing
+  class DeprecatedConstant < Module
+    def self.new(*args, &block)
+      object = args.first
+      return object unless object
+
+      super
+    end
+
+    def initialize(old_const, new_const)
+      @old_const = old_const
+      @new_const = new_const
+    end
+
+    instance_methods.each do |method_name|
+      undef_method method_name unless /^__|^object_id$/.match?(method_name)
+    end
+
+    def inspect
+      @new_const.inspect
+    end
+
+    def class
+      @new_const.class
+    end
+
+    private
+
+    def const_missing(name)
+      warn
+      @new_const.const_get(name)
+    end
+
+    def method_missing(method_name, *args, &block)
+      warn
+      @new_const.__send__(method_name, *args, &block)
+    end
+
+    def warn
+      puts(
+        "DEPRECATION WARNING: #{@old_const} is deprecated! " \
+        "Use #{@new_const} instead."
+      )
+    end
+  end
+  # rubocop:enable Style/MethodMissingSuper, Style/MissingRespondToMissing
+end

--- a/lib/faraday/deprecated_constant.rb
+++ b/lib/faraday/deprecated_constant.rb
@@ -17,8 +17,9 @@ module Faraday
       @new_const = new_const
     end
 
+    # TODO: use match? once Faraday drops Ruby 2.3 support
     instance_methods.each do |method_name|
-      undef_method method_name unless /^__|^object_id$/.match?(method_name)
+      undef_method method_name if /^__|^object_id$/.match(method_name).nil?
     end
 
     def inspect

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -2,6 +2,7 @@
 
 require 'faraday/deprecated_constant'
 
+# Faraday namespace.
 module Faraday
   # Faraday error base class.
   class Error < StandardError

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'faraday/deprecated_constant'
+
 module Faraday
   # Faraday error base class.
   class Error < StandardError
@@ -100,6 +102,9 @@ module Faraday
 
   %i[ClientError ConnectionFailed ResourceNotFound
      ParsingError TimeoutError SSLError RetriableResponse].each do |const|
-    Error.const_set(const, Faraday.const_get(const))
+    Error.const_set(
+      const,
+      Faraday::DeprecatedConstant.new("Faraday::Error::#{const}", Faraday.const_get(const))
+    )
   end
 end

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -97,4 +97,9 @@ module Faraday
   # @see Faraday::Request::Retry
   class RetriableResponse < Error
   end
+
+  %i[ClientError ConnectionFailed ResourceNotFound
+     ParsingError TimeoutError SSLError RetriableResponse].each do |const|
+    Error.const_set(const, Faraday.const_get(const))
+  end
 end

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -104,7 +104,10 @@ module Faraday
      ParsingError TimeoutError SSLError RetriableResponse].each do |const|
     Error.const_set(
       const,
-      Faraday::DeprecatedConstant.new("Faraday::Error::#{const}", Faraday.const_get(const))
+      Faraday::DeprecatedConstant.new(
+        "Faraday::Error::#{const}",
+        Faraday.const_get(const)
+      )
     )
   end
 end

--- a/spec/faraday/error_spec.rb
+++ b/spec/faraday/error_spec.rb
@@ -41,5 +41,11 @@ RSpec.describe Faraday::ClientError do
       it { expect(subject.message).to eq('["error1", "error2"]') }
       it { expect(subject.inspect).to eq('#<Faraday::ClientError #<Faraday::ClientError: ["error1", "error2"]>>') }
     end
+
+    context 'maintains backward-compatibility until 1.0' do
+      it 'does not raise an error for nested error classes' do
+        expect { Faraday::Error::ClientError }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/faraday/error_spec.rb
+++ b/spec/faraday/error_spec.rb
@@ -43,9 +43,24 @@ RSpec.describe Faraday::ClientError do
     end
 
     context 'maintains backward-compatibility until 1.0' do
-      it 'does not raise an error for nested error classes' do
-        expect { Faraday::Error::ClientError }.not_to raise_error
+      it 'does not raise an error for nested error classes but prints an error message' do
+        error_message, error = with_warn_squelching { Faraday::Error::ClientError.new('foo') }
+
+        expect(error).to be_a Faraday::ClientError
+        expect(error_message).to eq(
+          "DEPRECATION WARNING: Faraday::Error::ClientError is deprecated! Use Faraday::ClientError instead.\n"
+        )
       end
+    end
+
+    def with_warn_squelching
+      stdout_catcher = StringIO.new
+      original_stdout = $stdout
+      $stdout = stdout_catcher
+      result = yield if block_given?
+      [stdout_catcher.tap(&:rewind).string, result]
+    ensure
+      $stdout = original_stdout
     end
   end
 end


### PR DESCRIPTION
Faraday has been maintaining a backward-compatibility layer for errors
in the `Faraday::Error::` "namespace". These were removed with v0.16.0,
which caused issues for dependents that use semantic versioning
constraints.

It would be best if these were deprecated with a warning message and
then dropped in v1.0 in order to make sure transitive dependencies do
not break.

See octokit/octokit.rb#1154