### PR TITLE
Set middleware_mutex when middleware/adapter classes are defined

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -33,6 +33,7 @@ module Faraday
 
       def inherited(subclass)
         super
+        subclass.middleware_mutex
         subclass.supports_parallel = supports_parallel?
       end
     end

--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -17,5 +17,11 @@ module Faraday
         warn "#{@app} does not implement \#close!"
       end
     end
+
+    def self.inherited(subclass)
+      super
+      subclass.send(:load_error=, load_error) # DependencyLoader.inherited
+      subclass.middleware_mutex
+    end
   end
 end

--- a/lib/faraday/middleware_registry.rb
+++ b/lib/faraday/middleware_registry.rb
@@ -6,6 +6,11 @@ module Faraday
   # Adds the ability for other modules to register and lookup
   # middleware classes.
   module MiddlewareRegistry
+    def self.extended(klass)
+      super
+      klass.middleware_mutex
+    end
+
     # Register middleware class(es) on the current module.
     #
     # @param autoload_path [String] Middleware autoload path
@@ -92,8 +97,9 @@ module Faraday
     end
 
     def middleware_mutex(&block)
+      puts "#{self}: middleware_mutex" if @middleware_mutex.nil?
       @middleware_mutex ||= Monitor.new
-      @middleware_mutex.synchronize(&block)
+      @middleware_mutex.synchronize(&block) if block
     end
 
     def fetch_middleware(key)


### PR DESCRIPTION
This is an attempt to fix #1065 by calling `#middleware_mutex` when the classes are defined. This should prevent `@middleware_mutex` from being undefined when a `Faraday::Connection` instance is used in a multi-threaded environment.

Right now, the proper way to build a `Faraday::Connection` for use in a multi-threaded environment should look something like this:

```ruby
conn = Faraday.new(url: "some-base-url") do |f|
  f.request :something
  f.response :or_other
  f.adapter :some_http_client
end

conn.app
```

https://github.com/lostisland/faraday/blob/d51a6c6979363c820d81a9166847ab09d30fae2b/lib/faraday/rack_builder.rb#L156-L168

`Faraday::Connection#app` is delegated to `Faraday::RackBuilder#app`, which does the following:

* Uses the `Faraday::Request` middleware registry to load `:something`
* Uses the `Faraday::Response` middleware registry to load `:or_other`
* Uses the `Faraday::Adapter` middleware registry to load `:some_http_client`
* Locks the `Faraday::RackBuilder` instance from changing the middleware chain (`conn.builder.handlers`)
* Instantiates all of the middleware instances
* Builds the "app" instance from the loaded recursive middleware instances.

At this point, it _should_ be safe to use shared connection object across multiple threads. But, I don't know how often it's used like this, so there are likely some more bugs.

I also have another larger solution in mind that requires some refactoring. I'll publish once I have it working.