### PR TITLE
Proxy selector

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -5,6 +5,7 @@ require 'set'
 require 'forwardable'
 require 'faraday/middleware_registry'
 require 'faraday/dependency_loader'
+require 'faraday/proxy_selector'
 
 # This is the main namespace for Faraday.
 #

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -99,7 +99,6 @@ module Faraday
         else
           proxy_from_env(url)
         end
-      @temp_proxy = @proxy
     end
 
     # Sets the Hash of URI query unencoded key/value pairs.
@@ -490,11 +489,8 @@ module Faraday
         raise ArgumentError, "unknown http method: #{method}"
       end
 
-      # Resets temp_proxy
-      @temp_proxy = proxy_for_request(url)
-
       request = build_request(method) do |req|
-        req.options = req.options.merge(proxy: @temp_proxy)
+        req.options.proxy = proxy_for_request(url)
         req.url(url)                if url
         req.headers.update(headers) if headers
         req.body = body             if body
@@ -514,7 +510,7 @@ module Faraday
       Request.create(method) do |req|
         req.params  = params.dup
         req.headers = headers.dup
-        req.options = options
+        req.options = options.dup
         yield(req) if block_given?
       end
     end

--- a/lib/faraday/proxy_selector.rb
+++ b/lib/faraday/proxy_selector.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+# Faraday module.
+module Faraday
+  # Builds a ProxySelector that uses the given env. If no env is provided,
+  # this defaults to ENV unless Faraday.ignore_env_proxy is enabled.
+  #
+  # @param env [Hash, nil] Hash of environment variables, which can be set with
+  #        Symbol, String, or uppercased String keys.
+  #        Ex: :http_proxy, 'http_proxy', or 'HTTP_PROXY'
+  # @option env [String] :http_proxy Used as the proxy for HTTP and HTTPS
+  #         requests, unless overridden by :https_proxy or :no_proxy
+  # @option env [String] :https_proxy Used as the proxy for HTTPS requests,
+  #         unless overridden by :no_proxy
+  # @option env [String] :no_proxy A String that contains comma-separated values
+  #         specifying hosts that should be excluded from proxying. Each value
+  #         is represented by an IP address prefix (1.2.3.4), an IP address
+  #         prefix in CIDR notation (1.2.3.4/8), a domain name, or a special DNS
+  #         label (*). An IP address prefix and domain name can also include a
+  #         literal port number (1.2.3.4:80).
+  #         A domain name matches that name and all subdomains. A domain name
+  #         with a leading "." matches subdomains only. For example "foo.com"
+  #         matches "foo.com" and "bar.foo.com"; ".y.com" matches "x.y.com" but
+  #         not "y.com". A single asterisk (*) indicates that no proxying should
+  #         be done. A best effort is made to parse the string and errors are
+  #         ignored.
+  #
+  # @return [Faraday::ProxySelector::Environment, Faraday::ProxySelector::Nil]
+  def self.proxy_with_env(env = nil)
+    return ProxySelector::Nil.new if env.nil? && Faraday.ignore_env_proxy
+
+    ProxySelector::Environment.new(env)
+  end
+
+  # Builds a ProxySelector that returns the given uri.
+  #
+  # @param uri [URI] The proxy URI.
+  # @param user [String, nil] Optional user info for proxy.
+  # @param password [String, nil] Optional password info for proxy.
+  #
+  # @return [Faraday::ProxySelector::Single]
+  def self.proxy_to(uri, user: nil, password: nil)
+    ProxySelector::Single.new(uri, user: user, password: password)
+  end
+
+  # Builds a ProxySelector that returns the given uri.
+  #
+  # @param url [String] The proxy raw url.
+  # @param user [String, nil] Optional user info for proxy.
+  # @param password [String, nil] Optional password info for proxy.
+  #
+  # @return [Faraday::ProxySelector::Single]
+  def self.proxy_to_url(url, user: nil, password: nil)
+    proxy_to(Utils.URI(url), user: user, password: password)
+  end
+
+  # Proxy is a generic class that knows the Proxy for any given URL. You can
+  # initialize a Proxy selector instance with one of the class methods:
+  #
+  #   # Pulls from ENV
+  #   proxy = Faraday.proxy_with_env
+  #
+  #   # Set your own vars
+  #   proxy = Faraday.proxy_with_env(http_proxy: "http://proxy.example.com")
+  #
+  #   # Set with string URL
+  #   proxy = Faraday.proxy_to_url("http://proxy.example.com")
+  #
+  #   # Set with URI
+  #   uri = Faraday::Utils::URI("http://proxy.example.com")
+  #   proxy = Faraday.proxy_to(uri) # shortcut
+  #
+  # Once you have an instance, you can get the proxy for a request url:
+  #
+  #   proxy.proxy_for_url("http://example.com")
+  #   # => Faraday::ProxyOptions instance or nil
+  #
+  #   uri = Faraday::Utils::URI("http://example.com")
+  #   proxy.proxy_for(uri)
+  #   # => Faraday::ProxyOptions instance or nil
+  class ProxySelector
+    # Single is a ProxySelector implementation that always returns the given
+    # proxy uri.
+    class Single < ProxySelector
+      def initialize(uri, user: nil, password: nil)
+        @options = ProxyOptions.new(uri, user, password)
+      end
+
+      # Gets the configured proxy, regardless of the uri.
+      #
+      # @param _ [URI] Unused.
+      #
+      # @return [Faraday::ProxyOptions]
+      def proxy_for(_)
+        @options
+      end
+
+      # Gets the configured proxy, regardless of the url.
+      #
+      # @param _ [String] Unused.
+      #
+      # @return [Faraday::ProxyOptions]
+      def proxy_for_url(_)
+        @options
+      end
+
+      # Checks if the given uri has a configured proxy. Returns true, because
+      # every request uri should use the configured proxy.
+      #
+      # @param _ [URI] Unused.
+      #
+      # @return true
+      def use_for?(_)
+        !@options.nil?
+      end
+
+      # Checks if the given url has a configured proxy. Returns true, because
+      # every request url should use the configured proxy.
+      #
+      # @param _ [String] Unused.
+      #
+      # @return true
+      def use_for_url?(_)
+        !@options.nil?
+      end
+    end
+    # Environment is a ProxySelector implementation that picks a proxy based on
+    # how the given request url matches with the http_proxy, https_proxy, and
+    # no_proxy settings.
+    #
+    # Note: Logic for parsing proxy env vars heavily inspired by
+    # http://golang.org/x/net/http/httpproxy
+    class Environment < ProxySelector
+      def initialize(env = nil)
+        @env = env || ENV
+        # parse http_proxy, https_proxy, no_proxy
+      end
+
+      # Gets the proxy for the given uri
+      #
+      # @param uri [URI] URI being requested.
+      #
+      # @return [Faraday::ProxyOptions, nil]
+      def proxy_for(uri)
+        # check for proxy based on uri scheme
+        # check no_proxy
+        raise NotImplementedError, "given: #{uri.inspect}"
+      end
+
+      # Gets the proxy for the given url
+      #
+      # @param url [String] URL being requested.
+      #
+      # @return [Faraday::ProxyOptions, nil]
+      def proxy_for_url(url)
+        proxy_for(Utils.URI(url))
+      end
+
+      # Checks if the given uri has a configured proxy.
+      #
+      # @param uri [URI] URI being requested.
+      #
+      # @return [Bool]
+      def use_for?(uri)
+        # check for proxy based on uri scheme
+        # check no_proxy
+        raise NotImplementedError, "given: #{uri.inspect}"
+      end
+
+      # Checks if the given url has a configured proxy.
+      #
+      # @param url [String] URL being requested.
+      #
+      # @return [Bool]
+      def use_for_url?(url)
+        use_for?(Utils.URI(url))
+      end
+    end
+
+    # Nil is a ProxySelector implementation that always returns no proxy. Used
+    # if no proxy is manually configured, and Faraday.ignore_env_proxy is
+    # enabled.
+    class Nil < Single
+      def initialize; end
+    end
+  end
+end

