### PR TITLE
Ship 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Misc:
 * Describe clearing cached stubs #1045 (@viraptor)
 * Add project metadata to the gemspec #1046 (@orien)
 
-## v0.17.2
+## v0.17.3
 
 Fixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Faraday Changelog
 
-## v1.0-rc1
+## v1.0
 
 Features:
 
@@ -25,6 +25,7 @@ Misc:
 * Major effort to update code to RuboCop standards. #854 (@olleolleolle, @iMacTia, @technoweenie, @htwroclau, @jherdman, @Drenmi, @Insti)
 * Documentation tweaks (@adsteel, @Hubro, @iMacTia, @olleolleolle, @technoweenie)
 * Update license year #981 (@Kevin-Kawai)
+* Configure Jekyll plugin jekyll-remote-theme to support Docker usage #999 (@Lewiscowles1986)
 
 ## v0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@
 
 Features:
 
-* Add #trace and #connect support to Faraday::Connection #861 (@technoweenie)
+* Add #trace support to Faraday::Connection #861 (@technoweenie)
 * Add the log formatter that is easy to override and safe to inherit #889 (@prikha)
 * Support standalone adapters #941 (@iMacTia)
 * Introduce Faraday::ConflictError for 409 response code #979 (@lucasmoreno)
+* Add support for setting `read_timeout` option separately #1003 (@springerigor)
+* Refactor and cleanup timeout settings across adapters #1022 (@technoweenie)
+* Create ParamPart class to allow multipart posts with JSON content and file upload at the same time #1017 (@jeremy-israel)
+* Copy UploadIO const -> FilePart for consistency with ParamPart #1018, #1021 (@technoweenie)
+* Implement streaming responses in the Excon adapter #1026 (@technoweenie)
+* Add default implementation of `Middleware#close`. #1069 (@ioquatix)
+* Add `Adapter#close` so that derived classes can call super. #1091 (@ioquatix)
+* Add log_level option to logger default formatter #1079 (@amrrbakry)
+* Fix empty array for FlatParamsEncoder `{key: []} -> "key="` #1084 (@mrexox)
 
 Bugs:
 
@@ -18,14 +27,55 @@ Bugs:
 * Multipart: Drop Ruby 1.8 String behavior compat #892 (@olleolleolle)
 * Fix Ruby warnings in Faraday::Options.memoized #962 (@technoweenie)
 * Allow setting min/max SSL version for a Net::HTTP::Persistent connection #972, #973 (@bdewater, @olleolleolle)
+* Fix instances of frozen empty string literals #1040 (@BobbyMcWho)
+* remove temp_proxy and improve proxy tests #1063 (@technoweenie)
+* improve error initializer consistency #1095 (@technoweenie)
 
 Misc:
 
 * Convert minitest suite to RSpec #832 (@iMacTia, with help from @gaynetdinov, @Insti, @technoweenie)
 * Major effort to update code to RuboCop standards. #854 (@olleolleolle, @iMacTia, @technoweenie, @htwroclau, @jherdman, @Drenmi, @Insti)
+* Rubocop #1044, #1047 (@BobbyMcWho, @olleolleolle)
 * Documentation tweaks (@adsteel, @Hubro, @iMacTia, @olleolleolle, @technoweenie)
 * Update license year #981 (@Kevin-Kawai)
 * Configure Jekyll plugin jekyll-remote-theme to support Docker usage #999 (@Lewiscowles1986)
