### PR TITLE
allow private parse method in response middleware

### DIFF
--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -15,8 +15,12 @@ module Faraday
 
       # Override this to modify the environment after the response has finished.
       # Calls the `parse` method if defined
+      # `parse` method can be defined as private, public and protected
       def on_complete(env)
-        env.body = parse(env.body) if respond_to?(:parse) && env.parse_body?
+        all_included = true
+        return unless respond_to?(:parse, all_included) && env.parse_body?
+
+        env.body = parse(env.body)
       end
     end
 

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -17,8 +17,7 @@ module Faraday
       # Calls the `parse` method if defined
       # `parse` method can be defined as private, public and protected
       def on_complete(env)
-        all_included = true
-        return unless respond_to?(:parse, all_included) && env.parse_body?
+        return unless respond_to?(:parse, true) && env.parse_body?
 
         env.body = parse(env.body)
       end

--- a/spec/faraday/response/middleware_spec.rb
+++ b/spec/faraday/response/middleware_spec.rb
@@ -26,6 +26,22 @@ RSpec.describe Faraday::Response::Middleware do
     end
   end
 
+  context 'with a custom ResponseMiddleware and private parse' do
+    let(:custom_middleware) do
+      Class.new(Faraday::Response::Middleware) do
+        private
+
+        def parse(body)
+          body.upcase
+        end
+      end
+    end
+
+    it 'parses the response' do
+      expect(conn.get('ok').body).to eq('<BODY></BODY>')
+    end
+  end
+
   context 'with a custom ResponseMiddleware but empty response' do
     let(:custom_middleware) do
       Class.new(Faraday::Response::Middleware) do


### PR DESCRIPTION
## Description
Currently the Response Middleware enforces children classes to define public `parse` method.
This is due to the implicit arg `all_included=false` passed to [respond_to? method](https://ruby-doc.org/core-2.7.0/Object.html#method-i-respond_to-3F)

Now I would like to allow also private and protected `parse` method to allow more flexibility for the children classes.

<details>

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [x] Documentation

## Additional Notes
When running `bundle exec rspec` on master i noticed a bounce of failing specs which are not depending on this PR code changes.

The error is:
```console
Failure/Error: @session.request(env[:url].to_s, rack_env)

      NoMethodError:
        undefined method `split' for nil:NilClass
```

and it refers to [lib/faraday/adapter/rack.rb:62](https://github.com/lostisland/faraday/blob/099dd45f63ff99bbb343eebf7504a3cf0b10bc63/lib/faraday/adapter/rack.rb#L63)

Maybe an issue to fix that should be open.


</details>