### PR TITLE
Use Net::HTTP#start(&block) to ensure closed TCP connections

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -137,16 +137,24 @@ module Faraday
       end
 
       def request_via_get_method(http, env, &block)
-        http.get env[:url].request_uri, env[:request_headers], &block
+        # Must use Net::HTTP#start and pass it a block otherwise the server's
+        # TCP socket does not close correctly.
+        http.start do |opened_http|
+          opened_http.get env[:url].request_uri, env[:request_headers], &block
+        end
       end
 
       def request_via_request_method(http, env, &block)
-        if block_given?
-          http.request create_request(env) do |response|
-            response.read_body(&block)
+        # Must use Net::HTTP#start and pass it a block otherwise the server's
+        # TCP socket does not close correctly.
+        http.start do |opened_http|
+          if block_given?
+            opened_http.request create_request(env) do |response|
+              response.read_body(&block)
+            end
+          else
+            opened_http.request create_request(env)
           end
-        else
-          http.request create_request(env)
         end
       end
 

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -50,7 +50,11 @@ module Faraday
       end
 
       def perform_request(http, env)
-        http.request env[:url], create_request(env)
+        # Must use Net::HTTP#start and pass it a block otherwise the server's
+        # TCP socket does not close correctly.
+        http.start do |opened_http|
+          opened_http.request env[:url], create_request(env)
+        end
       rescue Errno::ETIMEDOUT => e
         raise Faraday::TimeoutError, e
       rescue Net::HTTP::Persistent::Error => e

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -50,11 +50,7 @@ module Faraday
       end
 
       def perform_request(http, env)
-        # Must use Net::HTTP#start and pass it a block otherwise the server's
-        # TCP socket does not close correctly.
-        http.start do |opened_http|
-          opened_http.request env[:url], create_request(env)
-        end
+        http.request env[:url], create_request(env)
       rescue Errno::ETIMEDOUT => e
         raise Faraday::TimeoutError, e
       rescue Net::HTTP::Persistent::Error => e


### PR DESCRIPTION
Despite the API indicating otherwise, using Net::HTTP#get (or #request) will open a TCP connection and it will remain open long after the request is finished, even though calling Net::HTTP#finish subsequently raises an IOError and the #to_s shows an incorrect "open=false".

Using the Net::HTTP#start block to explicitly open the connection causes Net::HTTP to fully close the TCP connection once the block complete evaluation.

This was verified by doing the following:

1. Running a webserver on a *nix OS (selected default nginx on Ubuntu docker)
2. Running `watch 'netstat -tunapl'` on that OS
3. Run `curl` to GET that webserver many times. Note how there are no "TIME_WAIT" sockets
4. In IRB run `Net::HTTP.get(...)` many times. Note how there are no "TIME_WAIT" sockets
5. In IRB with `rest-client` run `RestClient.get(...)` many times. Note how there are no "TIME_WAIT" sockets
6. In IRB with `faraday` run `Faraday.get(...)` many times. Note how there are n number of "TIME_WAIT" sockets on the webserver OS. They timeout and clear after 60s:

```
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      3511/nginx: master
tcp        0      0 172.17.0.2:80           172.17.0.1:60470        TIME_WAIT   -
tcp        0      0 172.17.0.2:80           172.17.0.1:60472        TIME_WAIT   -
tcp        0      0 172.17.0.2:80           172.17.0.1:60478        TIME_WAIT   -
tcp        0      0 172.17.0.2:80           172.17.0.1:60476        TIME_WAIT   -
tcp        0      0 172.17.0.2:80           172.17.0.1:60468        TIME_WAIT   -
tcp        0      0 172.17.0.2:80           172.17.0.1:60474        TIME_WAIT   -
...
```

This matters because a server receiving many HTTP requests from clients using Faraday will begin to oversaturate and timeout past a particular scale. We ran into this limit.

In short, #start must be used *first* before any requests are made on a Net::HTTP instance otherwise you'll get a dangling TCP connection server-side.

## Todos
- [ ] Changelog
