### PR TITLE
docs(website): add search to the website

### DIFF
--- a/docs/_includes/docs_nav.md
+++ b/docs/_includes/docs_nav.md
@@ -1,3 +1,4 @@
+
 <div class="docs-nav">
   <p class="docs-nav-item">
   {% if page.prev_link %}

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,0 +1,21 @@
+<!-- Directly extracted from https://github.com/rohanchandra/type-theme/blob/c6ec5a69ff7dfe2df193be08515193c72bd4a55d/_includes/footer.html
+for customization (DocSearch feature) -->
+
+{% if site.theme_settings.katex and page.id %}
+<script src="{{ "/assets/js/katex_init.js" | relative_url }}"></script>
+{% endif %}
+
+{% if site.theme_settings.footer_text %}
+<footer class="site-footer">
+	<p class="text">{{ site.theme_settings.footer_text }}</p>
+</footer>
+{% endif %}
+
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: '4b20e432aa42a515b1a465b1494df8bf',
+  indexName: 'lostisland_faraday',
+  inputSelector: '#search-box',
+  debug: false // Set debug to true if you want to inspect the dropdown
+});
+</script>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,0 +1,59 @@
+<!-- This is extracted directly from https://github.com/rohanchandra/type-theme/blob/c6ec5a69ff7dfe2df193be08515193c72bd4a55d/_includes/header.html
+for customization (DocSearch feature) -->
+<header class="site-header">
+	<div class="branding">
+		{% if site.theme_settings.gravatar %}
+		<a href="{{ site.baseurl }}/">
+			<img class="avatar" src="https://secure.gravatar.com/avatar/{{ site.theme_settings.gravatar }}?s=100" alt=""/>
+		</a>
+		{% elsif site.theme_settings.avatar %}
+		<a href="{{ site.baseurl }}/">
+			<img class="avatar" src="{{ site.baseurl }}/{{ site.theme_settings.avatar }}" alt=""/>
+		</a>
+		{% endif %}
+		<h1 class="site-title">
+			<a href="{{ site.baseurl }}/">{{ site.theme_settings.title }}</a>
+		</h1>
+	</div>
+	<nav class="site-nav">
+		<ul>
+			{% if site.theme_settings.site_navigation_sort %}
+				{% assign site_pages = site.pages | sort: site.theme_settings.site_navigation_sort %}
+			{% else %}
+				{% assign site_pages = site.pages %}
+			{% endif %}
+			{% for page in site_pages %}
+			{% if page.title and page.hide != true %}
+			<li>
+				<a class="page-link" href="{{ page.url | relative_url }}">
+					{{ page.title }}
+				</a>
+			</li>
+			{% endif %}
+			{% endfor %}
+			<!-- Social icons from Font Awesome, if enabled  -->
+			{% include icons.html %}
+
+            <!-- Search bar -->
+            {% if site.theme_settings.search %}
+            <li>
+            <form action="{{ site.baseurl }}/search.html" method="get">
+                <input type="text" id="search-box" name="query" placeholder="Search" class="">
+                <button type="submit" class="">
+                    <i class="fa fa-fw fa-search"></i>
+                </button>
+            </form>
+            </li>
+            {% endif %}
+      <li>
+        <form id="search-form">
+          <input type="text" id="search-box" placeholder="Search">
+          <button type="submit">
+              <i class="fa fa-fw fa-search"></i>
+          </button>
+        </form>
+      </li>
+		</ul>
+	</nav>
+
+</header>

--- a/docs/_sass/_variables.scss
+++ b/docs/_sass/_variables.scss
@@ -6,3 +6,4 @@ $link-color: #EE4266;
 $text-color: #3C3C3C;
 $font-family-main: 'KohinoorTelugu-Regular', Helvetica, Arial, sans-serif;
 $font-family-headings: 'Raleway', Helvetica, Arial, sans-serif;
+$search-color: #EE4266;

--- a/docs/_sass/faraday.sass
+++ b/docs/_sass/faraday.sass
@@ -120,3 +120,11 @@ footer
 
   100%
     transform: rotate(360deg)
+
+#search-form
+  display: inline-block
+  // You need a minimal window size for the search to display well, should be ok, people are on desktop
+  // when needing search usually
+  @media screen and (max-width: 800px)
+    display: none
+

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -4,3 +4,4 @@
 @import "variables";
 @import "type-theme";
 @import "faraday";
+@import "https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"


### PR DESCRIPTION
## Description
This commit adds documentation search to the whole website using Algolia's
DocSearch project: https://community.algolia.com/docsearch/

I tried to be as close as the Faraday design as possible.

fixes #1110 (at least it provides an easy way to search for pages, even if pages are not clearly laid out in the navigation)

You can test the search here: https://faraday.codeagain.now.sh/

![2020-01-17 16 00 49](https://user-images.githubusercontent.com/123822/72622898-6e575d00-3944-11ea-8a5a-557743fd1332.gif)


## Todos
List any remaining work that needs to be done, i.e:
- [ ] Get review from the Faraday team

## Additional Notes
It's possible to get analytics on the search feature: what is searched, what get no results (= need to document). I have access to all of that but if you maintainers want that too, just provide me your email address and I will invite you to the application. You will have to create an Algolia account.