--- a/lib/faraday/proxy_selector.rb
+++ b/lib/faraday/proxy_selector.rb
@@ -157,7 +157,16 @@ module Faraday
       attr_reader :host_matchers
 
       def initialize(env = nil)
-        @http_proxy = parse_proxy(env ||= ENV, HTTP_PROXY_KEYS)
+        env ||= ENV
+
+        # don't parse HTTP_PROXY if this looks like a CGI request
+        is_cgi = env['REQUEST_METHOD']
+        @http_proxy = if is_cgi.nil? || is_cgi.empty?
+                        parse_proxy(env, HTTP_PROXY_KEYS)
+                      else
+                        parse_proxy(env, HTTP_PROXY_KEYS[0...-1])
+                      end
+
         @https_proxy = parse_proxy(env, HTTPS_PROXY_KEYS)
         parse_no_proxy(env)
       end

--- a/lib/faraday/proxy_selector.rb
+++ b/lib/faraday/proxy_selector.rb
@@ -168,9 +168,9 @@ module Faraday
       #
       # @return [Faraday::ProxyOptions, nil]
       def proxy_for(uri)
-        # check for proxy based on uri scheme
-        # check no_proxy
-        raise NotImplementedError, "given: #{uri.inspect}"
+        proxy = (uri.scheme == 'https' && @https_proxy) || @http_proxy
+        proxy = nil if proxy && !use_for?(uri)
+        proxy
       end
 
       # Gets the proxy for the given url

