### PR TITLE
Fix request/response mix-up in docs text

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -52,7 +52,7 @@ resp = Faraday.get(url, {a: 1}, {'Accept' => 'application/json'})
 
 Faraday also supports HTTP verbs that do include request bodies, though the
 optional method arguments are different. Instead of HTTP query params, these
-methods accept a response body.
+methods accept a request body.
 
 * `post`
 * `put`


### PR DESCRIPTION
Fix for a small request/response mix-up in text in docs.