### PR TITLE
Cache adapter connections (attempt 1)

### DIFF
--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -6,10 +6,12 @@ module Faraday
     class NetHttpPersistent < NetHttp
       dependency 'net/http/persistent'
 
+      include CacheConnection
+
       private
 
       def net_http_connection(env)
-        @cached_connection ||=
+        conn =
           if Net::HTTP::Persistent.instance_method(:initialize)
                                   .parameters.first == %i[key name]
             options = { name: 'Faraday' }
@@ -22,10 +24,8 @@ module Faraday
           end
 
         proxy_uri = proxy_uri(env)
-        if @cached_connection.proxy_uri != proxy_uri
-          @cached_connection.proxy = proxy_uri
-        end
-        @cached_connection
+        conn.proxy = proxy_uri if conn.proxy_uri != proxy_uri
+        conn
       end
 
       def proxy_uri(env)

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -12,6 +12,7 @@ module Faraday
         session = ::Patron::Session.new
         @config_block&.call(session)
         configure_ssl(session, env[:ssl]) if env[:ssl]
+        configure_for_request(session, env[:connection])
         configure_for_request(session, env[:request])
         session
       end

--- a/lib/faraday/options/connection_options.rb
+++ b/lib/faraday/options/connection_options.rb
@@ -5,7 +5,8 @@ module Faraday
   # connection object.
   class ConnectionOptions < Options.new(:request, :proxy, :ssl, :builder, :url,
                                         :parallel_manager, :params, :headers,
-                                        :builder_class)
+                                        :builder_class, :bind, :read_timeout,
+                                        :timeout, :open_timeout, :write_timeout)
 
     options request: RequestOptions, ssl: SSLOptions
 

--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -46,10 +46,14 @@ module Faraday
   #
   # @!attribute reason_phrase
   #   @return [String]
+  #
+  # @!attribute connection
+  #   @return [Faraday::ConnectionOptions] The connection options for the
+  #   current adapter.
   class Env < Options.new(:method, :request_body, :url, :request,
                           :request_headers, :ssl, :parallel_manager, :params,
                           :response, :response_headers, :status,
-                          :reason_phrase, :response_body)
+                          :reason_phrase, :response_body, :connection)
 
     # rubocop:disable Naming/ConstantName
     ContentLength = 'Content-Length'
@@ -61,7 +65,7 @@ module Faraday
     # these requests, the Content-Length header is set to 0.
     MethodsWithBodies = Set.new(Faraday::METHODS_WITH_BODY.map(&:to_sym))
 
-    options request: RequestOptions,
+    options request: RequestOptions, connection: ConnectionOptions,
             request_headers: Utils::Headers, response_headers: Utils::Headers
 
     extend Forwardable

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -202,14 +202,7 @@ module Faraday
     #     :password   - Proxy server password
     # :ssl - Hash of options for configuring SSL requests.
     def build_env(connection, request)
-      exclusive_url = connection.build_exclusive_url(
-        request.path, request.params,
-        request.options.params_encoder
-      )
-
-      Env.new(request.method, request.body, exclusive_url,
-              request.options, request.headers, connection.ssl,
-              connection.parallel_manager)
+      request.to_env(connection)
     end
 
     private

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -141,8 +141,10 @@ module Faraday
     def to_env(connection)
       exc_url = connection.build_exclusive_url(path, params,
                                                options.params_encoder)
-      Env.new(method, body, exc_url, options, headers, connection.ssl,
-              connection.parallel_manager)
+      env = Env.new(method, body, exc_url, options, headers, connection.ssl,
+                    connection.parallel_manager)
+      env.connection = connection
+      env
     end
   end
 end

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -139,8 +139,10 @@ module Faraday
 
     # @return [Env] the Env for this Request
     def to_env(connection)
-      Env.new(method, body, connection.build_exclusive_url(path, params),
-              options, headers, connection.ssl, connection.parallel_manager)
+      exc_url = connection.build_exclusive_url(path, params,
+                                               options.params_encoder)
+      Env.new(method, body, exc_url, options, headers, connection.ssl,
+              connection.parallel_manager)
     end
   end
 end

--- a/spec/faraday/adapter/excon_spec.rb
+++ b/spec/faraday/adapter/excon_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Faraday::Adapter::Excon do
   end
 
   context 'config' do
-    let(:adapter) { Faraday::Adapter::Excon.new }
+    let(:adapter) { described_class.new }
     let(:request) { Faraday::RequestOptions.new }
     let(:uri) { URI.parse('https://example.com') }
     let(:env) do

