### PR TITLE
Update RuboCop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,11 @@ jobs:
 
     - name: Rubocop
       run: |
-        gem install rubocop rubocop-performance --no-document
-        rubocop --require rubocop-performance --format progress
+        gem install bundler
+        bundle config set without 'development test'
+        bundle config set with 'lint'
+        bundle install
+        bundle exec rubocop --format progress
 
     - name: Yard-Junk
       run: |

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 Metrics/BlockLength:
   Exclude:
@@ -18,6 +18,9 @@ Layout/LineLength:
     - spec/**/*.rb
     - examples/**/*.rb
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 Style/DoubleNegation:
   Enabled: false
 
@@ -25,3 +28,17 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
     - 'examples/**/*'
+
+Style/ExponentialNotation:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,18 @@ source 'https://rubygems.org'
 ruby RUBY_VERSION
 
 gem 'jruby-openssl', '~> 0.8.8', platforms: :jruby
-gem 'rake'
 
 group :development, :test do
   gem 'pry'
+  gem 'rake'
 end
 
-group :test do
+group :lint, :development do
+  gem 'rubocop', '~> 0.82.0'
+  gem 'rubocop-performance', '~> 1.0'
+end
+
+group :test, :development do
   gem 'coveralls', require: false
   gem 'em-http-request', '>= 1.1', require: 'em-http'
   gem 'em-synchrony', '>= 1.0.3', require: %w[em-synchrony em-synchrony/em-http]
@@ -24,7 +29,6 @@ group :test do
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'
   gem 'rspec_junit_formatter', '~> 0.4'
-  gem 'rubocop-performance', '~> 1.0'
   gem 'simplecov'
   gem 'typhoeus', '~> 1.3',
       git: 'https://github.com/typhoeus/typhoeus.git',

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,8 @@
+## Faraday 2.0
+
+### Others
+* Rename `Faraday::Request#method` to `#http_method`.
+
 ## Faraday 1.0
 
 ### Errors

--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://lostisland.github.io/faraday'
   spec.licenses = ['MIT']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
 

--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -34,9 +34,9 @@ module Faraday
 
         @app.call(env)
       rescue ::Excon::Errors::SocketError => e
-        raise Faraday::TimeoutError, e if e.message =~ /\btimeout\b/
+        raise Faraday::TimeoutError, e if e.message.match?(/\btimeout\b/)
 
-        raise Faraday::SSLError, e if e.message =~ /\bcertificate\b/
+        raise Faraday::SSLError, e if e.message.match?(/\bcertificate\b/)
 
         raise Faraday::ConnectionFailed, e
       rescue ::Excon::Errors::Timeout => e

--- a/lib/faraday/autoload.rb
+++ b/lib/faraday/autoload.rb
@@ -23,7 +23,7 @@ module Faraday
     #
     # @return [void]
     def autoload_all(prefix, options)
-      if prefix =~ %r{^faraday(/|$)}i
+      if prefix.match? %r{^faraday(/|$)}i
         prefix = File.join(Faraday.root_path, prefix)
       end
 

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -593,7 +593,7 @@ module Faraday
       uri = ENV['http_proxy']
       return unless uri && !uri.empty?
 
-      uri = 'http://' + uri if uri !~ /^http/i
+      uri = 'http://' + uri unless uri.match?(/^http/i)
       uri
     end
 

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -186,7 +186,7 @@ module Faraday
     end
 
     # ENV Keys
-    # :method - a symbolized request method (:get, :post)
+    # :http_method - a symbolized request HTTP method (:get, :post)
     # :body   - the request body that will eventually be converted to a string.
     # :url    - URI instance for the current request.
     # :status           - HTTP response status code
@@ -207,7 +207,7 @@ module Faraday
         request.options.params_encoder
       )
 
