### PR TITLE
Fix typo for RSpec

### DIFF
--- a/examples/client_spec.rb
+++ b/examples/client_spec.rb
@@ -19,7 +19,7 @@ class Client
   end
 end
 
-Rspec.describe Client do
+RSpec.describe Client do
   let(:stubs)  { Faraday::Adapter::Test::Stubs.new }
   let(:conn)   { Faraday.new { |b| b.adapter(:test, stubs) } }
   let(:client) { Client.new(conn) }


### PR DESCRIPTION
## Description
Fixed a typo in `examples/client_spec.rb` - `Rspec.describe` should be `RSpec.describe`