### PR TITLE
Remove Codeclimate coverage badge, CI coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,19 +64,8 @@ jobs:
         gem install bundler -v '<2'
         bundle install --jobs 4 --retry 3
 
-    - name: Setup Code Climate
-      if: matrix.ruby == '2.6'
-      run: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        chmod +x ./cc-test-reporter
-        ./cc-test-reporter before-build
-
     - name: Test
       run: |
         source $HOME/.rvm/scripts/rvm
         bundle exec rake
 
-    - name: Run Code Climate Test Reporter
-      if: success() && matrix.ruby == '2.6'
-      run: ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
-      continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/faraday.svg)](https://rubygems.org/gems/faraday)
 ![GitHub Actions CI](https://github.com/lostisland/faraday/workflows/CI/badge.svg)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/f869daab091ceef1da73/test_coverage)](https://codeclimate.com/github/lostisland/faraday/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f869daab091ceef1da73/maintainability)](https://codeclimate.com/github/lostisland/faraday/maintainability)
 [![Gitter](https://badges.gitter.im/lostisland/faraday.svg)](https://gitter.im/lostisland/faraday?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
Until CodeClimate supports SimpleCov 0.18:

- drop coverage badge from our README
- drop coverage reporting from our CI

## Description

See #1139 for a discussion of why this is needed.

(Perhaps we want to keep that Issue open, to track the SimpleCov 0.18 support in Codeclimate.)
