### PR TITLE
Improve Faraday::Error to get consistent response information

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -6,10 +6,11 @@ module Faraday
   class Error < StandardError
     attr_reader :response, :wrapped_exception
 
-    def initialize(exc, response = nil)
+    def initialize(exc, deprecated_response = nil, response = nil)
       @wrapped_exception = nil unless defined?(@wrapped_exception)
       @response = nil unless defined?(@response)
-      super(exc_msg_and_response!(exc, response))
+      @v2_response = response
+      super(exc_msg_and_response!(exc, deprecated_response))
     end
 
     def backtrace
@@ -26,6 +27,18 @@ module Faraday
       inner << " response=#{@response.inspect}" if @response
       inner << " #{super}" if inner.empty?
       %(#<#{self.class}#{inner}>)
+    end
+
+    def response_status
+      @v2_response&.status
+    end
+
+    def response_body
+      @v2_response&.body
+    end
+
+    def response_headers
+      @v2_response&.headers
     end
 
     protected

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -13,25 +13,34 @@ module Faraday
       def on_complete(env)
         case env[:status]
         when 400
-          raise Faraday::BadRequestError, response_values(env)
+          raise Faraday::BadRequestError
+            .new(response_values(env), nil, env.response)
         when 401
-          raise Faraday::UnauthorizedError, response_values(env)
+          raise Faraday::UnauthorizedError
+            .new(response_values(env), nil, env.response)
         when 403
-          raise Faraday::ForbiddenError, response_values(env)
+          raise Faraday::ForbiddenError
+            .new(response_values(env), nil, env.response)
         when 404
-          raise Faraday::ResourceNotFound, response_values(env)
+          raise Faraday::ResourceNotFound
+            .new(response_values(env), nil, env.response)
         when 407
           # mimic the behavior that we get with proxy requests with HTTPS
           msg = %(407 "Proxy Authentication Required")
-          raise Faraday::ProxyAuthError.new(msg, response_values(env))
+          raise Faraday::ProxyAuthError
+            .new(msg, response_values(env), env.response)
         when 409
-          raise Faraday::ConflictError, response_values(env)
+          raise Faraday::ConflictError
+            .new(response_values(env), nil, env.response)
         when 422
-          raise Faraday::UnprocessableEntityError, response_values(env)
+          raise Faraday::UnprocessableEntityError
+            .new(response_values(env), nil, env.response)
         when ClientErrorStatuses
-          raise Faraday::ClientError, response_values(env)
+          raise Faraday::ClientError
+            .new(response_values(env), nil, env.response)
         when ServerErrorStatuses
-          raise Faraday::ServerError, response_values(env)
+          raise Faraday::ServerError
+            .new(response_values(env), nil, env.response)
         when nil
           raise Faraday::NilStatusError, response_values(env)
         end

--- a/spec/faraday/error_spec.rb
+++ b/spec/faraday/error_spec.rb
@@ -2,7 +2,8 @@
 
 RSpec.describe Faraday::ClientError do
   describe '.initialize' do
-    subject { described_class.new(exception, response) }
+    subject { described_class.new(exception, deprecated_response, response) }
+    let(:deprecated_response) { nil }
     let(:response) { nil }
 
     context 'with exception only' do
@@ -15,7 +16,7 @@ RSpec.describe Faraday::ClientError do
       it { expect(subject.inspect).to eq('#<Faraday::ClientError wrapped=#<RuntimeError: test>>') }
     end
 
-    context 'with response hash' do
+    context 'with deprecated_response hash' do
       let(:exception) { { status: 400 } }
 
       it { expect(subject.wrapped_exception).to be_nil }
@@ -40,6 +41,33 @@ RSpec.describe Faraday::ClientError do
       it { expect(subject.response).to be_nil }
       it { expect(subject.message).to eq('["error1", "error2"]') }
       it { expect(subject.inspect).to eq('#<Faraday::ClientError #<Faraday::ClientError: ["error1", "error2"]>>') }
+    end
+
+    context 'with exception string and deprecated_response hash' do
+      let(:exception) { 'custom message' }
+      let(:deprecated_response) { { status: 400 } }
+
+      it { expect(subject.wrapped_exception).to be_nil }
+      it { expect(subject.response).to eq(deprecated_response) }
+      it { expect(subject.message).to eq('custom message') }
+      it { expect(subject.inspect).to eq('#<Faraday::ClientError response={:status=>400}>') }
+    end
+
+    context 'with deprecated_response hash and response' do
+      let(:exception) { { status: 400 } }
+      let(:env) do
+        Faraday::Env.from(status: 400, body: 'yikes',
+                          response_headers: { 'Content-Type' => 'text/plain' })
+      end
+      let(:response) { Faraday::Response.new(env) }
+
+      it { expect(subject.wrapped_exception).to be_nil }
+      it { expect(subject.response).to eq(exception) }
+      it { expect(subject.message).to eq('the server responded with status 400') }
+      it { expect(subject.inspect).to eq('#<Faraday::ClientError response={:status=>400}>') }
+      it { expect(subject.response_status).to eq(400) }
+      it { expect(subject.response_body).to eq('yikes') }
+      it { expect(subject.response_headers).to eq({ 'Content-Type' => 'text/plain' }) }
     end
   end
 end

--- a/spec/faraday/response/raise_error_spec.rb
+++ b/spec/faraday/response/raise_error_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.message).to eq('the server responded with status 400')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(400)
+      expect(ex.response_status).to eq(400)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
     end
   end
 