--- a/spec/faraday/adapter/httpclient_spec.rb
+++ b/spec/faraday/adapter/httpclient_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe Faraday::Adapter::HTTPClient do
 
       # client2 is cached because no important request options are set
       client2 = adapter.connection(env)
-      expect(client2.object_id).to eq(client.object_id)
       expect(client2.ssl_config.client_cert).to eq('client-cert')
       expect(client2.connect_timeout).to eq(60)
+      expect(client2.object_id).to eq(client.object_id)
 
       # important request setting, so client3 is new
       env.request.timeout = 5

--- a/spec/faraday/adapter/httpclient_spec.rb
+++ b/spec/faraday/adapter/httpclient_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Faraday::Adapter::HTTPClient do
         url: URI.parse('https://example.com')
       )
     end
-    let(:adapter) { Faraday::Adapter::HTTPClient.new }
+    let(:adapter) { described_class.new }
     let(:client) { adapter.connection(env) }
 
     it 'caches connection' do

--- a/spec/faraday/adapter/httpclient_spec.rb
+++ b/spec/faraday/adapter/httpclient_spec.rb
@@ -35,21 +35,25 @@ RSpec.describe Faraday::Adapter::HTTPClient do
     let(:client) { adapter.connection(env) }
 
     it 'caches connection' do
+      # before client is created
       env.ssl.client_cert = 'client-cert'
+      request.boundary = 'doesnt-matter'
 
       expect(client.ssl_config.client_cert).to eq('client-cert')
+      expect(client.connect_timeout).to eq(60)
 
+      # client2 is cached because no important request options are set
       client2 = adapter.connection(env)
       expect(client2.object_id).to eq(client.object_id)
       expect(client2.ssl_config.client_cert).to eq('client-cert')
+      expect(client2.connect_timeout).to eq(60)
 
+      # important request setting, so client3 is new
       env.request.timeout = 5
       client3 = adapter.connection(env)
-      expect(client3.object_id).to eq(client3.object_id)
+      expect(client3.object_id).not_to eq(client2.object_id)
       expect(client3.ssl_config.client_cert).to eq('client-cert')
 
-      expect(client.connect_timeout).to eq(5)
-      expect(client2.connect_timeout).to eq(5)
       expect(client3.connect_timeout).to eq(5)
     end
 

--- a/spec/faraday/adapter/patron_spec.rb
+++ b/spec/faraday/adapter/patron_spec.rb
@@ -15,4 +15,43 @@ RSpec.describe Faraday::Adapter::Patron do
 
     expect { conn.get('/') }.to raise_error(RuntimeError, 'Configuration block called')
   end
+
+  context 'config' do
+    let(:adapter) { Faraday::Adapter::Patron.new }
+    let(:request) { Faraday::RequestOptions.new }
+    let(:uri) { URI.parse('https://example.com') }
+    let(:env) do
+      Faraday::Env.from(
+        request: request,
+        ssl: Faraday::SSLOptions.new,
+        url: uri
+      )
+    end
+
+    it 'caches connection' do
+      # before client is created
+      env.ssl.ca_file = 'ca-file'
+      request.boundary = 'doesnt-matter'
+
+      client = adapter.connection(env)
+      expect(!!client.insecure).to eq(false)
+      expect(client.cacert).to eq('ca-file')
+      expect(client.timeout).to eq(5)
+
+      # client2 is cached because no important request options are set
+      client2 = adapter.connection(env)
+      expect(!!client2.insecure).to eq(false)
+      expect(client2.cacert).to eq('ca-file')
+      expect(client2.timeout).to eq(5)
+      expect(client2.object_id).to eq(client.object_id)
+
+      # important request setting, so client3 is new
+      env.request.timeout = 3
+      client3 = adapter.connection(env)
+      expect(!!client3.insecure).to eq(false)
+      expect(client3.cacert).to eq('ca-file')
+      expect(client3.timeout).to eq(3)
+      expect(client3.object_id).not_to eq(client2.object_id)
+    end
+  end
 end

--- a/spec/faraday/adapter/patron_spec.rb
+++ b/spec/faraday/adapter/patron_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Faraday::Adapter::Patron do
   end
 
   context 'config' do
-    let(:adapter) { Faraday::Adapter::Patron.new }
+    let(:adapter) { described_class.new }
     let(:request) { Faraday::RequestOptions.new }
     let(:uri) { URI.parse('https://example.com') }
     let(:env) do