+* Fix Ruby 2.7 warnings #1009 (@tenderlove)
+* Cleanup adapter connections #1023 (@technoweenie)
+* Describe clearing cached stubs #1045 (@viraptor)
+* Add project metadata to the gemspec #1046 (@orien)
+
+## v0.17.2
+
+Fixes:
+
+* Reverts changes in error classes hierarchy. #1092 (@iMacTia)
+* Fix Ruby 1.9 syntax errors and improve Error class testing #1094 (@BanzaiMan,
+  @mrexox, @technoweenie)
+
+Misc:
+
+* Stops using `&Proc.new` for block forwarding. #1083 (@olleolleolle)
+* Update CI to test against ruby 2.0-2.7 #1087, #1099 (@iMacTia, @olleolleolle,
+  @technoweenie)
+* require FARADAY_DEPRECATE=warn to show Faraday v1.0 deprecation warnings
+  #1098 (@technoweenie)
+
+## v0.17.1
+
+Final release before Faraday v1.0, with important fixes for Ruby 2.7.
+
+Fixes:
+
+* RaiseError response middleware raises exception if HTTP client returns a nil
+  status. #1042 (@jonnyom, @BobbyMcWho)
+
+Misc:
+
+* Fix Ruby 2.7 warnings (#1009)
+* Add `Faraday::Deprecate` to warn about upcoming v1.0 changes. (#1054, #1059,
+    #1076, #1077)
+* Add release notes up to current in CHANGELOG.md (#1066)
+* Port minimal rspec suite from main branch to run backported tests. (#1058)
 
 ## v0.17.0
 
@@ -79,17 +129,17 @@ Fixes:
 
 Features:
 
-* Allow overriding env proxy (#754)
-* Remove legacy Typhoeus adapter (#715)
-* External Typhoeus Adapter Compatibility (#748)
-* Warn about missing adapter when making a request (#743)
-* Faraday::Adapter::Test stubs now support entire urls (with host) (#741)
+* Allow overriding env proxy #754 (@iMacTia)
+* Remove legacy Typhoeus adapter #715 (@olleolleolle)
+* External Typhoeus Adapter Compatibility #748 (@iMacTia)
+* Warn about missing adapter when making a request #743 (@antstorm)
+* Faraday::Adapter::Test stubs now support entire urls (with host) #741 (@erik-escobedo)
 
 Fixes:
 
-* If proxy is manually provided, this takes priority over `find_proxy` (#724)
-* Fixes the behaviour for Excon's open_timeout (not setting write_timeout anymore) (#731)
-* Handle all connection timeout messages in Patron (#687)
+* If proxy is manually provided, this takes priority over `find_proxy` #724 (@iMacTia)
+* Fixes the behaviour for Excon's open_timeout (not setting write_timeout anymore) #731 (@apachelogger)
+* Handle all connection timeout messages in Patron #687 (@stayhero)
 
 ## v0.13.1
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Need more details? See the [Faraday API Documentation][apidoc] to see how it wor
 This library aims to support and is [tested against][actions] the following Ruby
 implementations:
 
-* Ruby 2.3+
+* Ruby 2.4+
 
 If something doesn't work on one of these Ruby versions, it's a bug.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,7 +26,7 @@ This should work without you noticing if your adapter inherits from `Faraday::Ad
 
 ### Others
 * Dropped support for jruby and Rubinius.
-* Officially supports Ruby 2.3+
+* Officially supports Ruby 2.4+
 * In order to specify the adapter you now MUST use the `#adapter` method on the connection builder. If you don't do so and your adapter inherits from `Faraday::Adapter` then Faraday will raise an exception. Otherwise, Faraday will automatically push the default adapter at the end of the stack causing your request to be executed twice.
 ```ruby
 class OfficialAdapter < Faraday::Adapter

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -19,7 +19,7 @@ require 'faraday/dependency_loader'
 #   conn.get '/'
 #
 module Faraday
-  VERSION = '0.16.0'
+  VERSION = '1.0.0'
   METHODS_WITH_QUERY = %w[get head delete connect trace].freeze
   METHODS_WITH_BODY = %w[post put patch].freeze
 

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -64,7 +64,7 @@ module Faraday
     # after calling close.
     def close
       # Possible implementation:
-      # @app.close if @app.respond_to?(:close)
+      #   @app.close if @app.respond_to?(:close)
     end
 
     def call(env)

--- a/spec/faraday/response/logger_spec.rb
+++ b/spec/faraday/response/logger_spec.rb
@@ -69,10 +69,6 @@ RSpec.describe Faraday::Response::Logger do
   context 'with custom formatter' do
     let(:formatter_class) do
       Class.new(Faraday::Logging::Formatter) do
-        def initialize(*args)
-          super
-        end
-
         def request(_env)
           info 'Custom log formatter request'
         end


### PR DESCRIPTION
* [x] Review/merge error class changes #1095
* [x] push Faraday::Deprecate upstream for eventual 2.0 deprecations?
  * no need now. we can grab it any time.
* [x] double check readme/gemfile/etc for consistency in faraday website, supported ruby versions, gems, etc. also update minimum ruby version to 2.4.0
* [x] bump supported addressable version from <2.4.0 to <2.7.0?
  * addressable version is unspecified already
* [x] bump supported ruby version to 2.3.x or 2.4.x?
* [x] drop CONNECT method support?
* [x] Changelog
* [x] Verify against technoweenie/faraday-live

Items ending in `?` are suggestions...