### PR TITLE
Fix empty array for FlatParamsEncoder {key: []} -> "key="

### DIFF
--- a/lib/faraday/encoders/flat_params_encoder.rb
+++ b/lib/faraday/encoders/flat_params_encoder.rb
@@ -45,9 +45,13 @@ module Faraday
         if value.nil?
           buffer << "#{encoded_key}&"
         elsif value.is_a?(Array)
-          value.each do |sub_value|
-            encoded_value = escape(sub_value)
-            buffer << "#{encoded_key}=#{encoded_value}&"
+          if value.empty?
+            buffer << "#{encoded_key}=&"
+          else
+            value.each do |sub_value|
+              encoded_value = escape(sub_value)
+              buffer << "#{encoded_key}=#{encoded_value}&"
+            end
           end
         else
           encoded_value = escape(value)

--- a/spec/faraday/params_encoders/flat_spec.rb
+++ b/spec/faraday/params_encoders/flat_spec.rb
@@ -26,4 +26,9 @@ RSpec.describe Faraday::FlatParamsEncoder do
     params = { a: [true, false] }
     expect(subject.encode(params)).to eq('a=true&a=false')
   end
+
+  it 'encodes empty array in hash' do
+    params = { a: [] }
+    expect(subject.encode(params)).to eq('a=')
+  end
 end


### PR DESCRIPTION
## Description
For an empty array in params hash should not ignore the key.
- [x] Test

## Additional Notes
The problem is: **each on empty array does not yield**.