@@ -37,6 +40,9 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.message).to eq('the server responded with status 401')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(401)
+      expect(ex.response_status).to eq(401)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
     end
   end
 
@@ -45,6 +51,9 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.message).to eq('the server responded with status 403')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(403)
+      expect(ex.response_status).to eq(403)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
     end
   end
 
@@ -53,6 +62,9 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.message).to eq('the server responded with status 404')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(404)
+      expect(ex.response_status).to eq(404)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
     end
   end
 
@@ -61,6 +73,9 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.message).to eq('407 "Proxy Authentication Required"')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(407)
+      expect(ex.response_status).to eq(407)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
     end
   end
 
@@ -69,6 +84,9 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.message).to eq('the server responded with status 409')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(409)
+      expect(ex.response_status).to eq(409)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
     end
   end
 
@@ -77,6 +95,9 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.message).to eq('the server responded with status 422')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(422)
+      expect(ex.response_status).to eq(422)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
     end
   end
 
@@ -93,6 +114,9 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.message).to eq('the server responded with status 499')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(499)
+      expect(ex.response_status).to eq(499)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
     end
   end
 
@@ -101,6 +125,9 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.message).to eq('the server responded with status 500')
       expect(ex.response[:headers]['X-Error']).to eq('bailout')
       expect(ex.response[:status]).to eq(500)
+      expect(ex.response_status).to eq(500)
+      expect(ex.response_body).to eq('fail')
+      expect(ex.response_headers['X-Error']).to eq('bailout')
     end
   end
 end


### PR DESCRIPTION
Hi, I faced this problem https://github.com/lostisland/faraday/issues/956 on my development using faraday. I need to make patch in our private codebase but I also have a motivation to make an improvement to the upstream codebase. I'm glad if I can hear your opinions.

## Description

I'm glad if this pull request can achieve these goals:

- Make improvements for faraday v1 (current version) as far as not breaking backward compatibility
  - In this PR, I added some instance methods returning response information to Faraday::Error.
- Make gradual consensus about how to fix that inconsistency problem in faraday v2

### Current Problem

I think it is described well in https://github.com/lostisland/faraday/issues/956 , but I'd like to clarify it here.

The `Faraday::Error` instance wraps `response` object. This object is desired to be Faraday::Response instance, but currently this is just a hash including status/body/headers keys. This makes an inconsistency which is a bit annoying to treat for Faraday users.

One more problem (which is my motivation to solve it) is, the `body` in the response hash is always a raw one, not one rewritten by the response middlewares. For example, I configured as below

(**Edited.** First I specified the response middlewares in the wrong order. Now it's corrected)

```rb
conn = Faraday.new(...) do |conn|
  conn.response :raise_error
  conn.response :json, :content_type => /\bjson$/
end
```

and send a request. Let me assume that the response status code is 500, and body is JSON data like `{ "error": "msg"}` with the `Content-Type: application/json` header.

In this case, an error of Faraday::ServerError instance will be raised by the raise_error middleware. I expect that `error.response[:body]` is a hash `{ "error" => "msg"}`  because json middleware exists before the raise_error middleware, but actually it is just a String `'{ "error": "msg"}'` .

### Improvement for v1 codebase

Currently, `Faraday::Error#response` returns a hash which is not an instance of `Faraday::Response`. This cannot be changed in v1 without breaking the backward compatibility.

As @technoweenie mentioned [here](https://github.com/lostisland/faraday/issues/956#issuecomment-478072433) , we can extend the initializers to receive an actual `Faraday::Response` object, and add some methods to try to get the data from that object. (note: we need to pay attention for that it cannot be got if the error is created in userland)

**In this PR, I added 3 methods: `response_status`, `response_body`, `response_headers`.**

### How it should be in faraday v2 (allowing breaking changes)?

It's not mandatory to discuss this in this PR, but I think it's better to have gradual consensus for the sake of the better change considering the seamless migration.

In my understanding, `Faraday::Error` instance should wrap the `Faraday::Response` instance. **The current response data (hash) will be no longer necessary** because it is a subset of `Faraday::Response` instance.

One point we can discuss is the signature of initializer. Current one is below. (`exc` is expected to  error message or response hash)

```rb
def initialize(exc, response = nil)
end
```

As mentioned [here](https://github.com/lostisland/faraday/pull/1042/files/2c81ed67ed6bfb7b25db0c3b5687faa338ca44ad#r334571035) , the `response` might be desired to an named argument. So I'd like to suggest the signature basically like below:

```rb
# response is a Faraday::Response instance
def initialize(exc = nil, response:)
  @response = response
  # ...
end
attr_reader :response
```
I'm glad if I can hear your opinion.

## Todos

- Documentation (if needed. I think it's not necessary until v2 will be released)