### PR TITLE
Fully qualify constants to be checked

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -153,7 +153,7 @@ module Faraday
     @default_connection_options = ConnectionOptions.from(options)
   end
 
-  unless const_defined? :Timer
+  unless defined?(::Faraday::Timer)
     require 'timeout'
     Timer = Timeout
   end

--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -142,7 +142,8 @@ module Faraday
 
         raise Faraday::ConnectionFailed, e
       rescue StandardError => e
-        if defined?(OpenSSL) && e.is_a?(OpenSSL::SSL::SSLError)
+        if defined?(::OpenSSL::SSL::SSLError) && \
+           e.is_a?(::OpenSSL::SSL::SSLError)
           raise Faraday::SSLError, e
         end
 

--- a/lib/faraday/adapter/httpclient.rb
+++ b/lib/faraday/adapter/httpclient.rb
@@ -66,7 +66,8 @@ module Faraday
       rescue Errno::EADDRNOTAVAIL, Errno::ECONNREFUSED, IOError, SocketError
         raise Faraday::ConnectionFailed, $ERROR_INFO
       rescue StandardError => e
-        if defined?(OpenSSL) && e.is_a?(OpenSSL::SSL::SSLError)
+        if defined?(::OpenSSL::SSL::SSLError) && \
+           e.is_a?(::OpenSSL::SSL::SSLError)
           raise Faraday::SSLError, e
         end
 

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -30,8 +30,10 @@ module Faraday
         Zlib::GzipFile::Error
       ]
 
-      exceptions << OpenSSL::SSL::SSLError if defined?(OpenSSL)
-      exceptions << Net::OpenTimeout if defined?(Net::OpenTimeout)
+      if defined?(::OpenSSL::SSL::SSLError)
+        exceptions << ::OpenSSL::SSL::SSLError
+      end
+      exceptions << ::Net::OpenTimeout if defined?(::Net::OpenTimeout)
 
       NET_HTTP_EXCEPTIONS = exceptions.freeze
 

--- a/lib/faraday/request/authorization.rb
+++ b/lib/faraday/request/authorization.rb
@@ -4,7 +4,9 @@ module Faraday
   class Request
     # Request middleware for the Authorization HTTP header
     class Authorization < Faraday::Middleware
-      KEY = 'Authorization' unless defined? KEY
+      unless defined?(::Faraday::Request::Authorization::KEY)
+        KEY = 'Authorization'
+      end
 
       # @param type [String, Symbol]
       # @param token [String, Symbol, Hash]

--- a/lib/faraday/request/multipart.rb
+++ b/lib/faraday/request/multipart.rb
@@ -8,7 +8,7 @@ module Faraday
     # Middleware for supporting multi-part requests.
     class Multipart < UrlEncoded
       self.mime_type = 'multipart/form-data'
-      unless defined? DEFAULT_BOUNDARY_PREFIX
+      unless defined?(::Faraday::Request::Multipart::DEFAULT_BOUNDARY_PREFIX)
         DEFAULT_BOUNDARY_PREFIX = '-----------RubyMultipartPost'
       end
 

--- a/lib/faraday/request/url_encoded.rb
+++ b/lib/faraday/request/url_encoded.rb
@@ -4,7 +4,9 @@ module Faraday
   class Request
     # Middleware for supporting urlencoded requests.
     class UrlEncoded < Faraday::Middleware
-      CONTENT_TYPE = 'Content-Type' unless defined? CONTENT_TYPE
+      unless defined?(::Faraday::Request::UrlEncoded::CONTENT_TYPE)
+        CONTENT_TYPE = 'Content-Type'
+      end
 
       class << self
         attr_accessor :mime_type

--- a/spec/faraday/adapter/rack_spec.rb
+++ b/spec/faraday/adapter/rack_spec.rb
@@ -4,5 +4,5 @@ RSpec.describe Faraday::Adapter::Rack do
   features :request_body_on_query_methods, :trace_method,
            :skip_response_body_on_head
 
-  it_behaves_like 'an adapter', adapter_options: WebmockRackApp.new, skip: true
+  it_behaves_like 'an adapter', adapter_options: WebmockRackApp.new
 end

--- a/spec/faraday/adapter/rack_spec.rb
+++ b/spec/faraday/adapter/rack_spec.rb
@@ -4,5 +4,5 @@ RSpec.describe Faraday::Adapter::Rack do
   features :request_body_on_query_methods, :trace_method,
            :skip_response_body_on_head
 
-  it_behaves_like 'an adapter', adapter_options: WebmockRackApp.new
+  it_behaves_like 'an adapter', adapter_options: WebmockRackApp.new, skip: true
 end


### PR DESCRIPTION
Refer to constants in ways that their names  never collide.

## Description

See https://github.com/lostisland/faraday/issues/974 for details.

This  quote lists  the route this PR took:

> Another fix would be changing the defined? checks to look at the ::Expanded::Module::Path. I'm going to list other cases in the code base that this is done, so we can make a single consistent fix:


~**In order to see if tests are green** - this PR disables rack adapters tests which suffer #1119~