--- a/lib/faraday/proxy_selector.rb
+++ b/lib/faraday/proxy_selector.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ipaddr'
+
 # Faraday module.
 module Faraday
   # Builds a ProxySelector that uses the given env. If no env is provided,
@@ -13,17 +15,8 @@ module Faraday
   # @option env [String] :https_proxy Used as the proxy for HTTPS requests,
   #         unless overridden by :no_proxy
   # @option env [String] :no_proxy A String that contains comma-separated values
-  #         specifying hosts that should be excluded from proxying. Each value
-  #         is represented by an IP address prefix (1.2.3.4), an IP address
-  #         prefix in CIDR notation (1.2.3.4/8), a domain name, or a special DNS
-  #         label (*). An IP address prefix and domain name can also include a
-  #         literal port number (1.2.3.4:80).
-  #         A domain name matches that name and all subdomains. A domain name
-  #         with a leading "." matches subdomains only. For example "foo.com"
-  #         matches "foo.com" and "bar.foo.com"; ".y.com" matches "x.y.com" but
-  #         not "y.com". A single asterisk (*) indicates that no proxying should
-  #         be done. A best effort is made to parse the string and errors are
-  #         ignored.
+  #         specifying hosts that should be excluded from proxying. See
+  #         Faraday::ProxySelector::Environment for more info.
   #
   # @return [Faraday::ProxySelector::Environment, Faraday::ProxySelector::Nil]
   def self.proxy_with_env(env = nil)
@@ -95,14 +88,13 @@ module Faraday
         @options
       end
 
+      # @!method proxy_for_url(_)
       # Gets the configured proxy, regardless of the url.
       #
       # @param _ [String] Unused.
       #
       # @return [Faraday::ProxyOptions]
-      def proxy_for_url(_)
-        @options
-      end
+      alias proxy_for_url proxy_for
 
       # Checks if the given uri has a configured proxy. Returns true, because
       # every request uri should use the configured proxy.
@@ -114,31 +106,47 @@ module Faraday
         !@options.nil?
       end
 
+      # @!method use_for_url?(_)
       # Checks if the given url has a configured proxy. Returns true, because
       # every request url should use the configured proxy.
       #
       # @param _ [String] Unused.
       #
       # @return true
-      def use_for_url?(_)
-        !@options.nil?
-      end
+      alias use_for_url? use_for?
     end
+
+    # Nil is a ProxySelector implementation that always returns no proxy. Used
+    # if no proxy is manually configured, and Faraday.ignore_env_proxy is
+    # enabled.
+    class Nil < Single
+      def initialize; end
+    end
+
     # Environment is a ProxySelector implementation that picks a proxy based on
     # how the given request url matches with the http_proxy, https_proxy, and
     # no_proxy settings.
