### PR TITLE
0.1x deprecate fixes 2

### DIFF
--- a/lib/faraday/deprecate.rb
+++ b/lib/faraday/deprecate.rb
@@ -17,7 +17,7 @@ module Faraday
           deprecate :inherited, klass_name, '1.0'
 
           def ===(other)
-            superclass === other || super
+            other.is_a?(superclass) || super
           end
         end
       end


### PR DESCRIPTION
Fixes some minor issues with the deprecate stuff that I found while trying to port this to the master branch.

1. Fix [rubocop compliant about `===`](https://rubystyle.guide/#no-case-equality)
2. Refactor `DeprecatedClass.proxy_class` so it can accept any version. Bonus: now that the `klass_name` is not built in an isolated `metaclass` scope, it can just use the method's `origclass` argument for the replacement messages, _without regexes_.
3. Use a shared `Gem::Version` instance in wrappers around deprecated methods.