### PR TITLE
Raise exception on nil status

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -85,7 +85,7 @@ module Faraday
 
   # Raised by Faraday::Response::RaiseError in case of a nil status in response.
   class NilStatusError < ServerError
-    def initialize(response = nil)
+    def initialize(_exc, response: nil)
       message = 'http status could not be derived from the server response'
       super(message, response)
     end

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -83,6 +83,14 @@ module Faraday
     end
   end
 
+  # Raised by Faraday::Response::RaiseError in case of a nil status in response.
+  class NilStatusError < ServerError
+    def initialize(response = nil)
+      message = 'http status could not be derived from the server response'
+      super(message, response)
+    end
+  end
+
   # A unified error for failed connections.
   class ConnectionFailed < Error
   end

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -29,7 +29,7 @@ module Faraday
         when 422
           raise Faraday::UnprocessableEntityError, response_values(env)
         when nil
-          raise Faraday::NilStatusError, response_values(env)
+          raise Faraday::NilStatusError, response: response_values(env)
         when ClientErrorStatuses
           raise Faraday::ClientError, response_values(env)
         when ServerErrorStatuses

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -28,6 +28,8 @@ module Faraday
           raise Faraday::ConflictError, response_values(env)
         when 422
           raise Faraday::UnprocessableEntityError, response_values(env)
+        when nil
+          raise Faraday::NilStatusError, response_values(env)
         when ClientErrorStatuses
           raise Faraday::ClientError, response_values(env)
         when ServerErrorStatuses

--- a/spec/faraday/response/raise_error_spec.rb
+++ b/spec/faraday/response/raise_error_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Faraday::Response::RaiseError do
         stub.get('conflict') { [409, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('unprocessable-entity') { [422, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('4xx') { [499, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('nil-status') { [nil, { 'X-Reason' => 'bailout' }, 'fail'] }
         stub.get('server-error') { [500, { 'X-Error' => 'bailout' }, 'fail'] }
       end
     end
@@ -69,6 +70,12 @@ RSpec.describe Faraday::Response::RaiseError do
     expect { conn.get('unprocessable-entity') }.to raise_error(Faraday::UnprocessableEntityError) do |ex|
       expect(ex.message).to eq('the server responded with status 422')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::NilStatusError for nil status in response' do
+    expect { conn.get('nil-status') }.to raise_error(Faraday::NilStatusError) do |ex|
+      expect(ex.message).to eq('http status could not be derived from the server response')
     end
   end
 


### PR DESCRIPTION
## Description
If a host responds badly to HTTP requests it's possible for the HTTP status to be returned `nil`.
It makes sense to raise an exception here that can be rescued from and handled appropriately instead of silently allowing them through.
Fixes https://github.com/lostisland/faraday/issues/1028

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [ ] Documentation

