### PR TITLE
[Ruby 2.7] Stops using `&Proc.new` for block forwarding.

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -64,8 +64,7 @@ module Faraday
     #     :params => {:page => 1}
     #
     # Returns a Faraday::Connection.
-    def new(url = nil, options = nil)
-      block = block_given? ? Proc.new : nil
+    def new(url = nil, options = nil, &block)
       options = options ? default_connection_options.merge(options) : default_connection_options
       Faraday::Connection.new(url, options, &block)
     end

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -162,8 +162,8 @@ module Faraday
       @attribute_options ||= {}
     end
 
-    def self.memoized(key)
-      memoized_attributes[key.to_sym] = Proc.new
+    def self.memoized(key, &block)
+      memoized_attributes[key.to_sym] = block
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{key}() self[:#{key}]; end
       RUBY

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -49,10 +49,10 @@ module Faraday
       end
     end
 
-    def initialize(handlers = [])
+    def initialize(handlers = [], &block)
       @handlers = handlers
       if block_given?
-        build(&Proc.new)
+        build(&block)
       elsif @handlers.empty?
         # default stack, if nothing else is configured
         self.request :url_encoded


### PR DESCRIPTION

## Description

In order to be Ruby 2.7 warning-free, back-port 5ace0ea5ab82b49bb13648dcfd0272d068a82885

## Additional Notes

<details>

```
Faraday::Response::RaiseError
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises Faraday::ClientError for 500 responses
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises Faraday::ClientError for other 4xx responses
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises Faraday::ClientError for 400 responses
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises Faraday::ConnectionFailed for 407 responses
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises Faraday::ClientError for 401 responses
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises Faraday::ClientError for 409 responses
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises no exception for 200 responses
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises Faraday::ClientError for 403 responses
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises Faraday::NilStatusError for nil status in response
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises Faraday::ResourceNotFound for 404 responses
/Users/olle/opensource/faraday/lib/faraday.rb:68: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/olle/opensource/faraday/lib/faraday/rack_builder.rb:55: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
  raises Faraday::ClientError for 422 responses

```

</details>
