### PR TITLE
Fix instances of frozen empty string literals

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -59,7 +59,7 @@ module Faraday
           end
 
           save_response(env, http_response.code.to_i,
-                        http_response.body || '', nil,
+                        http_response.body || +'', nil,
                         http_response.message) do |response_headers|
             http_response.each_header do |key, value|
               response_headers[key] = value
@@ -101,7 +101,7 @@ module Faraday
               env[:request].on_data.call(chunk, size)
             end
           end
-          env[:request].on_data.call('', 0) unless yielded
+          env[:request].on_data.call(+'', 0) unless yielded
           # Net::HTTP returns something,
           # but it's not meaningful according to the docs.
           http_response.body = nil

--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -132,7 +132,7 @@ module Faraday
     # Sets content length to zero and the body to the empty string.
     def clear_body
       request_headers[ContentLength] = '0'
-      self.body = ''
+      self.body = +''
     end
 
     # @return [Boolean] true if the status isn't in the set of


### PR DESCRIPTION
When the frozen string literals magic comments were added, not all empty strings were made mutable. This causes issues down the line like the ones being seen in #1038 for fastlane/fastlane
