### PR TITLE
Backport wrapping Errno::EADDRNOTAVAIL in the net/http adapter to 0.1x

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -11,6 +11,7 @@ module Faraday
     class NetHttp < Faraday::Adapter
       NET_HTTP_EXCEPTIONS = [
         IOError,
+        Errno::EADDRNOTAVAIL,
         Errno::ECONNABORTED,
         Errno::ECONNREFUSED,
         Errno::ECONNRESET,


### PR DESCRIPTION
Just as 148b99ee0fde8 also does but for the v0.1x releases.