### PR TITLE
remove CONNECT method

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -20,7 +20,7 @@ require 'faraday/dependency_loader'
 #
 module Faraday
   VERSION = '0.16.0'
-  METHODS_WITH_QUERY = %w[get head delete connect trace].freeze
+  METHODS_WITH_QUERY = %w[get head delete trace].freeze
   METHODS_WITH_BODY = %w[post put patch].freeze
 
   class << self

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -14,7 +14,7 @@ module Faraday
   #
   class Connection
     # A Set of allowed HTTP verbs.
-    METHODS = Set.new %i[get post put delete head patch options trace connect]
+    METHODS = Set.new %i[get post put delete head patch options trace]
 
     # @return [Hash] URI query unencoded key/value pairs.
     attr_reader :params
@@ -172,21 +172,6 @@ module Faraday
     #
     # @example
     #   conn.delete '/items/1'
-    #
-    # @yield [Faraday::Request] for further request customizations
-    # @return [Faraday::Response]
-
-    # @!method connect(url = nil, params = nil, headers = nil)
-    # Makes a CONNECT HTTP request without a body.
-    # @!scope class
-    #
-    # @param url [String] The optional String base URL to use as a prefix for
-    #            all requests.  Can also be the options Hash.
-    # @param params [Hash] Hash of URI query unencoded key/value pairs.
-    # @param headers [Hash] unencoded HTTP header key/value pairs.
-    #
-    # @example
-    #   conn.connect '/items/1'
     #
     # @yield [Faraday::Request] for further request customizations
     # @return [Faraday::Response]

--- a/spec/faraday/adapter/em_http_spec.rb
+++ b/spec/faraday/adapter/em_http_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::Adapter::EMHttp do
-  features :request_body_on_query_methods, :reason_phrase_parse, :trace_method, :connect_method,
+  features :request_body_on_query_methods, :reason_phrase_parse, :trace_method,
            :skip_response_body_on_head, :parallel, :local_socket_binding
 
   it_behaves_like 'an adapter'

--- a/spec/faraday/adapter/excon_spec.rb
+++ b/spec/faraday/adapter/excon_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::Adapter::Excon do
-  features :request_body_on_query_methods, :reason_phrase_parse, :trace_method, :connect_method
+  features :request_body_on_query_methods, :reason_phrase_parse, :trace_method
 
   it_behaves_like 'an adapter'
 

--- a/spec/faraday/adapter/httpclient_spec.rb
+++ b/spec/faraday/adapter/httpclient_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Faraday::Adapter::HTTPClient do
   HTTPCLIENT_WRITE = 120
 
   features :request_body_on_query_methods, :reason_phrase_parse, :compression,
-           :trace_method, :connect_method, :local_socket_binding
+           :trace_method, :local_socket_binding
 
   it_behaves_like 'an adapter'
 

--- a/spec/faraday/adapter/net_http_persistent_spec.rb
+++ b/spec/faraday/adapter/net_http_persistent_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::Adapter::NetHttpPersistent do
-  features :request_body_on_query_methods, :reason_phrase_parse, :compression, :trace_method, :connect_method
+  features :request_body_on_query_methods, :reason_phrase_parse, :compression, :trace_method
 
   it_behaves_like 'an adapter'
 

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::Adapter::NetHttp do
-  features :request_body_on_query_methods, :reason_phrase_parse, :compression, :streaming, :trace_method, :connect_method
+  features :request_body_on_query_methods, :reason_phrase_parse, :compression, :streaming, :trace_method
 
   it_behaves_like 'an adapter'
 

--- a/spec/faraday/adapter/rack_spec.rb
+++ b/spec/faraday/adapter/rack_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Faraday::Adapter::Rack do
   features :request_body_on_query_methods, :trace_method,
-           :connect_method, :skip_response_body_on_head
+           :skip_response_body_on_head
 
   it_behaves_like 'an adapter', adapter_options: WebmockRackApp.new
 end

--- a/spec/faraday/adapter/typhoeus_spec.rb
+++ b/spec/faraday/adapter/typhoeus_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Faraday::Adapter::Typhoeus do
-  features :request_body_on_query_methods, :parallel, :trace_method, :connect_method
+  features :request_body_on_query_methods, :parallel, :trace_method
 
   it_behaves_like 'an adapter'
 end

--- a/spec/support/shared_examples/adapter.rb
+++ b/spec/support/shared_examples/adapter.rb
@@ -52,14 +52,6 @@ shared_examples 'adapter examples' do |**options|
     expect(request_stub).to have_been_requested unless request_stub.disabled?
   end
 
-  on_feature :connect_method do
-    describe '#connect' do
-      let(:http_method) { :connect }
-
-      it_behaves_like 'a request method', :connect
-    end
-  end
-
   describe '#delete' do
     let(:http_method) { :delete }
 


### PR DESCRIPTION
This removes the CONNECT method because of https://github.com/lostisland/faraday/pull/1101#issuecomment-569702352

...

I ran the [faraday-live](https://github.com/technoweenie/faraday-live) test suite against this branch, and the current version of Typhoeus in Git (until v1.4.0 is released). I ran into this issue with the `CONNECT` calls:

```
  1) typhoeus with HTTPS server (typhoeus) #CONNECT request behaves like an idempotent request returns Content-Type response header
     Failure/Error: @response = conn.public_send(http_method, 'idempotent_request')

     Faraday::ConnectionFailed:
       Stream error in the HTTP/2 framing layer
     Shared Example Group: "any request" called from ./spec/support/examples/request_idempotent.rb:11
     Shared Example Group: "an idempotent request" called from ./spec/support/examples/connection.rb:24
     Shared Example Group: "a connection making requests" called from ./spec/secure_spec.rb:5
```

I propose that we cut `CONNECT` method support before 1.0. It's never actually showed up in a release version of Faraday, so it won't be a breaking change. While [`TRACE`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/TRACE) is obscure, it's easy enough to support. However, [`CONNECT`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT) seems to be used for proxy servers, which doesn't work well with Faraday's request/response nature.