+    #
+    # The no_proxy is a string containing comma-separated values specifying
+    # HTTP request hosts that should be excluded from proxying. Hosts can be
+    # specified as host names or IP address. See the HostMatcher and IPMatcher
+    # classes for the implementation of those respective filters. A single
+    # asterisk (*) indicates that no proxying should be done. It's
+    # implementation is in AsteriskMatcher.
     #
     # Note: Logic for parsing proxy env vars heavily inspired by
     # http://golang.org/x/net/http/httpproxy
     class Environment < ProxySelector
       attr_reader :http_proxy
       attr_reader :https_proxy
+      attr_reader :ip_matchers
+      attr_reader :host_matchers
 
       def initialize(env = nil)
         env ||= ENV
         @http_proxy = parse_proxy(env, HTTP_PROXY_KEYS)
         @https_proxy = parse_proxy(env, HTTPS_PROXY_KEYS)
-        # parse no_proxy
+        parse_no_proxy(env)
       end
 
       # Gets the proxy for the given uri
@@ -161,18 +169,18 @@ module Faraday
         proxy_for(Utils.URI(url))
       end
 
-      # Checks if the given uri has a configured proxy.
+      # Checks if the given uri is allowed by the no_proxy setting.
       #
       # @param uri [URI] URI being requested.
       #
       # @return [Bool]
       def use_for?(uri)
-        # check for proxy based on uri scheme
-        # check no_proxy
-        raise NotImplementedError, "given: #{uri.inspect}"
+        return false if uri.host == 'localhost'
+
+        host_port_use_proxy?(uri.host, uri.port)
       end
 
-      # Checks if the given url has a configured proxy.
+      # Checks if the given url is allowed by the no_proxy setting.
       #
       # @param url [String] URL being requested.
       #
@@ -183,10 +191,72 @@ module Faraday
 
       private
 
+      def host_port_use_proxy?(host, port)
+        return false if @host_matchers.any? { |m| m.matches?(host, port) }
+
+        # attempt to parse every host as an IP
+        ip = IPAddr.new(host)
+        !(ip.loopback? || @ip_matchers.any? { |m| m.matches?(ip, port) })
+      rescue IPAddr::InvalidAddressError
+        true
+      end
+
       def parse_proxy(env, keys)
         value = nil
         keys.detect { |k| value = env[k] }
         value ? ProxyOptions.from(value) : nil
+      end
+
+      def parse_no_proxy(env)
+        @ip_matchers = []
+        @host_matchers = []
+        value = nil
+        NO_PROXY_KEYS.detect { |k| value = env[k] }
+        return unless value
+
+        value.split(',').each do |entry|
+          entry.strip!
+          entry.downcase!
+
+          if entry == '*'
+            @ip_matchers = @host_matchers = AsteriskMatcher
+            break
+          end
+
+          parse_no_proxy_entry(entry) unless entry.empty?
+        end
+        @ip_matchers.freeze
+        @host_matchers.freeze
+      end
+
+      def parse_no_proxy_entry(entry)
+        port, ip, host = parse_entry(entry)
+        @ip_matchers << IPMatcher.new(ip, port) if ip
+        @host_matchers << HostMatcher.new(host, port) if host
+      end
+
+      def parse_entry(entry)
+        # This is an IP or IP range with no port
+        # Parser raises if IP has port suffix.
+        [nil, IPAddr.new(entry), nil]
+      rescue IPAddr::InvalidAddressError
+        host, port = if /\A(?<h>.*):(?<p>\d+)\z/i =~ entry
+                       [h, p.to_i]
+                     else
+                       [entry, nil]
+                     end
+
+        # There is no host part, likely the entry is malformed; ignore.
+        return if host.empty?
+
+        begin
+          # This is an IP or IP range with explicit port
+          return [port, IPAddr.new(host), nil]
+        rescue IPAddr::InvalidAddressError # rubocop:disable Lint/HandleExceptions
+        end
+
+        # can't parse as IP, assume it's a domain
+        [port, nil, host]
       end
 
       HTTP_PROXY_KEYS = [:http_proxy, 'http_proxy', 'HTTP_PROXY'].freeze
@@ -194,11 +264,70 @@ module Faraday
       NO_PROXY_KEYS = [:no_proxy, 'no_proxy', 'NO_PROXY'].freeze
     end
 