--- a/spec/faraday/adapter/patron_spec.rb
+++ b/spec/faraday/adapter/patron_spec.rb
@@ -24,25 +24,30 @@ RSpec.describe Faraday::Adapter::Patron do
       Faraday::Env.from(
         request: request,
         ssl: Faraday::SSLOptions.new,
-        url: uri
+        url: uri,
+        connection: Faraday::ConnectionOptions.new
       )
     end
 
     it 'caches connection' do
       # before client is created
+      env.connection.timeout = 4
+      env.connection.open_timeout = 1
       env.ssl.ca_file = 'ca-file'
       request.boundary = 'doesnt-matter'
 
       client = adapter.connection(env)
       expect(!!client.insecure).to eq(false)
       expect(client.cacert).to eq('ca-file')
-      expect(client.timeout).to eq(5)
+      expect(client.timeout).to eq(4)
+      expect(client.connect_timeout).to eq(1)
 
       # client2 is cached because no important request options are set
       client2 = adapter.connection(env)
       expect(!!client2.insecure).to eq(false)
       expect(client2.cacert).to eq('ca-file')
-      expect(client2.timeout).to eq(5)
+      expect(client2.timeout).to eq(4)
+      expect(client2.connect_timeout).to eq(1)
       expect(client2.object_id).to eq(client.object_id)
 
       # important request setting, so client3 is new
@@ -51,6 +56,7 @@ RSpec.describe Faraday::Adapter::Patron do
       expect(!!client3.insecure).to eq(false)
       expect(client3.cacert).to eq('ca-file')
       expect(client3.timeout).to eq(3)
+      expect(client3.connect_timeout).to eq(3)
       expect(client3.object_id).not_to eq(client2.object_id)
     end
   end

--- a/spec/faraday/adapter_spec.rb
+++ b/spec/faraday/adapter_spec.rb
@@ -2,9 +2,51 @@
 
 RSpec.describe Faraday::Adapter do
   let(:adapter) { Faraday::Adapter.new }
-  let(:request) { {} }
+
+  context '#reconfigure_connection?' do
+    let(:all_keys) do
+      (Faraday::ConnectionOptions.members + Faraday::RequestOptions.members).uniq
+    end
+    let(:non_request_keys) { all_keys - Faraday::Adapter::CONNECTION_OPTIONS }
+
+    it 'is not truthy with nil env request value' do
+      expect(!!reconfigure_connection?(request: nil)).to eq(false)
+    end
+
+    it 'is not truthy with nil env' do
+      expect(!!reconfigure_connection?(nil)).to eq(false)
+    end
+
+    it 'is not truthy with unimportant request keys' do
+      env = {}
+      non_request_keys.each do |key|
+        env[key] = :set
+      end
+      env[:request] = env
+
+      expect(!!reconfigure_connection?(env)).to eq(false)
+    end
+
+    Faraday::Adapter::CONNECTION_OPTIONS.each do |key|
+      it "is truthy with request #{key.inspect} key" do
+        env = { request: { key => true } }
+        expect(!!reconfigure_connection?(env)).to eq(true)
+
+        non_request_keys.each do |k|
+          env[:request][k] = :set
+        end
+
+        expect(!!reconfigure_connection?(env)).to eq(true)
+      end
+    end
+
+    def reconfigure_connection?(*args)
+      adapter.send(:reconfigure_connection?, *args)
+    end
+  end
 
   context '#request_timeout' do
+    let(:request) { {} }
     it 'gets :read timeout' do
       expect(timeout(:read)).to eq(nil)
 


### PR DESCRIPTION
This was an attempt to steps 2, 4, and 5 of #1024

(items copied below, since #1024 has changed)

1. ...
2. Send `ConnectionOptions` to Env as `:connection` key.
3. ...
4. Copy settings that configure the HTTP connection from `RequestOptions` to `ConnectionOptions`: `:proxy, :bind, :timeout, :read_timeout, :open_timeout, :write_timeout`
5. Teach `Adapter#initialize` to save the connection if it can:
* If any of the moved RequestOptions settings are used, skip this!
* ...
* If the adapter does not support pooling, @conn = build_connection

I started by caching the connection first, and _then_ worrying about how to include the connection options. But, I realized I need a way to merge the connection options with request options, so that something like this will work as expected:

```ruby
Faraday.new(timeout: 5, request: { write_timeout: 3 })
```

I think this approach was backwards. I should setup `ConnectionOptions` and merge it with `RequestOptions` at the right time, with whatever `proxy` changes are needed, before worrying about caching the HTTP object.

I'm keeping this PR around as an example, but I'll probably end up rewriting or cherry-picking these commits into something else later.