### PR TITLE
Middleware mutex class

### DIFF
--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -6,6 +6,8 @@ module Faraday
     extend MiddlewareRegistry
     extend DependencyLoader
 
+    register_middleware('')
+
     def initialize(app = nil)
       @app = app
     end

--- a/lib/faraday/middleware_registry.rb
+++ b/lib/faraday/middleware_registry.rb
@@ -3,6 +3,111 @@
 require 'monitor'
 
 module Faraday
+  # ClassRegistry tracks potential middleware dependencies for a given parent
+  # class. These potential dependencies are lazily required upon first access
+  # during runtime.
+  class ClassRegistry
+    attr_reader :autoload_path
+
+    def initialize(klass, autoload_path, mapping = nil)
+      @klass = klass
+      @autoload_path = autoload_path.to_s.freeze
+      @monitor = Monitor.new
+      @registered_middleware = {}
+      register(mapping) if mapping
+    end
+
+    # Register middleware class(es) on the current module.
+    #
+    # @param mapping [Hash{
+    #          Symbol => Module,
+    #          Symbol => Array<Module, Symbol, String>,
+    #        }] Middleware mapping from a lookup symbol to a reference to the
+    #        middleware.
+    #        Classes can be expressed as:
+    #          - a fully qualified constant
+    #          - a Symbol
+    #          - a Proc that will be lazily called to return the former
+    #          - an array is given, its first element is the constant or symbol,
+    #            and its second is a file to `require`.
+    # @return [void]
+    #
+    # @example
+    #
+    #   # builds a registry for Faraday::Adapter, lazily loading from
+    #   # 'path/to/adapters/*.rb'
+    #   cr = ClassRegistry.new(Faraday::Adapter, 'path/to/adapters')
+    #   cr.register(
+    #     # Lookup constant
+    #     some_adapter: SomeAdapter,
+    #
+    #     # Lookup symbol constant name
+    #     # Same as Faraday::Adapter.const_get(:SomeAdapter2)
+    #     some_adapter_2: :SomeAdapter2,
+    #
+    #     # Require lib and then lookup class
+    #     # require('some-adapter-3')
+    #     # Returns Faraday::Adapter::SomeAdapter3
+    #     some_adapter_3: [:SomeAdapter3, 'some-adapter-3']
+    #   )
+    #
+    def register(mapping)
+      @monitor.synchronize { @registered_middleware.update(mapping) }
+    end
+
+    # Unregister a previously registered middleware class.
+    #
+    # @param key [Symbol] key for the registered middleware.
+    def unregister(key)
+      @registered_middleware.delete(key)
+    end
+
+    # Lookup middleware class with a registered Symbol shortcut.
+    #
+    # @param key [Symbol] key for the registered middleware.
+    # @return [Class] a middleware Class.
+    # @raise [Faraday::Error] if given key is not registered
+    #
+    # @example
+    #
+    #   cr = ClassRegistry.new(Faraday::Adapter, .path/to/adapters.)
+    #   cr.register(some_adapter: SomeAdapter)
+    #
+    #   cr.lookup(:some_adapter)
+    #   # => SomeAdapter
+    #
+    def lookup(key)
+      load_class(key) ||
+        raise(Faraday::Error,
+              "#{key.inspect} is not registered on #{@klass}")
+    end
+
+    private
+
+    def load_class(key)
+      case value = @registered_middleware[key]
+      when Module, NilClass
+        return value
+      when Symbol, String
+        register(key => @klass.const_get(value))
+      when Proc
+        register(key => value.call)
+      when Array
+        const, path = value
+        if (root = @autoload_path) && !root.empty?
+          path = "#{root}/#{path}"
+        end
+        require(path)
+        register(key => const)
+      else
+        msg = "unexpected #{@klass} value for #{key.inspect}: #{value.inspect}"
+        raise ArgumentError, msg
+      end
+
+      load_class(key)
+    end
+  end
+
   # Adds the ability for other modules to register and lookup
   # middleware classes.
   module MiddlewareRegistry

--- a/lib/faraday/request/basic_authentication.rb
+++ b/lib/faraday/request/basic_authentication.rb
@@ -5,7 +5,7 @@ require 'base64'
 module Faraday
   class Request
     # Authorization middleware for Basic Authentication.
-    class BasicAuthentication < load_middleware(:authorization)
+    class BasicAuthentication < lookup_middleware(:authorization)
       # @param login [String]
       # @param pass [String]
       #

--- a/lib/faraday/request/token_authentication.rb
+++ b/lib/faraday/request/token_authentication.rb
@@ -4,7 +4,7 @@ module Faraday
   class Request
     # TokenAuthentication is a middleware that adds a 'Token' header to a
     # Faraday request.
-    class TokenAuthentication < load_middleware(:authorization)
+    class TokenAuthentication < lookup_middleware(:authorization)
       # Public
       def self.header(token, options = nil)
         options ||= {}


### PR DESCRIPTION
This extracts the `Faraday::MiddlewareRegistry` module functionality into a `Faraday::ClassRegistry` class. This allows us to make some better assumptions about how the class registry's internal vars are loaded.

TODO:

* [ ] copy/adapt MiddlewareRegistry specs for` ClassRegistry
* [ ] test with [technoweenie/faraday-live](https://github.com/technoweenie/faraday-live)

I also made a few small changes that may bite us later:

1. Deprecated `#load_middleware`. It's the same as `#lookup_middleware`, except `#lookup_middleware` raises if it doesn't return anything. When deciding between `ClassRegistry#lookup` and `#load`, I went with `#lookup` since `#load` is an existing ruby method.

https://github.com/lostisland/faraday/blob/1c5672acf00dd976960c4f8940d4260e50509e56/lib/faraday/middleware_registry.rb#L207-L214

2. Deprecated `#middleware_mutex` and `#fetch_middleware`. Those should've been private originally. They're not used elsewhere in Faraday, but may be in use in an external lib or app. Pretty low chance though...

https://github.com/lostisland/faraday/blob/1c5672acf00dd976960c4f8940d4260e50509e56/lib/faraday/middleware_registry.rb#L216-L222

3. `#register_middleware` now complains if you try to change the `autoload_path` _after the ClassRegistry has been setup`. So, something like:

```ruby
module Faraday
  class Adapter
    extend MiddlewareRegistry

    # first time, set 'path/to/adapters' as @autoload_path
    register_middleware 'path/to/adapters', foo: Foo

    # subsequent calls MUST ignore @autoload_path
    register_middleware bar: Bar

    # raises a warning: 
    # "Cannot change autoload_path of existing Faraday::Adapter.class_registry"
    register_middleware 'path/to/other-adapters', baz: Baz
  end
end
```

https://github.com/lostisland/faraday/blob/1c5672acf00dd976960c4f8940d4260e50509e56/lib/faraday/middleware_registry.rb#L173-L175