### PR TITLE
Use the lock also when reading, in AdapterRegistry

### DIFF
--- a/lib/faraday/adapter_registry.rb
+++ b/lib/faraday/adapter_registry.rb
@@ -12,7 +12,9 @@ module Faraday
     end
 
     def get(name)
-      klass = @constants[name]
+      klass = @lock.synchronize do
+        @constants[name]
+      end
       return klass if klass
 
       Object.const_get(name).tap { |c| set(c, name) }


### PR DESCRIPTION
## Description

Adapter Registry _stores_ information in "a thread-safe way" (using a synchronize block). But, when _reading_, it doesn't use the lock.

This PR tries to repair the issue reported in #1068, by using a synchronize block around the reading, too.

## Todos

Remaining things

- [ ] Tests
- [ ] Document this kind of thing in the DEVELOP guide?
- [ ] Perhaps have a concurrency label? Is that the right word?

## Additional Notes

This was inspired by watching a video from RWC2019. Here it is: https://www.youtube.com/watch?v=qX_FRa43r4k