### PR TITLE
Rubocop: Lint/SendWithMixinArgument

### DIFF
--- a/lib/faraday/adapter/em_http_ssl_patch.rb
+++ b/lib/faraday/adapter/em_http_ssl_patch.rb
@@ -59,4 +59,4 @@ module EmHttpSslPatch
   end
 end
 
-EventMachine::HttpStubConnection.send(:include, EmHttpSslPatch)
+EventMachine::HttpStubConnection.include(EmHttpSslPatch)


### PR DESCRIPTION
Make lint pass on master.

## Description

This PR lints a newly-added RuboCop rule.

  - same as 0ac691abaf1f78185f025ea8c8711f3970b49ebc

## Todos

## Additional Notes

Thanks to @BobbyMcWho for this patch.