### PR TITLE
Limits rack to v2.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,13 +20,15 @@ group :test do
   gem 'multipart-parser'
   gem 'net-http-persistent'
   gem 'patron', '>= 0.4.2', platforms: :ruby
+  gem 'rack', '< 2.1'
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'
   gem 'rspec_junit_formatter', '~> 0.4'
   gem 'rubocop-performance', '~> 1.0'
   gem 'simplecov'
-  gem 'typhoeus', '~> 1.3', git: 'https://github.com/typhoeus/typhoeus.git',
-                            require: 'typhoeus'
+  gem 'typhoeus', '~> 1.3',
+      git: 'https://github.com/typhoeus/typhoeus.git',
+      require: 'typhoeus'
   gem 'webmock', '~> 3.4'
 end
 


### PR DESCRIPTION
## Description
There seems like a bug has been introduced in rack 2.1 that causes our tests to fail.
It works find up to 2.0.8 so for now I'm limiting to that version to allow tests to pass.
Fixes #1119

## Additional Notes
We should investigate how the tests got broken due to a minor bump in the rack version.
