### PR TITLE
0.1x nil error

### DIFF
--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -124,9 +124,9 @@ module Faraday
         end
       rescue EventMachine::Connectify::CONNECTError => err
         if err.message.include?("Proxy Authentication Required")
-          raise Error::ConnectionFailed, %{407 "Proxy Authentication Required "}
+          raise Faraday::ConnectionFailed, %{407 "Proxy Authentication Required "}
         else
-          raise Error::ConnectionFailed, err
+          raise Faraday::ConnectionFailed, err
         end
       rescue => err
         if defined?(OpenSSL) && OpenSSL::SSL::SSLError === err
@@ -159,15 +159,15 @@ module Faraday
       end
 
       def raise_error(msg)
-        errklass = Faraday::Error::ClientError
+        errklass = Faraday::ClientError
         if msg == Errno::ETIMEDOUT
-          errklass = Faraday::Error::TimeoutError
+          errklass = Faraday::TimeoutError
           msg = "request timed out"
         elsif msg == Errno::ECONNREFUSED
-          errklass = Faraday::Error::ConnectionFailed
+          errklass = Faraday::ConnectionFailed
           msg = "connection refused"
         elsif msg == "connection closed by server"
-          errklass = Faraday::Error::ConnectionFailed
+          errklass = Faraday::ConnectionFailed
         end
         raise errklass, msg
       end
@@ -211,7 +211,7 @@ module Faraday
               end
             end
             if @errors.size > 0
-              raise Faraday::Error::ClientError, @errors.first || "connection failed"
+              raise Faraday::ClientError, @errors.first || "connection failed"
             end
           end
         ensure

--- a/lib/faraday/adapter/em_synchrony.rb
+++ b/lib/faraday/adapter/em_synchrony.rb
@@ -65,18 +65,18 @@ module Faraday
 
         @app.call env
       rescue Errno::ECONNREFUSED
-        raise Error::ConnectionFailed, $!
+        raise Faraday::ConnectionFailed, $!
       rescue EventMachine::Connectify::CONNECTError => err
         if err.message.include?("Proxy Authentication Required")
-          raise Error::ConnectionFailed, %{407 "Proxy Authentication Required "}
+          raise Faraday::ConnectionFailed, %{407 "Proxy Authentication Required "}
         else
-          raise Error::ConnectionFailed, err
+          raise Faraday::ConnectionFailed, err
         end
       rescue Errno::ETIMEDOUT => err
-        raise Error::TimeoutError, err
+        raise Faraday::TimeoutError, err
       rescue RuntimeError => err
         if err.message == "connection closed by server"
-          raise Error::ConnectionFailed, err
+          raise Faraday::ConnectionFailed, err
         else
           raise
         end

--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -59,14 +59,14 @@ module Faraday
         @app.call env
       rescue ::Excon::Errors::SocketError => err
         if err.message =~ /\btimeout\b/
-          raise Error::TimeoutError, err
+          raise Faraday::TimeoutError, err
         elsif err.message =~ /\bcertificate\b/
           raise Faraday::SSLError, err
         else
-          raise Error::ConnectionFailed, err
+          raise Faraday::ConnectionFailed, err
         end
       rescue ::Excon::Errors::Timeout => err
-        raise Error::TimeoutError, err
+        raise Faraday::TimeoutError, err
       end
 
       def create_connection(env, opts)

--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -43,15 +43,15 @@ module Faraday
 
         @app.call env
       rescue ::HTTPClient::TimeoutError, Errno::ETIMEDOUT
-        raise Faraday::Error::TimeoutError, $!
+        raise Faraday::TimeoutError, $!
       rescue ::HTTPClient::BadResponseError => err
         if err.message.include?('status 407')
-          raise Faraday::Error::ConnectionFailed, %{407 "Proxy Authentication Required "}
+          raise Faraday::ConnectionFailed, %{407 "Proxy Authentication Required "}
         else
-          raise Faraday::Error::ClientError, $!
+          raise Faraday::ClientError, $!
         end
       rescue Errno::ECONNREFUSED, IOError, SocketError
-        raise Faraday::Error::ConnectionFailed, $!
+        raise Faraday::ConnectionFailed, $!
       rescue => err
         if defined?(OpenSSL) && OpenSSL::SSL::SSLError === err
           raise Faraday::SSLError, err

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -45,7 +45,7 @@ module Faraday
             if defined?(OpenSSL) && OpenSSL::SSL::SSLError === err
               raise Faraday::SSLError, err
             else