-    # Nil is a ProxySelector implementation that always returns no proxy. Used
-    # if no proxy is manually configured, and Faraday.ignore_env_proxy is
-    # enabled.
-    class Nil < Single
-      def initialize; end
+    # IPMatcher parses an IP related entry in the no_proxy env variable.
+    class IPMatcher
+      # @param ip [IPAddr] IP address prefix (1.2.3.4) or an IP address prefix
+      #        in CIDR notation (1.2.3.4/8).
+      # @param port [Integer, nil] Determines whether a given ip and port
+      #        combo must match a specific port, or if any port is valid.
+      def initialize(ip, port)
+        @ip = ip
+        @port = port
+      end
+
+      # Determines if the given ip and port are matched by this IPMatcher.
+      #
+      # @param ip [IPAddr] IP address prefix (1.2.3.4) of the request URL.
+      # @param port [Integer] Port of the request URL.
+      #
+      # @return [Bool]
+      def matches?(ip, port)
+        return false unless @port.nil? || @port == port
+
+        @ip.include?(ip)
+      end
+    end
+
+    # HostMatcher parses a no_proxy entry with a domain and optional port. A
+    # host name matches that name and all subdomains. A host name with a
+    # leading "." matches subdomains only. For example, "foo.com" matches
+    # "foo.com" and "bar.foo.com"; ".y.com" matches "x.y.com" but not "y.com".
+    class HostMatcher
+      # @param host [String] The host name entry from no_proxy.
+      # @param port [Integer, nil] Determines whether a given host and port
+      #        combo must match a specific port, or if any port is valid.
+      def initialize(host, port)
+        host = host[1..-1] if host[0..1] == '*.'
+
+        @port = port
+        @host = if (@match_host = host[0] != '.')
+                  ".#{host}"
+                else
+                  host
+                end
+      end
+
+      # Determines if the given host and port are matched by this HostMatcher.
+      #
+      # @param host [String] Host name of the request URL.
+      # @param port [Integer] Port of the request URL.
+      #
+      # @return [Bool]
+      def matches?(host, port)
+        return false unless @port.nil? || @port == port
+        return true if host.end_with?(@host)
+
+        @match_host && host == @host[1..-1]
+      end
+    end
+
+    # AsteriskMatcher replaces all ip and host matchers in a
+    # ProxySelector::Environment with one that indicates no proxying will be
+    # done.
+    class AsteriskMatcher
+      def self.any?
+        true
+      end
     end
   end
 end

--- a/lib/faraday/proxy_selector.rb
+++ b/lib/faraday/proxy_selector.rb
@@ -131,9 +131,14 @@ module Faraday
     # Note: Logic for parsing proxy env vars heavily inspired by
     # http://golang.org/x/net/http/httpproxy
     class Environment < ProxySelector
+      attr_reader :http_proxy
+      attr_reader :https_proxy
+
       def initialize(env = nil)
-        @env = env || ENV
-        # parse http_proxy, https_proxy, no_proxy
+        env ||= ENV
+        @http_proxy = parse_proxy(env, HTTP_PROXY_KEYS)
+        @https_proxy = parse_proxy(env, HTTPS_PROXY_KEYS)
+        # parse no_proxy
       end
 
       # Gets the proxy for the given uri
@@ -175,6 +180,18 @@ module Faraday
       def use_for_url?(url)
         use_for?(Utils.URI(url))
       end
+
+      private
+
+      def parse_proxy(env, keys)
+        value = nil
+        keys.detect { |k| value = env[k] }
+        value ? ProxyOptions.from(value) : nil
+      end
+
+      HTTP_PROXY_KEYS = [:http_proxy, 'http_proxy', 'HTTP_PROXY'].freeze
+      HTTPS_PROXY_KEYS = [:https_proxy, 'https_proxy', 'HTTPS_PROXY'].freeze
+      NO_PROXY_KEYS = [:no_proxy, 'no_proxy', 'NO_PROXY'].freeze
     end
 
     # Nil is a ProxySelector implementation that always returns no proxy. Used

--- a/spec/faraday/proxy_selector_spec.rb
+++ b/spec/faraday/proxy_selector_spec.rb
@@ -74,6 +74,45 @@ RSpec.describe Faraday::ProxySelector do
     Faraday.ignore_env_proxy = @ignore_env_proxy
   end
 
