### PR TITLE
Rubocop: Lint/SendWithMixinArgument

### DIFF
--- a/lib/faraday/adapter/em_http_ssl_patch.rb
+++ b/lib/faraday/adapter/em_http_ssl_patch.rb
@@ -59,4 +59,4 @@ module EmHttpSslPatch
   end
 end
 
-EventMachine::HttpStubConnection.send(:include, EmHttpSslPatch)
+EventMachine::HttpStubConnection.include(EmHttpSslPatch)


### PR DESCRIPTION
Fixes a new rubocop error that's failing the linting step. 
