### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -16,6 +16,19 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/faraday'
   spec.licenses = ['MIT']
 
+  spec.metadata = {
+    'bug_tracker_uri' =>
+      'https://github.com/lostisland/faraday/issues',
+    'changelog_uri' =>
+      "https://github.com/lostisland/faraday/releases/tag/v#{spec.version}",
+    'documentation_uri' =>
+      "https://www.rubydoc.info/gems/faraday/#{spec.version}",
+    'source_code_uri' =>
+      "https://github.com/lostisland/faraday/tree/v#{spec.version}",
+    'wiki_uri' =>
+      'https://github.com/lostisland/faraday/wiki'
+  }
+
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `wiki_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/faraday and be available via the rubygems API after the next release.