+  context '#with_env with explicit hash' do
+    let(:proxy_url) { '://example.com' }
+
+    before { Faraday.ignore_env_proxy = true }
+
+    http_keys = Faraday::ProxySelector::Environment::HTTP_PROXY_KEYS
+    https_keys = Faraday::ProxySelector::Environment::HTTPS_PROXY_KEYS
+    http_keys.each do |http|
+      it "parses #{http}" do
+        selector = Faraday.proxy_with_env(
+          http => 'http'+proxy_url
+        )
+        expect(selector.http_proxy.scheme).to eq('http')
+        expect(selector.http_proxy.host).to eq('example.com')
+      end
+
+      https_keys.each do |https|
+        it "parses #{https}" do
+          selector = Faraday.proxy_with_env(
+            https => 'https'+proxy_url
+          )
+          expect(selector.https_proxy.scheme).to eq('https')
+          expect(selector.https_proxy.host).to eq('example.com')
+        end
+
+        it "parses #{http} & #{https}" do
+          selector = Faraday.proxy_with_env(
+            http => 'http'+proxy_url,
+            https => 'https'+proxy_url
+          )
+          expect(selector.http_proxy.scheme).to eq('http')
+          expect(selector.http_proxy.host).to eq('example.com')
+          expect(selector.https_proxy.scheme).to eq('https')
+          expect(selector.https_proxy.host).to eq('example.com')
+        end
+      end
+    end
+  end
+
   context '#with_env with env disabled' do
     Faraday.ignore_env_proxy = true
     proxy = Faraday.proxy_with_env(nil)

--- a/spec/faraday/proxy_selector_spec.rb
+++ b/spec/faraday/proxy_selector_spec.rb
@@ -179,6 +179,18 @@ context Faraday::ProxySelector::Environment do
       # Use secure for https.
       [{ http_proxy: 'http.proxy.tld', https_proxy: 'secure.proxy.tld' },
        'https://secure.tld/', 'http://secure.proxy.tld'],
+      # don't use HTTP_PROXY in a CGI environment, where HTTP_PROXY can be
+      # attacker-controlled.
+      [{ 'HTTP_PROXY' => 'http://10.1.2.3:8080', 'REQUEST_METHOD' => '1' }, nil,
+       nil],
+      # :http_proxy and "http_proxy" still work
+      [{ http_proxy: 'http://10.1.2.3:8080', 'REQUEST_METHOD' => '1' }, nil,
+       'http://10.1.2.3:8080'],
+      [{ 'http_proxy' => 'http://10.1.2.3:8080', 'REQUEST_METHOD' => '1' }, nil,
+       'http://10.1.2.3:8080'],
+      # HTTPS proxy is still used even in CGI environment.
+      [{ https_proxy: 'https://secure.proxy.tld', 'REQUEST_METHOD' => '1' }, nil,
+       nil],
       [{ http_proxy: 'http.proxy.tld', https_proxy: 'https://secure.proxy.tld' },
        'https://secure.tld/', 'https://secure.proxy.tld'],
       [{ no_proxy: 'example.com', http_proxy: 'proxy' }, nil, nil],

