### PR TITLE
0.1x deprecate fixes

### DIFF
--- a/lib/faraday/deprecate.rb
+++ b/lib/faraday/deprecate.rb
@@ -12,7 +12,7 @@ module Faraday
         class << k
           extend Faraday::Deprecate
           # Make this more human readable than #<Class:Faraday::ClientError>
-          klass_name = superclass.to_s[/^#<Class:(\w{1}[\w:]*)>$/, 1]
+          klass_name = superclass.to_s[/^#<Class:([\w:]+)>$/, 1]
           deprecate :new, "#{klass_name}.new", '1.0'
           deprecate :inherited, klass_name, '1.0'
 

--- a/lib/faraday/deprecate.rb
+++ b/lib/faraday/deprecate.rb
@@ -12,7 +12,7 @@ module Faraday
         class << k
           extend Faraday::Deprecate
           # Make this more human readable than #<Class:Faraday::ClientError>
-          klass_name = superclass.to_s[/^#<Class:(\w*::\w*)>$/, 1]
+          klass_name = superclass.to_s[/^#<Class:(\w{1}[\w:]*)>$/, 1]
           deprecate :new, "#{klass_name}.new", '1.0'
           deprecate :inherited, klass_name, '1.0'
         end

--- a/lib/faraday/deprecate.rb
+++ b/lib/faraday/deprecate.rb
@@ -15,6 +15,10 @@ module Faraday
           klass_name = superclass.to_s[/^#<Class:(\w{1}[\w:]*)>$/, 1]
           deprecate :new, "#{klass_name}.new", '1.0'
           deprecate :inherited, klass_name, '1.0'
+
+          def ===(other)
+            superclass === other || super
+          end
         end
       end
     end

--- a/lib/faraday/deprecate.rb
+++ b/lib/faraday/deprecate.rb
@@ -8,8 +8,8 @@ module Faraday
   # @see Faraday::Deprecate
   module DeprecatedClass
     def self.proxy_class(new_klass)
-      Class.new(new_klass).tap do |k|
-        class << k
+      Class.new(new_klass) do
+        class << self
           extend Faraday::Deprecate
           # Make this more human readable than #<Class:Faraday::ClientError>
           klass_name = superclass.to_s[/^#<Class:([\w:]+)>$/, 1]

--- a/spec/faraday/deprecate_spec.rb
+++ b/spec/faraday/deprecate_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Faraday::DeprecatedClass do
+  class SampleClass < StandardError
+    attr_accessor :foo
+
+    def initialize(foo = nil)
+      @foo = foo || :foo
+    end
+  end
+
+  SampleDeprecatedClass = Faraday::DeprecatedClass.proxy_class(SampleClass)
+
+  it 'does not raise error for deprecated classes but prints an error message' do
+    error_message, foobar = with_warn_squelching { SampleDeprecatedClass.new(:foo_bar) }
+    expect(foobar).to be_a(SampleClass)
+    expect(foobar.foo).to eq(:foo_bar)
+    expect(error_message).to match(
+      Regexp.new(
+        'NOTE: SampleDeprecatedClass.new is deprecated; '\
+        'use SampleClass.new instead. It will be removed in or after version 1.0'
+      )
+    )
+  end
+
+  it 'does not raise an error for inherited error-namespaced classes but prints an error message' do
+    error_message, = with_warn_squelching { Class.new(SampleDeprecatedClass) }
+
+    expect(error_message).to match(
+      Regexp.new(
+        'NOTE: Inheriting SampleDeprecatedClass is deprecated; '\
+        'use SampleClass instead. It will be removed in or after version 1.0'
+      )
+    )
+  end
+
+  it 'allows backward-compatible class to be subclassed' do
+    expect {
+      with_warn_squelching { Class.new(SampleDeprecatedClass) }
+    }.not_to raise_error
+  end
+
+  it 'allows rescuing of a current error with a deprecated error' do
+    begin
+      raise SampleClass, nil
+    rescue SampleDeprecatedClass
+    rescue StandardError => exc
+      fail "rescued #{exc.class.name} instead"
+    end
+  end
+
+  it 'allows rescuing of a current error with a current error' do
+    begin
+      raise SampleClass, nil
+    rescue SampleClass
+    rescue StandardError => exc
+      fail "rescued #{exc.class.name} instead"
+    end
+  end
+
+  it 'allows rescuing of a deprecated error with a deprecated error' do
+    begin
+      raise SampleDeprecatedClass, nil
+    rescue SampleDeprecatedClass
+    rescue StandardError => exc
+      fail "rescued #{exc.class.name} instead"
+    end
+  end
+
+  it 'allows rescuing of a deprecated error with a current error' do
+    begin
+      raise SampleDeprecatedClass, nil
+    rescue SampleClass
+    rescue StandardError => exc
+      fail "rescued #{exc.class.name} instead"
+    end
+  end
+
+
+  def with_warn_squelching
+    stderr_catcher = StringIO.new
+    original_stderr = $stderr
+    $stderr = stderr_catcher
+    result = yield if block_given?
+    [stderr_catcher.tap(&:rewind).string, result]
+  ensure
+    $stderr = original_stderr
+  end
+end

--- a/spec/faraday/deprecate_spec.rb
+++ b/spec/faraday/deprecate_spec.rb
@@ -41,39 +41,19 @@ RSpec.describe Faraday::DeprecatedClass do
   end
 
   it 'allows rescuing of a current error with a deprecated error' do
-    begin
-      raise SampleClass, nil
-    rescue SampleDeprecatedClass
-    rescue StandardError => exc
-      fail "rescued #{exc.class.name} instead"
-    end
+    expect { raise SampleClass, nil }.to raise_error(SampleDeprecatedClass)
   end
 
   it 'allows rescuing of a current error with a current error' do
-    begin
-      raise SampleClass, nil
-    rescue SampleClass
-    rescue StandardError => exc
-      fail "rescued #{exc.class.name} instead"
-    end
+    expect { raise SampleClass, nil }.to raise_error(SampleClass)
   end
 
   it 'allows rescuing of a deprecated error with a deprecated error' do
-    begin
-      raise SampleDeprecatedClass, nil
-    rescue SampleDeprecatedClass
-    rescue StandardError => exc
-      fail "rescued #{exc.class.name} instead"
-    end
+    expect { raise SampleDeprecatedClass, nil }.to raise_error(SampleDeprecatedClass)
   end
 
   it 'allows rescuing of a deprecated error with a current error' do
-    begin
-      raise SampleDeprecatedClass, nil
-    rescue SampleClass
-    rescue StandardError => exc
-      fail "rescued #{exc.class.name} instead"
-    end
+    expect { raise SampleDeprecatedClass, nil }.to raise_error(SampleClass)
   end
 
 

--- a/spec/faraday/error_spec.rb
+++ b/spec/faraday/error_spec.rb
@@ -67,7 +67,9 @@ RSpec.describe Faraday::ClientError do
       end
 
       it 'allows backward-compatible class to be subclassed' do
-        expect { Class.new(Faraday::Error::ClientError) }.not_to raise_error
+        expect {
+          with_warn_squelching { Class.new(Faraday::Error::ClientError) }
+        }.not_to raise_error
       end
 
       it 'allows rescuing of a current error with a deprecated error' do

--- a/spec/faraday/error_spec.rb
+++ b/spec/faraday/error_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Faraday::ClientError do
       end
 
       it 'does not raise an error for inherited error-namespaced classes but prints an error message' do
-        error_message, = with_warn_squelching { class E < Faraday::Error::ClientError; end }
+        error_message, = with_warn_squelching { Class.new(Faraday::Error::ClientError) }
 
         expect(error_message).to match(
           Regexp.new(
@@ -67,7 +67,43 @@ RSpec.describe Faraday::ClientError do
       end
 
       it 'allows backward-compatible class to be subclassed' do
-        expect { class CustomError < Faraday::Error::ClientError; end }.not_to raise_error
+        expect { Class.new(Faraday::Error::ClientError) }.not_to raise_error
+      end
+
+      it 'allows rescuing of a current error with a deprecated error' do
+        begin
+          raise Faraday::ClientError, nil
+        rescue Faraday::Error::ClientError
+        rescue Faraday::Error => exc
+          fail "rescued #{exc.class.name} instead"
+        end
+      end
+
+      it 'allows rescuing of a current error with a current error' do
+        begin
+          raise Faraday::ClientError, nil
+        rescue Faraday::ClientError
+        rescue Faraday::Error => exc
+          fail "rescued #{exc.class.name} instead"
+        end
+      end
+
+      it 'allows rescuing of a deprecated error with a deprecated error' do
+        begin
+          raise Faraday::Error::ClientError, nil
+        rescue Faraday::Error::ClientError
+        rescue Faraday::Error => exc
+          fail "rescued #{exc.class.name} instead"
+        end
+      end
+
+      it 'allows rescuing of a deprecated error with a current error' do
+        begin
+          raise Faraday::Error::ClientError, nil
+        rescue Faraday::ClientError
+        rescue Faraday::Error => exc
+          fail "rescued #{exc.class.name} instead"
+        end
       end
     end
 

--- a/spec/faraday/error_spec.rb
+++ b/spec/faraday/error_spec.rb
@@ -73,39 +73,19 @@ RSpec.describe Faraday::ClientError do
       end
 
       it 'allows rescuing of a current error with a deprecated error' do
-        begin
-          raise Faraday::ClientError, nil
-        rescue Faraday::Error::ClientError
-        rescue Faraday::Error => exc
-          fail "rescued #{exc.class.name} instead"
-        end
+        expect { raise Faraday::ClientError, nil }.to raise_error(Faraday::Error::ClientError)
       end
 
       it 'allows rescuing of a current error with a current error' do
-        begin
-          raise Faraday::ClientError, nil
-        rescue Faraday::ClientError
-        rescue Faraday::Error => exc
-          fail "rescued #{exc.class.name} instead"
-        end
+        expect { raise Faraday::ClientError, nil }.to raise_error(Faraday::ClientError)
       end
 
       it 'allows rescuing of a deprecated error with a deprecated error' do
-        begin
-          raise Faraday::Error::ClientError, nil
-        rescue Faraday::Error::ClientError
-        rescue Faraday::Error => exc
-          fail "rescued #{exc.class.name} instead"
-        end
+        expect { raise Faraday::Error::ClientError, nil }.to raise_error(Faraday::Error::ClientError)
       end
 
       it 'allows rescuing of a deprecated error with a current error' do
-        begin
-          raise Faraday::Error::ClientError, nil
-        rescue Faraday::ClientError
-        rescue Faraday::Error => exc
-          fail "rescued #{exc.class.name} instead"
-        end
+        expect { raise Faraday::Error::ClientError, nil }.to raise_error(Faraday::ClientError)
       end
     end
 


### PR DESCRIPTION
This fixes a few issues with #1054

First: You can't rescue a current Faraday exception (`Faraday::ClientError`, for example) with its deprecated error class (`Faraday::Error::ClientError`). This would let us remove all `Faraday::Error::*` references for Faraday `v0.17.1`. We should update them too, so that users don't get a bunch of deprecation warnings they can't fix. Even if that's too risky of a change, I still think this behavior is correct and worth including.

Second, the regex for the class name changed so it could grab the class name of a root level class. Only came up because some of the test constants have no namespace.

```diff
-/^#<Class:(\w*::\w*)>$/
+/^#<Class:(\w{1}[\w:]*)>$/
```

Finally, I copied some of the tests in `spec/faraday/error_spec.rb` to `spec/faraday/deprecate_spec.rb`, so that those things are still tested once the `Faraday::Error::*` stuff is all removed for good. This raised some problems with the `CustomError` and `E` classes created in `error_spec.rb`, so I changed those to use `Class.new` instead.

@BobbyMcWho: I'd really appreciate your thoughts on this :)