### PR TITLE
fix: Expose spec-assisting tools for authors of external adapters

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   files = %w[CHANGELOG.md LICENSE.md README.md Rakefile examples lib spec]
   spec.files = `git ls-files -z #{files.join(' ')}`.split("\0")
+  spec.require_paths = %w[lib spec/external_adapters]
   spec.metadata = {
     'homepage_uri' => 'https://lostisland.github.io/faraday',
     'changelog_uri' =>


### PR DESCRIPTION
## Description

This adds back the require path for "external adapters", which is an assist feature that supports adapter authors.

## Details

The one such adapter in existence is faraday-http, which had a failure to build, and that led me here.

  - the exposure was inadvertently (I think) removed in 0c873c1500b0849cafcc6a0c4d7ccfeedcc7a48a
  - the feature was introduced in #941

I found this out when https://github.com/lostisland/faraday-http/pull/8 failed to build.

When referring to THIS PR as a dependency to that PR: we can get to green - https://github.com/lostisland/faraday-http/pull/8

---

One thing that users of the feature may need to know is that 

`gem 'multipart-parser'` is needed in their Gemfile.