--- a/spec/faraday/proxy_selector_spec.rb
+++ b/spec/faraday/proxy_selector_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'ProxySelector::Nil' do |proxy_sel|
+  it 'is the right type' do
+    expect(proxy_sel).to be_a(Faraday::ProxySelector::Nil)
+  end
+
+  it 'returns no proxy for http url' do
+    expect(proxy_sel.proxy_for_url(http_request_url)).to be_nil
+    expect(proxy_sel.proxy_for(http_request_uri)).to be_nil
+  end
+
+  it 'returns no proxy for https url' do
+    expect(proxy_sel.proxy_for_url(https_request_url)).to be_nil
+    expect(proxy_sel.proxy_for(https_request_uri)).to be_nil
+  end
+
+  it 'doesnt use proxy for http url' do
+    expect(proxy_sel.use_for_url?(http_request_url)).to eq(false)
+    expect(proxy_sel.use_for?(http_request_uri)).to eq(false)
+  end
+
+  it 'doesnt use proxy for https url' do
+    expect(proxy_sel.use_for_url?(https_request_url)).to eq(false)
+    expect(proxy_sel.use_for?(https_request_uri)).to eq(false)
+  end
+end
+
+RSpec.shared_examples 'ProxySelector::Single' do |proxy_sel, expected_user, expected_pass|
+  it 'is the right type' do
+    expect(proxy_sel).to be_a(Faraday::ProxySelector::Single)
+  end
+
+  it 'fetches proxy for http url' do
+    proxy = proxy_sel.proxy_for(http_request_uri)
+    expect(proxy_sel.proxy_for_url(http_request_url)).to eq(proxy)
+    expect(proxy).not_to be_nil
+    expect(proxy.host).to eq('proxy.com')
+    expect(proxy.user).to eq(expected_user)
+    expect(proxy.password).to eq(expected_pass)
+  end
+
+  it 'fetches proxy for https url' do
+    proxy = proxy_sel.proxy_for(https_request_uri)
+    expect(proxy_sel.proxy_for_url(https_request_url)).to eq(proxy)
+    expect(proxy).not_to be_nil
+    expect(proxy.host).to eq('proxy.com')
+    expect(proxy.user).to eq(expected_user)
+    expect(proxy.password).to eq(expected_pass)
+  end
+
+  it 'uses proxy for http url' do
+    expect(proxy_sel.use_for_url?(http_request_url)).to eq(true)
+    expect(proxy_sel.use_for?(http_request_uri)).to eq(true)
+  end
+
+  it 'uses proxy for https url' do
+    expect(proxy_sel.use_for_url?(https_request_url)).to eq(true)
+    expect(proxy_sel.use_for?(https_request_uri)).to eq(true)
+  end
+end
+
+RSpec.describe Faraday::ProxySelector do
+  let(:http_request_url) { 'http://http.example.com' }
+  let(:https_request_url) { 'https://https.example.com' }
+  let(:http_request_uri) { Faraday::Utils.URI(http_request_url) }
+  let(:https_request_uri) { Faraday::Utils.URI(https_request_url) }
+
+  before do
+    @ignore_env_proxy = Faraday.ignore_env_proxy
+  end
+
+  after do
+    Faraday.ignore_env_proxy = @ignore_env_proxy
+  end
+
+  context '#with_env with env disabled' do
+    Faraday.ignore_env_proxy = true
+    proxy = Faraday.proxy_with_env(nil)
+    include_examples 'ProxySelector::Nil', proxy
+  end
+
+  context '#none' do
+    include_examples 'ProxySelector::Nil', Faraday::ProxySelector::Nil.new
+  end
+
+  context '#to_url without user auth' do
+    proxy = Faraday.proxy_to_url('http://proxy.com')
+    include_examples 'ProxySelector::Single', proxy, nil, nil
+  end
+
+  context '#to_url with user auth in proxy url' do
+    proxy = Faraday.proxy_to_url('http://u%3A1:p%3A2@proxy.com')
+    include_examples 'ProxySelector::Single', proxy, 'u:1', 'p:2'
+  end
+
+  context '#to_url with explicit user auth' do
+    proxy = Faraday.proxy_to_url('http://proxy.com',
+                                 user: 'u:1', password: 'p:2')
+    include_examples 'ProxySelector::Single', proxy, 'u:1', 'p:2'
+  end
+end


### PR DESCRIPTION
I started poking at the proxy code, and then decided trying to implement the [`net/http/httpproxy` package in Go](https://godoc.org/golang.org/x/net/http/httpproxy). Basically, I thought what it'd be like to replace 14 lines of code with my own version in 326 lines (plus docs):

https://github.com/lostisland/faraday/blob/e4b4b973073b8bea739eefe41efc0647ea1f7469/lib/faraday/connection.rb#L587-L600

Three benefits:

1. `no_proxy` is correctly handled in cases where `URI#find_proxy` don't exist. I don't know what versions are affected, so this may be a moot point.
2. Potential speed improvements on repeat `#proxy_for` calls, especially with lots of `no_proxy` entries.
3. Actually support `https_proxy`

Is it worth it? I'm not really sure. But it was fun to write :)
