### PR TITLE
Add log_level option to logger default formatter

### DIFF
--- a/docs/middleware/response/logger.md
+++ b/docs/middleware/response/logger.md
@@ -71,6 +71,17 @@ conn.get('/', api_key: 'secret')
 # => DEBUG -- response: date: "Sun, 19 May 2019 16:12:36 GMT"
 ```
 
+### Change log level
+
+By default, the `logger` middleware logs on the `info` log level. It is possible to configure
+the severity by providing the `log_level` option:
+
+```ruby
+conn = Faraday.new(url: 'http://sushi.com') do |faraday|
+  faraday.response :logger, nil, { bodies: true, log_level: :debug }
+end
+```
+
 ### Customize the formatter
 
 You can also provide a custom formatter to control how requests and responses are logged.

--- a/spec/faraday/response/logger_spec.rb
+++ b/spec/faraday/response/logger_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Faraday::Response::Logger do
   context 'when not logging response headers' do
     let(:logger_options) { { headers: { response: false } } }
 
-    it 'does log response headers if option is false' do
+    it 'does not log response headers if option is false' do
       conn.get '/hello', nil, accept: 'text/html'
       expect(string_io.string).not_to match(%(Content-Type: "text/html))
     end
@@ -189,6 +189,36 @@ RSpec.describe Faraday::Response::Logger do
       expect(string_io.string).to match(%(soylent green is))
       expect(string_io.string).to match(%(tasty))
       expect(string_io.string).not_to match(%(people))
+    end
+  end
+
+  context 'when using log_level' do
+    let(:logger_options) { { bodies: true, log_level: :debug } }
+
+    it 'logs request/request body on the specified level (debug)' do
+      logger.level = Logger::DEBUG
+      conn.post '/ohyes', 'name=Ebi', accept: 'text/html'
+      expect(string_io.string).to match(%(name=Ebi))
+      expect(string_io.string).to match(%(pebbles))
+    end
+
+    it 'logs headers on the debug level' do
+      logger.level = Logger::DEBUG
+      conn.get '/hello', nil, accept: 'text/html'
+      expect(string_io.string).to match(%(Content-Type: "text/html))
+    end
+
+    it 'does not log request/response body on the info level' do
+      logger.level = Logger::INFO
+      conn.post '/ohyes', 'name=Ebi', accept: 'text/html'
+      expect(string_io.string).not_to match(%(name=Ebi))
+      expect(string_io.string).not_to match(%(pebbles))
+    end
+
+    it 'does not log headers on the info level' do
+      logger.level = Logger::INFO
+      conn.get '/hello', nil, accept: 'text/html'
+      expect(string_io.string).not_to match(%(Content-Type: "text/html))
     end
   end
 end


### PR DESCRIPTION
## Description
Logger default formatter log severity can now be configured through the `log_level` option (related #1078)

## Todos
List any remaining work that needs to be done, i.e:
- [X] Tests
- [X] Documentation