-      Env.new(request.method, request.body, exclusive_url,
+      Env.new(request.http_method, request.body, exclusive_url,
               request.options, request.headers, connection.ssl,
               connection.parallel_manager)
     end

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -12,7 +12,7 @@ module Faraday
   #     req.body = 'abc'
   #   end
   #
-  # @!attribute method
+  # @!attribute http_method
   #   @return [Symbol] the HTTP method of the Request
   # @!attribute path
   #   @return [URI, String] the path
@@ -26,7 +26,9 @@ module Faraday
   #   @return [RequestOptions] options
   #
   # rubocop:disable Style/StructInheritance
-  class Request < Struct.new(:method, :path, :params, :headers, :body, :options)
+  class Request < Struct.new(
+    :http_method, :path, :params, :headers, :body, :options
+  )
     # rubocop:enable Style/StructInheritance
 
     extend MiddlewareRegistry
@@ -54,6 +56,14 @@ module Faraday
       new(request_method).tap do |request|
         yield(request) if block_given?
       end
+    end
+
+    def method
+      warn <<~TEXT
+        WARNING: `Faraday::Request##{__method__}` is deprecated; use `#http_method` instead. It will be removed in or after version 2.0.
+        `Faraday::Request##{__method__}` called from #{caller_locations(1..1).first}
+      TEXT
+      http_method
     end
 
     # Replace params, preserving the existing hash type.
@@ -116,7 +126,7 @@ module Faraday
     # @return [Hash] the hash ready to be serialized in Marshal.
     def marshal_dump
       {
-        method: method,
+        http_method: http_method,
         body: body,
         headers: headers,
         path: path,
@@ -129,17 +139,17 @@ module Faraday
     # Restores the instance variables according to the +serialised+.
     # @param serialised [Hash] the serialised object.
     def marshal_load(serialised)
-      self.method  = serialised[:method]
-      self.body    = serialised[:body]
-      self.headers = serialised[:headers]
-      self.path    = serialised[:path]
-      self.params  = serialised[:params]
-      self.options = serialised[:options]
+      self.http_method = serialised[:http_method]
+      self.body        = serialised[:body]
+      self.headers     = serialised[:headers]
+      self.path        = serialised[:path]
+      self.params      = serialised[:params]
+      self.options     = serialised[:options]
     end
 
     # @return [Env] the Env for this Request
     def to_env(connection)
-      Env.new(method, body, connection.build_exclusive_url(path, params),
+      Env.new(http_method, body, connection.build_exclusive_url(path, params),
               options, headers, connection.ssl, connection.parallel_manager)
     end
   end

--- a/script/proxy-server
+++ b/script/proxy-server
@@ -15,7 +15,7 @@ if (found = ARGV.index('-u'))
 end
 
 match_credentials = lambda { |credentials|
-  got_username, got_password = credentials.to_s.unpack('m*')[0].split(':', 2)
+  got_username, got_password = credentials.to_s.unpack1('m*').split(':', 2)
   got_username == username && got_password == password
 }
 

--- a/spec/faraday/request_spec.rb
+++ b/spec/faraday/request_spec.rb
@@ -6,20 +6,31 @@ RSpec.describe Faraday::Request do
                 headers: { 'Mime-Version' => '1.0' },
                 request: { oauth: { consumer_key: 'anonymous' } })
   end
-  let(:method) { :get }
+  let(:http_method) { :get }
   let(:block) { nil }
 
-  subject { conn.build_request(method, &block) }
+  subject { conn.build_request(http_method, &block) }
 
   context 'when nothing particular is configured' do
-    it { expect(subject.method).to eq(:get) }
+    it { expect(subject.http_method).to eq(:get) }
     it { expect(subject.to_env(conn).ssl.verify).to be_falsey }
   end
 
-  context 'when method is post' do
-    let(:method) { :post }
+  context 'when HTTP method is post' do
+    let(:http_method) { :post }
+
+    it { expect(subject.http_method).to eq(:post) }
+  end
+
+  describe 'deprecate method for HTTP method' do
+    let(:http_method) { :post }
+    let(:expected_warning) do
+      %r{WARNING: `Faraday::Request#method` is deprecated; use `#http_method` instead. It will be removed in or after version 2.0.\n`Faraday::Request#method` called from .+/spec/faraday/request_spec.rb:\d+.}
+    end
 
     it { expect(subject.method).to eq(:post) }
+
+    it { expect { subject.method }.to output(expected_warning).to_stderr }
   end
 
   context 'when setting the url on setup with a URI' do


### PR DESCRIPTION
Require its specific version in `Gemfile`.

Fix it's installation in CI.

Enable new cops.

Resolve new offenses.

Drop support of Ruby 2.3
(it's not supported by RuboCop and by MRI:https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/)

Deprecate `Faraday::Request#method`, replace it with `#http_method`.

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [ ] Documentation

## Additional Notes

It requires for neighbor pull requests.