### PR TITLE
Fix CI for Ruby 2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.3.x, 2.4.x, 2.5.x, 2.6.x]
+        ruby: [2.4.x, 2.5.x, 2.6.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Support for github action of ruby 2.3 was removed. Now according to https://github.com/actions/setup-ruby/blob/master/action.yml the minimal version is 2.4.