-              raise Error::ConnectionFailed, err
+              raise Faraday::ConnectionFailed, err
             end
           end
 
@@ -58,7 +58,7 @@ module Faraday
 
         @app.call env
       rescue Timeout::Error, Errno::ETIMEDOUT => err
-        raise Faraday::Error::TimeoutError, err
+        raise Faraday::TimeoutError, err
       end
 
       private

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -37,12 +37,12 @@ module Faraday
       def perform_request(http, env)
         http.request env[:url], create_request(env)
       rescue Errno::ETIMEDOUT => error
-        raise Faraday::Error::TimeoutError, error
+        raise Faraday::TimeoutError, error
       rescue Net::HTTP::Persistent::Error => error
         if error.message.include? 'Timeout'
-          raise Faraday::Error::TimeoutError, error
+          raise Faraday::TimeoutError, error
         elsif error.message.include? 'connection refused'
-          raise Faraday::Error::ConnectionFailed, error
+          raise Faraday::ConnectionFailed, error
         else
           raise
         end

--- a/lib/faraday/adapter/patron.rb
+++ b/lib/faraday/adapter/patron.rb
@@ -28,7 +28,7 @@ module Faraday
           data = env[:body] ? env[:body].to_s : nil
           session.request(env[:method], env[:url].to_s, env[:request_headers], :data => data)
         rescue Errno::ECONNREFUSED, ::Patron::ConnectionFailed
-          raise Error::ConnectionFailed, $!
+          raise Faraday::ConnectionFailed, $!
         end
 
         # Remove the "HTTP/1.1 200", leaving just the reason phrase
@@ -39,15 +39,15 @@ module Faraday
         @app.call env
       rescue ::Patron::TimeoutError => err
         if connection_timed_out_message?(err.message)
-          raise Faraday::Error::ConnectionFailed, err
+          raise Faraday::ConnectionFailed, err
         else
-          raise Faraday::Error::TimeoutError, err
+          raise Faraday::TimeoutError, err
         end
       rescue ::Patron::Error => err
         if err.message.include?("code 407")
-          raise Error::ConnectionFailed, %{407 "Proxy Authentication Required "}
+          raise Faraday::ConnectionFailed, %{407 "Proxy Authentication Required "}
         else
-          raise Error::ConnectionFailed, err
+          raise Faraday::ConnectionFailed, err
         end
       end
 

--- a/lib/faraday/adapter/rack.rb
+++ b/lib/faraday/adapter/rack.rb
@@ -41,7 +41,7 @@ module Faraday
 
         timeout  = env[:request][:timeout] || env[:request][:open_timeout]
         response = if timeout
-          Timer.timeout(timeout, Faraday::Error::TimeoutError) { execute_request(env, rack_env) }
+          Timer.timeout(timeout, Faraday::TimeoutError) { execute_request(env, rack_env) }
         else
           execute_request(env, rack_env)
         end

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -83,6 +83,14 @@ module Faraday
     end
   end
 
+  # Raised by Faraday::Response::RaiseError in case of a nil status in response.
+  class NilStatusError < ServerError
+    def initialize(_exc, response: nil)
+      message = 'http status could not be derived from the server response'
+      super(message, response)
+    end
+  end
+
   # A unified error for failed connections.
   class ConnectionFailed < Error
   end

--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -21,7 +21,9 @@ module Faraday
   # interval that is random between 0.1 and 0.15
   #
   class Request::Retry < Faraday::Middleware
