### PR TITLE
Handle separation of positional and keyword arguments in ruby 2.7

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
+  spec.add_dependency 'ruby2_keywords'
 
   files = %w[CHANGELOG.md LICENSE.md README.md Rakefile examples lib spec]
   spec.files = `git ls-files -z #{files.join(' ')}`.split("\0")

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'faraday/adapter_registry'
+require 'ruby2_keywords'
 
 module Faraday
   # A Builder that processes requests into responses by passing through an inner
@@ -27,7 +28,7 @@ module Faraday
 
       attr_reader :name
 
-      def initialize(klass, *args, &block)
+      ruby2_keywords def initialize(klass, *args, &block)
         @name = klass.to_s
         REGISTRY.set(klass) if klass.respond_to?(:name)
         @args = args
@@ -89,7 +90,7 @@ module Faraday
       @handlers.frozen?
     end
 
-    def use(klass, *args, &block)
+    ruby2_keywords def use(klass, *args, &block)
       if klass.is_a? Symbol
         use_symbol(Faraday::Middleware, klass, *args, &block)
       else
@@ -99,15 +100,15 @@ module Faraday
       end
     end
 
-    def request(key, *args, &block)
+    ruby2_keywords def request(key, *args, &block)
       use_symbol(Faraday::Request, key, *args, &block)
     end
 
-    def response(key, *args, &block)
+    ruby2_keywords def response(key, *args, &block)
       use_symbol(Faraday::Response, key, *args, &block)
     end
 
-    def adapter(klass = NO_ARGUMENT, *args, &block)
+    ruby2_keywords def adapter(klass = NO_ARGUMENT, *args, &block)
       return @adapter if klass == NO_ARGUMENT
 
       klass = Faraday::Adapter.lookup_middleware(klass) if klass.is_a?(Symbol)
@@ -116,7 +117,7 @@ module Faraday
 
     ## methods to push onto the various positions in the stack:
 
-    def insert(index, *args, &block)
+    ruby2_keywords def insert(index, *args, &block)
       raise_if_locked
       index = assert_index(index)
       handler = self.class::Handler.new(*args, &block)
@@ -125,12 +126,12 @@ module Faraday
 
     alias insert_before insert
 
-    def insert_after(index, *args, &block)
+    ruby2_keywords def insert_after(index, *args, &block)
       index = assert_index(index)
       insert(index + 1, *args, &block)
     end
 
-    def swap(index, *args, &block)
+    ruby2_keywords def swap(index, *args, &block)
       raise_if_locked
       index = assert_index(index)
       @handlers.delete_at(index)
@@ -234,7 +235,7 @@ module Faraday
       klass.ancestors.include?(Faraday::Adapter)
     end
 
-    def use_symbol(mod, key, *args, &block)
+    ruby2_keywords def use_symbol(mod, key, *args, &block)
       use(mod.lookup_middleware(key), *args, &block)
     end
 


### PR DESCRIPTION
Ruby 2.7 separates positional and keyword arguments. This resulted in several deprecation warnings in `Faraday::RackBuilder`. Keyword arguments are often passed to it that are implicitly passed through as a hash (as the last positional argument). Ruby 2.7 raises a warning for this and 3.0 will error.

For example, faraday-http-cache, which is configured something like `builder.use Faraday::HttpCache, serializer: Marshal, shared_cache: false`, will raise warnings, because RackBuilder doesn’t handle the Ruby-2.7 change.

This PR removes the deprecation in a backwards- and forward-compatible way. It uses a new compatability method in ruby 2.7 and a shim to support older rubies, which is recommended on the [ruby blog](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).