### PR TITLE
Link from GitHub Actions badge to CI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [![Faraday](./docs/assets/img/repo-card-slim.png)][website]
 
 [![Gem Version](https://badge.fury.io/rb/faraday.svg)](https://rubygems.org/gems/faraday)
-![GitHub Actions CI](https://github.com/lostisland/faraday/workflows/CI/badge.svg)
+[![GitHub Actions CI](https://github.com/lostisland/faraday/workflows/CI/badge.svg)](https://github.com/lostisland/faraday/actions?query=workflow%3ACI)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f869daab091ceef1da73/maintainability)](https://codeclimate.com/github/lostisland/faraday/maintainability)
 [![Gitter](https://badges.gitter.im/lostisland/faraday.svg)](https://gitter.im/lostisland/faraday?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
## Description

In order to be less surprising, this changes the link around the SVG to link to the https://github.com/lostisland/faraday/actions?query=workflow%3ACI page.

