### PR TITLE
Encode Spaces in Query Strings as '%20' Instead of '+'

### DIFF
--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -16,12 +16,12 @@ module Faraday
       NestedParamsEncoder.encode(params)
     end
 
-    ESCAPE_RE = /[^a-zA-Z0-9 .~_-]/.freeze
+    ESCAPE_RE = /[^a-zA-Z0-9.~_-]/.freeze
 
     def escape(str)
       str.to_s.gsub(ESCAPE_RE) do |match|
         '%' + match.unpack('H2' * match.bytesize).join('%').upcase
-      end.tr(' ', '+')
+      end
     end
 
     def unescape(str)

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -16,12 +16,20 @@ module Faraday
       NestedParamsEncoder.encode(params)
     end
 
-    ESCAPE_RE = /[^a-zA-Z0-9.~_-]/.freeze
+    def default_space_encoding
+      @default_space_encoding ||= '+'
+    end
+
+    class << self
+      attr_writer :default_space_encoding
+    end
+
+    ESCAPE_RE = /[^a-zA-Z0-9 .~_-]/.freeze
 
     def escape(str)
       str.to_s.gsub(ESCAPE_RE) do |match|
         '%' + match.unpack('H2' * match.bytesize).join('%').upcase
-      end
+      end.gsub(' ', default_space_encoding)
     end
 
     def unescape(str)

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -310,12 +310,12 @@ RSpec.describe Faraday::Connection do
 
     it 'parses url params into query' do
       @params = { 'a[b]' => '1 + 2' }
-      expect(subject.query).to eq('a%5Bb%5D=1+%2B+2')
+      expect(subject.query).to eq('a%5Bb%5D=1%20%2B%202')
     end
 
     it 'escapes per spec' do
       @params = { 'a' => '1+2 foo~bar.-baz' }
-      expect(subject.query).to eq('a=1%2B2+foo~bar.-baz')
+      expect(subject.query).to eq('a=1%2B2%20foo~bar.-baz')
     end
 
     it 'bracketizes nested params in query' do

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -310,12 +310,12 @@ RSpec.describe Faraday::Connection do
 
     it 'parses url params into query' do
       @params = { 'a[b]' => '1 + 2' }
-      expect(subject.query).to eq('a%5Bb%5D=1%20%2B%202')
+      expect(subject.query).to eq('a%5Bb%5D=1+%2B+2')
     end
 
     it 'escapes per spec' do
       @params = { 'a' => '1+2 foo~bar.-baz' }
-      expect(subject.query).to eq('a=1%2B2%20foo~bar.-baz')
+      expect(subject.query).to eq('a=1%2B2+foo~bar.-baz')
     end
 
     it 'bracketizes nested params in query' do

--- a/spec/faraday/request/url_encoded_spec.rb
+++ b/spec/faraday/request/url_encoded_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Faraday::Request::UrlEncoded do
   it 'works with unicode' do
     err = capture_warnings do
       response = conn.post('/echo', str: 'eé cç aã aâ')
-      expect(response.body).to eq('str=e%C3%A9%20c%C3%A7%20a%C3%A3%20a%C3%A2')
+      expect(response.body).to eq('str=e%C3%A9+c%C3%A7+a%C3%A3+a%C3%A2')
     end
     expect(err.empty?).to be_truthy
   end
@@ -66,5 +66,12 @@ RSpec.describe Faraday::Request::UrlEncoded do
   it 'works with nested keys' do
     response = conn.post('/echo', 'a' => { 'b' => { 'c' => ['d'] } })
     expect(response.body).to eq('a%5Bb%5D%5Bc%5D%5B%5D=d')
+  end
+
+  it 'allows the character used to encode spaces to be customised' do
+    Faraday::Utils.default_space_encoding = '%20'
+    response = conn.post('/echo', str: 'apple banana')
+    expect(response.body).to eq('str=apple%20banana')
+    Faraday::Utils.default_space_encoding = nil
   end
 end

--- a/spec/faraday/request/url_encoded_spec.rb
+++ b/spec/faraday/request/url_encoded_spec.rb
@@ -68,14 +68,14 @@ RSpec.describe Faraday::Request::UrlEncoded do
     expect(response.body).to eq('a%5Bb%5D%5Bc%5D%5B%5D=d')
   end
 
-  context 'customising the character used to encode spaces' do
+  context 'customising default_space_encoding' do
     around do |example|
       Faraday::Utils.default_space_encoding = '%20'
       example.run
       Faraday::Utils.default_space_encoding = nil
     end
 
-    it 'uses the custom character' do
+    it 'uses the custom character to encode spaces' do
       response = conn.post('/echo', str: 'apple banana')
       expect(response.body).to eq('str=apple%20banana')
     end

--- a/spec/faraday/request/url_encoded_spec.rb
+++ b/spec/faraday/request/url_encoded_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Faraday::Request::UrlEncoded do
   it 'works with unicode' do
     err = capture_warnings do
       response = conn.post('/echo', str: 'eé cç aã aâ')
-      expect(response.body).to eq('str=e%C3%A9+c%C3%A7+a%C3%A3+a%C3%A2')
+      expect(response.body).to eq('str=e%C3%A9%20c%C3%A7%20a%C3%A3%20a%C3%A2')
     end
     expect(err.empty?).to be_truthy
   end

--- a/spec/faraday/request/url_encoded_spec.rb
+++ b/spec/faraday/request/url_encoded_spec.rb
@@ -68,10 +68,16 @@ RSpec.describe Faraday::Request::UrlEncoded do
     expect(response.body).to eq('a%5Bb%5D%5Bc%5D%5B%5D=d')
   end
 
-  it 'allows the character used to encode spaces to be customised' do
-    Faraday::Utils.default_space_encoding = '%20'
-    response = conn.post('/echo', str: 'apple banana')
-    expect(response.body).to eq('str=apple%20banana')
-    Faraday::Utils.default_space_encoding = nil
+  context 'customising the character used to encode spaces' do
+    around do |example|
+      Faraday::Utils.default_space_encoding = '%20'
+      example.run
+      Faraday::Utils.default_space_encoding = nil
+    end
+
+    it 'uses the custom character' do
+      response = conn.post('/echo', str: 'apple banana')
+      expect(response.body).to eq('str=apple%20banana')
+    end
   end
 end


### PR DESCRIPTION
 While `+` is supposed to be a valid encoding for spaces in query strings, it seems like it is causing some issues with some servers (namely [Apple's](https://github.com/nhosoya/omniauth-apple/pull/16))

Given that encodeURIComponent encodes spaces as `%20`, and `%20` is what is recommended by [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.1) maybe this could be the default. 

Fixes #1124