-    DEFAULT_EXCEPTIONS = [Errno::ETIMEDOUT, 'Timeout::Error', Error::TimeoutError, Faraday::Error::RetriableResponse].freeze
+    DEFAULT_EXCEPTIONS = [Errno::ETIMEDOUT, 'Timeout::Error',
+                          Faraday::TimeoutError, Faraday::RetriableResponse
+                         ].freeze
     IDEMPOTENT_METHODS = [:delete, :get, :head, :options, :put]
 
     class Options < Faraday::Options.new(:max, :interval, :max_interval, :interval_randomness,
@@ -94,7 +96,7 @@ module Faraday
     # exceptions          - The list of exceptions to handle. Exceptions can be
     #                       given as Class, Module, or String. (default:
     #                       [Errno::ETIMEDOUT, 'Timeout::Error',
-    #                       Error::TimeoutError, Faraday::Error::RetriableResponse])
+    #                       Faraday::TimeoutError, Faraday::RetriableResponse])
     # methods             - A list of HTTP methods to retry without calling retry_if.  Pass
     #                       an empty Array to call retry_if for all exceptions.
     #                       (defaults to the idempotent HTTP methods in IDEMPOTENT_METHODS)
@@ -127,7 +129,7 @@ module Faraday
       begin
         env[:body] = request_body # after failure env[:body] is set to the response body
         @app.call(env).tap do |resp|
-          raise Faraday::Error::RetriableResponse.new(nil, resp) if @options.retry_statuses.include?(resp.status)
+          raise Faraday::RetriableResponse.new(nil, resp) if @options.retry_statuses.include?(resp.status)
         end
       rescue @errmatch => exception
         if retries > 0 && retry_request?(env, exception)
@@ -140,7 +142,7 @@ module Faraday
           end
         end
 
-        if exception.is_a?(Faraday::Error::RetriableResponse)
+        if exception.is_a?(Faraday::RetriableResponse)
           exception.response
         else
           raise

--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -21,7 +21,6 @@ module Faraday
   # interval that is random between 0.1 and 0.15
   #
   class Request::Retry < Faraday::Middleware
-
     DEFAULT_EXCEPTIONS = [Errno::ETIMEDOUT, 'Timeout::Error', Error::TimeoutError, Faraday::Error::RetriableResponse].freeze
     IDEMPOTENT_METHODS = [:delete, :get, :head, :options, :put]
 

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -5,12 +5,16 @@ module Faraday
     def on_complete(env)
       case env[:status]
       when 404
-        raise Faraday::Error::ResourceNotFound, response_values(env)
+        raise Faraday::ResourceNotFound, response_values(env)
       when 407
         # mimic the behavior that we get with proxy requests with HTTPS
-        raise Faraday::Error::ConnectionFailed, %{407 "Proxy Authentication Required "}
+        raise Faraday::ConnectionFailed.new(
+                %{407 "Proxy Authentication Required "},
+                response_values(env))
       when ClientErrorStatuses
-        raise Faraday::Error::ClientError, response_values(env)
+        raise Faraday::ClientError, response_values(env)
+      when nil
+        raise Faraday::NilStatusError, response: response_values(env)
       end
     end
 

--- a/spec/faraday/response/raise_error_spec.rb
+++ b/spec/faraday/response/raise_error_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+RSpec.describe Faraday::Response::RaiseError do
+  let(:conn) do
+    Faraday.new do |b|
+      b.response :raise_error
+      b.adapter :test do |stub|
+        stub.get('ok') { [200, { 'Content-Type' => 'text/html' }, '<body></body>'] }
+        stub.get('bad-request') { [400, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('unauthorized') { [401, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('forbidden') { [403, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('not-found') { [404, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('proxy-error') { [407, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('conflict') { [409, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('unprocessable-entity') { [422, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('4xx') { [499, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('nil-status') { [nil, { 'X-Reason' => 'bailout' }, 'fail'] }
+        stub.get('server-error') { [500, { 'X-Error' => 'bailout' }, 'fail'] }
+      end
+    end
+  end
+
+  it 'raises no exception for 200 responses' do
+    expect { conn.get('ok') }.not_to raise_error
+  end
+
+  it 'raises Faraday::ClientError for 400 responses' do
+    expect { conn.get('bad-request') }.to raise_error(Faraday::ClientError) do |ex|
+      expect(ex.message).to eq('the server responded with status 400')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::ClientError for 401 responses' do
+    expect { conn.get('unauthorized') }.to raise_error(Faraday::ClientError) do |ex|
+      expect(ex.message).to eq('the server responded with status 401')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::ClientError for 403 responses' do
+    expect { conn.get('forbidden') }.to raise_error(Faraday::ClientError) do |ex|
+      expect(ex.message).to eq('the server responded with status 403')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::ResourceNotFound for 404 responses' do
+    expect { conn.get('not-found') }.to raise_error(Faraday::ResourceNotFound) do |ex|
+      expect(ex.message).to eq('the server responded with status 404')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::ConnectionFailed for 407 responses' do
+    expect { conn.get('proxy-error') }.to raise_error(Faraday::ConnectionFailed) do |ex|
+      expect(ex.message).to eq('407 "Proxy Authentication Required "')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::ClientError for 409 responses' do
+    expect { conn.get('conflict') }.to raise_error(Faraday::ClientError) do |ex|
+      expect(ex.message).to eq('the server responded with status 409')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::ClientError for 422 responses' do
+    expect { conn.get('unprocessable-entity') }.to raise_error(Faraday::ClientError) do |ex|
+      expect(ex.message).to eq('the server responded with status 422')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::NilStatusError for nil status in response' do
+    expect { conn.get('nil-status') }.to raise_error(Faraday::NilStatusError) do |ex|
+      expect(ex.message).to eq('http status could not be derived from the server response')
+    end
+  end
+
+  it 'raises Faraday::ClientError for other 4xx responses' do
+    expect { conn.get('4xx') }.to raise_error(Faraday::ClientError) do |ex|
+      expect(ex.message).to eq('the server responded with status 499')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::ClientError for 500 responses' do
+    expect { conn.get('server-error') }.to raise_error(Faraday::ClientError) do |ex|
+      expect(ex.message).to eq('the server responded with status 500')
+      expect(ex.response[:headers]['X-Error']).to eq('bailout')
+    end
+  end
+end

--- a/test/adapters/integration.rb
+++ b/test/adapters/integration.rb
@@ -180,13 +180,13 @@ module Adapters
 
       def test_timeout
         conn = create_connection(:request => {:timeout => 1, :open_timeout => 1})
-        assert_raises Faraday::Error::TimeoutError do
+        assert_raises Faraday::TimeoutError do
           conn.get '/slow'
         end
       end
 
       def test_connection_error
-        assert_raises Faraday::Error::ConnectionFailed do
+        assert_raises Faraday::ConnectionFailed do
           get 'http://localhost:4'
         end
       end
@@ -209,7 +209,7 @@ module Adapters
         proxy_uri.password = 'WRONG'
         conn = create_connection(:proxy => proxy_uri)
 
-        err = assert_raises Faraday::Error::ConnectionFailed do
+        err = assert_raises Faraday::ConnectionFailed do
           conn.get '/echo'
         end
 

--- a/test/adapters/patron_test.rb
+++ b/test/adapters/patron_test.rb
@@ -31,7 +31,7 @@ module Adapters
 
       def test_connection_timeout
         conn = create_connection(:request => {:timeout => 10, :open_timeout => 1})
-        assert_raises Faraday::Error::ConnectionFailed do
+        assert_raises Faraday::ConnectionFailed do
           conn.get 'http://8.8.8.8:88'
         end
       end

--- a/test/adapters/rack_test.rb
+++ b/test/adapters/rack_test.rb
@@ -26,7 +26,7 @@ module Adapters
       conn = create_connection(:request => {:timeout => 1, :open_timeout => 1})
       begin
         conn.get '/slow'
-      rescue Faraday::Error::TimeoutError
+      rescue Faraday::TimeoutError
       end
     end
 

--- a/test/response_middleware_test.rb
+++ b/test/response_middleware_test.rb
@@ -23,7 +23,7 @@ class ResponseMiddlewareTest < Faraday::TestCase
   end
 
   def test_raises_not_found
-    error = assert_raises Faraday::Error::ResourceNotFound do
+    error = assert_raises Faraday::ResourceNotFound do
       @conn.get('not-found')
     end
     assert_equal 'the server responded with status 404', error.message
@@ -31,7 +31,7 @@ class ResponseMiddlewareTest < Faraday::TestCase
   end
 
   def test_raises_error
-    error = assert_raises Faraday::Error::ClientError do
+    error = assert_raises Faraday::ClientError do
       @conn.get('error')
     end
     assert_equal 'the server responded with status 500', error.message


### PR DESCRIPTION
This ports #1028 into 0.1x. The RaiseError middleware changed pretty significantly between Faraday 0.15.4 and the current master branch, so I only added the NilStatus exception.

This also removes references of the legacy error classes inside Faraday, so user apps aren't bombarded by as many warnings.