### PR TITLE
Failing spec for #1033

### DIFF
--- a/spec/faraday/error_spec.rb
+++ b/spec/faraday/error_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe Faraday::ClientError do
           "DEPRECATION WARNING: Faraday::Error::ClientError is deprecated! Use Faraday::ClientError instead.\n"
         )
       end
+
+      it 'allows backward-compatible class to be subclassed' do
+        expect { class CustomError < Faraday::Error::ClientError; end }.not_to raise_error(TypeError)
+      end
     end
 
     def with_warn_squelching


### PR DESCRIPTION
## Description
A failing spec for #1033

```
  1) Faraday::ClientError.initialize maintains backward-compatibility until 1.0 allows backward-compatible class to be subclassed
     Failure/Error: expect { class CustomError < Faraday::Error::ClientError; end }.not_to raise_error(TypeError)
     
       expected no TypeError, got #<TypeError: superclass must be a Class (Faraday::DeprecatedConstant given)> with backtrace:
         # ./spec/faraday/error_spec.rb:56:in `block (5 levels) in <top (required)>'
         # ./spec/faraday/error_spec.rb:56:in `block (4 levels) in <top (required)>'
     # ./spec/faraday/error_spec.rb:56:in `block (4 levels) in <top (required)>'

Finished in 0.0637 seconds (files took 1.04 seconds to load)
19 examples, 1 failure
```