### PR TITLE
Set middleware_mutex when middleware/adapter classes are defined

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -33,6 +33,7 @@ module Faraday
 
       def inherited(subclass)
         super
+        subclass.middleware_mutex
         subclass.supports_parallel = supports_parallel?
       end
     end

--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -17,5 +17,11 @@ module Faraday
         warn "#{@app} does not implement \#close!"
       end
     end
+
+    def self.inherited(subclass)
+      super
+      subclass.send(:load_error=, load_error) # DependencyLoader.inherited
+      subclass.middleware_mutex
+    end
   end
 end

--- a/lib/faraday/middleware_registry.rb
+++ b/lib/faraday/middleware_registry.rb
@@ -6,6 +6,11 @@ module Faraday
   # Adds the ability for other modules to register and lookup
   # middleware classes.
   module MiddlewareRegistry
+    def self.extended(klass)
+      super
+      klass.middleware_mutex
+    end
+
     # Register middleware class(es) on the current module.
     #
     # @param autoload_path [String] Middleware autoload path
@@ -92,8 +97,9 @@ module Faraday
     end
 
     def middleware_mutex(&block)
+      puts "#{self}: middleware_mutex" if @middleware_mutex.nil?
       @middleware_mutex ||= Monitor.new
-      @middleware_mutex.synchronize(&block)
+      @middleware_mutex.synchronize(&block) if block
     end
 
     def fetch_middleware(key)


### PR DESCRIPTION
## Description

See #1074.

This PR is a rebase on `master` in order to be able to run the tests in GitHub Actions. (At the time of #1074 being authored, CI was in a period of change.)

## Todos

- [ ] Tests

## Additional Notes
Optional section
