### PR TITLE
Avoid 'last arg as keyword param' warning when building user middleware on Ruby 2.7

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
+  spec.add_dependency 'ruby2_keywords'
 
   files = %w[CHANGELOG.md LICENSE.md README.md Rakefile examples lib spec]
   spec.files = `git ls-files -z #{files.join(' ')}`.split("\0")

--- a/lib/faraday/dependency_loader.rb
+++ b/lib/faraday/dependency_loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+def ruby2_keywords(*) end if RUBY_VERSION < '2.7'
+
 module Faraday
   # DependencyLoader helps Faraday adapters and middleware load dependencies.
   module DependencyLoader
@@ -13,7 +15,7 @@ module Faraday
       self.load_error = e
     end
 
-    def new(*)
+    ruby2_keywords def new(*)
       unless loaded?
         raise "missing dependency for #{self}: #{load_error.message}"
       end

--- a/lib/faraday/dependency_loader.rb
+++ b/lib/faraday/dependency_loader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-def ruby2_keywords(*) end if RUBY_VERSION < '2.7'
+require 'ruby2_keywords'
 
 module Faraday
   # DependencyLoader helps Faraday adapters and middleware load dependencies.

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+def ruby2_keywords(*) end if RUBY_VERSION < '2.7'
+
 require 'faraday/adapter_registry'
 
 module Faraday
@@ -27,7 +29,7 @@ module Faraday
 
       attr_reader :name
 
-      def initialize(klass, *args, &block)
+      ruby2_keywords def initialize(klass, *args, &block)
         @name = klass.to_s
         REGISTRY.set(klass) if klass.respond_to?(:name)
         @args = args
@@ -89,7 +91,7 @@ module Faraday
       @handlers.frozen?
     end
 
-    def use(klass, *args, &block)
+    ruby2_keywords def use(klass, *args, &block)
       if klass.is_a? Symbol
         use_symbol(Faraday::Middleware, klass, *args, &block)
       else
@@ -234,7 +236,7 @@ module Faraday
       klass.ancestors.include?(Faraday::Adapter)
     end
 
-    def use_symbol(mod, key, *args, &block)
+    ruby2_keywords def use_symbol(mod, key, *args, &block)
       use(mod.lookup_middleware(key), *args, &block)
     end
 

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -117,7 +117,7 @@ module Faraday
 
     ## methods to push onto the various positions in the stack:
 
-    def insert(index, *args, &block)
+    ruby2_keywords def insert(index, *args, &block)
       raise_if_locked
       index = assert_index(index)
       handler = self.class::Handler.new(*args, &block)

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -104,7 +104,7 @@ module Faraday
       use_symbol(Faraday::Request, key, *args, &block)
     end
 
-    def response(key, *args, &block)
+    ruby2_keywords def response(key, *args, &block)
       use_symbol(Faraday::Response, key, *args, &block)
     end
 

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -100,7 +100,7 @@ module Faraday
       end
     end
 
-    def request(key, *args, &block)
+    ruby2_keywords def request(key, *args, &block)
       use_symbol(Faraday::Request, key, *args, &block)
     end
 

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -108,7 +108,7 @@ module Faraday
       use_symbol(Faraday::Response, key, *args, &block)
     end
 
-    def adapter(klass = NO_ARGUMENT, *args, &block)
+    ruby2_keywords def adapter(klass = NO_ARGUMENT, *args, &block)
       return @adapter if klass == NO_ARGUMENT
 
       klass = Faraday::Adapter.lookup_middleware(klass) if klass.is_a?(Symbol)

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -131,7 +131,7 @@ module Faraday
       insert(index + 1, *args, &block)
     end
 
-    def swap(index, *args, &block)
+    ruby2_keywords def swap(index, *args, &block)
       raise_if_locked
       index = assert_index(index)
       @handlers.delete_at(index)

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -126,7 +126,7 @@ module Faraday
 
     alias insert_before insert
 
-    def insert_after(index, *args, &block)
+    ruby2_keywords def insert_after(index, *args, &block)
       index = assert_index(index)
       insert(index + 1, *args, &block)
     end

--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-def ruby2_keywords(*) end if RUBY_VERSION < '2.7'
-
+require 'ruby2_keywords'
 require 'faraday/adapter_registry'
 
 module Faraday

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -206,6 +206,9 @@ RSpec.describe Faraday::RackBuilder do
         end
       end
     end
+    let(:dog) do
+      subject.handlers.find { |handler| handler == dog_middleware }.build
+    end
 
     let(:cat_middleware) do
       Class.new(Faraday::Middleware) do
@@ -216,11 +219,22 @@ RSpec.describe Faraday::RackBuilder do
         end
       end
     end
+    let(:cat) do
+      subject.handlers.find { |handler| handler == cat_middleware }.build
+    end
+
     it 'adds a handler to construct middleware with options passed to use' do
       subject.use dog_middleware, 'Rex'
-      expect(subject.handlers.find { |handler| handler == dog_middleware }.build.name).to eq('Rex')
+      expect { dog }.to_not output(
+        /warning: Using the last argument as keyword parameters is deprecated/
+      ).to_stderr
+      expect(dog.name).to eq('Rex')
+
       subject.use cat_middleware, name: 'Felix'
-      expect(subject.handlers.find { |handler| handler == cat_middleware }.build.name).to eq('Felix')
+      expect { cat }.to_not output(
+        /warning: Using the last argument as keyword parameters is deprecated/
+      ).to_stderr
+      expect(cat.name).to eq('Felix')
     end
   end
 end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -194,13 +194,13 @@ RSpec.describe Faraday::RackBuilder do
     end
   end
 
-  context 'when middleware is added with arguments' do
+  context 'when middleware is added with named arguments' do
     let(:conn) { Faraday::Connection.new {} }
 
     let(:dog_middleware) do
       Class.new(Faraday::Middleware) do
         attr_accessor :name
-        def initialize(app, name)
+        def initialize(app, name:)
           super(app)
           @name = name
         end
@@ -210,31 +210,12 @@ RSpec.describe Faraday::RackBuilder do
       subject.handlers.find { |handler| handler == dog_middleware }.build
     end
 
-    let(:cat_middleware) do
-      Class.new(Faraday::Middleware) do
-        attr_accessor :name
-        def initialize(app, name:)
-          super(app)
-          @name = name
-        end
-      end
-    end
-    let(:cat) do
-      subject.handlers.find { |handler| handler == cat_middleware }.build
-    end
-
     it 'adds a handler to construct middleware with options passed to use' do
-      subject.use dog_middleware, 'Rex'
+      subject.use dog_middleware, name: 'Rex'
       expect { dog }.to_not output(
         /warning: Using the last argument as keyword parameters is deprecated/
       ).to_stderr
       expect(dog.name).to eq('Rex')
-
-      subject.use cat_middleware, name: 'Felix'
-      expect { cat }.to_not output(
-        /warning: Using the last argument as keyword parameters is deprecated/
-      ).to_stderr
-      expect(cat.name).to eq('Felix')
     end
   end
 end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -328,5 +328,14 @@ RSpec.describe Faraday::RackBuilder do
       ).to_stderr
       expect(rock.name).to eq('Rocky')
     end
+
+    it 'adds a handler with options passed to swap' do
+      subject.insert 0, rock_handler, name: 'Flint'
+      subject.swap 0, rock_handler, name: 'Chert'
+      expect { rock }.to_not output(
+        /warning: Using the last argument as keyword parameters is deprecated/
+      ).to_stderr
+      expect(rock.name).to eq('Chert')
+    end
   end
 end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -271,4 +271,30 @@ RSpec.describe Faraday::RackBuilder do
       expect(fish.name).to eq('Bubbles')
     end
   end
+
+  context 'when a plain adapter is added with named arguments' do
+    let(:conn) { Faraday::Connection.new {} }
+
+    let(:rabbit_adapter) do
+      Class.new(Faraday::Adapter) do
+        attr_accessor :name
+        def initialize(app, name:)
+          super(app)
+          @name = name
+        end
+      end
+    end
+    let(:rabbit) do
+      subject.adapter.build
+    end
+
+    it 'adds a handler to construct adapter with options passed to adapter' do
+      Faraday::Adapter.register_middleware rabbit_adapter: rabbit_adapter
+      subject.adapter :rabbit_adapter, name: 'Thumper'
+      expect { rabbit }.to_not output(
+        /warning: Using the last argument as keyword parameters is deprecated/
+      ).to_stderr
+      expect(rabbit.name).to eq('Thumper')
+    end
+  end
 end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -320,5 +320,13 @@ RSpec.describe Faraday::RackBuilder do
       ).to_stderr
       expect(rock.name).to eq('Stony')
     end
+
+    it 'adds a handler with options passed to insert_after' do
+      subject.insert_after 0, rock_handler, name: 'Rocky'
+      expect { rock }.to_not output(
+        /warning: Using the last argument as keyword parameters is deprecated/
+      ).to_stderr
+      expect(rock.name).to eq('Rocky')
+    end
   end
 end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe Faraday::RackBuilder do
     let(:rock_handler) do
       Class.new do
         attr_accessor :name
-        def initialize(app, name:)
+        def initialize(_app, name:)
           @name = name
         end
       end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -297,4 +297,28 @@ RSpec.describe Faraday::RackBuilder do
       expect(rabbit.name).to eq('Thumper')
     end
   end
+
+  context 'when handlers are directly added or updated' do
+    let(:conn) { Faraday::Connection.new {} }
+
+    let(:rock_handler) do
+      Class.new do
+        attr_accessor :name
+        def initialize(app, name:)
+          @name = name
+        end
+      end
+    end
+    let(:rock) do
+      subject.handlers.find { |handler| handler == rock_handler }.build
+    end
+
+    it 'adds a handler to construct adapter with options passed to insert' do
+      subject.insert 0, rock_handler, name: 'Stony'
+      expect { rock }.to_not output(
+        /warning: Using the last argument as keyword parameters is deprecated/
+      ).to_stderr
+      expect(rock.name).to eq('Stony')
+    end
+  end
 end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -197,18 +197,23 @@ RSpec.describe Faraday::RackBuilder do
   context 'when middleware is added with arguments' do
     let(:conn) { Faraday::Connection.new {} }
 
-    class Dog < Faraday::Middleware
-      attr_accessor :name
-      def initialize(app, name)
-        super(app)
-        @name = name
+    let(:dog_middleware_class) do
+      Class.new(Faraday::Middleware) do
+        attr_accessor :name
+        def initialize(app, name)
+          super(app)
+          @name = name
+        end
       end
     end
-    class Cat < Faraday::Middleware
-      attr_accessor :name
-      def initialize(app, name:)
-        super(app)
-        @name = name
+
+    let(:cat_middleware_class) do
+      Class.new(Faraday::Middleware) do
+        attr_accessor :name
+        def initialize(app, name:)
+          super(app)
+          @name = name
+        end
       end
     end
     it 'adds a handler to construct middleware with options passed to use' do

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -193,4 +193,29 @@ RSpec.describe Faraday::RackBuilder do
       end
     end
   end
+
+  context 'when middleware is added with arguments' do
+    let(:conn) { Faraday::Connection.new {} }
+
+    class Dog < Faraday::Middleware
+      attr_accessor :name
+      def initialize(app, name)
+        super(app)
+        @name = name
+      end
+    end
+    class Cat < Faraday::Middleware
+      attr_accessor :name
+      def initialize(app, name:)
+        super(app)
+        @name = name
+      end
+    end
+    it 'adds a handler to construct middleware with options passed to use' do
+      subject.use Dog, 'Rex'
+      expect(subject.handlers.find { |handler| handler == Dog }.build.name).to eq('Rex')
+      subject.use Cat, name: 'Felix'
+      expect(subject.handlers.find { |handler| handler == Cat }.build.name).to eq('Felix')
+    end
+  end
 end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -245,4 +245,30 @@ RSpec.describe Faraday::RackBuilder do
       expect(cat.name).to eq('Felix')
     end
   end
+
+  context 'when a response adapter is added with named arguments' do
+    let(:conn) { Faraday::Connection.new {} }
+
+    let(:fish_response) do
+      Class.new(Faraday::Response::Middleware) do
+        attr_accessor :name
+        def initialize(app, name:)
+          super(app)
+          @name = name
+        end
+      end
+    end
+    let(:fish) do
+      subject.handlers.find { |handler| handler == fish_response }.build
+    end
+
+    it 'adds a handler to construct response adapter with options passed to response' do
+      Faraday::Response.register_middleware fish_response: fish_response
+      subject.response :fish_response, name: 'Bubbles'
+      expect { fish }.to_not output(
+        /warning: Using the last argument as keyword parameters is deprecated/
+      ).to_stderr
+      expect(fish.name).to eq('Bubbles')
+    end
+  end
 end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Faraday::RackBuilder do
     let(:conn) { Faraday::Connection.new {} }
 
     let(:cat_request) do
-      Class.new(Faraday::Request) do
+      Class.new(Faraday::Middleware) do
         attr_accessor :name
         def initialize(app, name:)
           super(app)
@@ -236,7 +236,6 @@ RSpec.describe Faraday::RackBuilder do
     end
 
     it 'adds a handler to construct request adapter with options passed to request' do
-      skip 'still raising last argument kwarg deprecation warnings'
       Faraday::Request.register_middleware cat_request: cat_request
       subject.request :cat_request, name: 'Felix'
       expect { cat }.to_not output(

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Faraday::RackBuilder do
   context 'when middleware is added with arguments' do
     let(:conn) { Faraday::Connection.new {} }
 
-    let(:dog_middleware_class) do
+    let(:dog_middleware) do
       Class.new(Faraday::Middleware) do
         attr_accessor :name
         def initialize(app, name)
@@ -207,7 +207,7 @@ RSpec.describe Faraday::RackBuilder do
       end
     end
 
-    let(:cat_middleware_class) do
+    let(:cat_middleware) do
       Class.new(Faraday::Middleware) do
         attr_accessor :name
         def initialize(app, name:)
@@ -217,10 +217,10 @@ RSpec.describe Faraday::RackBuilder do
       end
     end
     it 'adds a handler to construct middleware with options passed to use' do
-      subject.use Dog, 'Rex'
-      expect(subject.handlers.find { |handler| handler == Dog }.build.name).to eq('Rex')
-      subject.use Cat, name: 'Felix'
-      expect(subject.handlers.find { |handler| handler == Cat }.build.name).to eq('Felix')
+      subject.use dog_middleware, 'Rex'
+      expect(subject.handlers.find { |handler| handler == dog_middleware }.build.name).to eq('Rex')
+      subject.use cat_middleware, name: 'Felix'
+      expect(subject.handlers.find { |handler| handler == cat_middleware }.build.name).to eq('Felix')
     end
   end
 end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -218,4 +218,31 @@ RSpec.describe Faraday::RackBuilder do
       expect(dog.name).to eq('Rex')
     end
   end
+
+  context 'when a request adapter is added with named arguments' do
+    let(:conn) { Faraday::Connection.new {} }
+
+    let(:cat_request) do
+      Class.new(Faraday::Request) do
+        attr_accessor :name
+        def initialize(app, name:)
+          super(app)
+          @name = name
+        end
+      end
+    end
+    let(:cat) do
+      subject.handlers.find { |handler| handler == cat_request }.build
+    end
+
+    it 'adds a handler to construct request adapter with options passed to request' do
+      skip 'still raising last argument kwarg deprecation warnings'
+      Faraday::Request.register_middleware cat_request: cat_request
+      subject.request :cat_request, name: 'Felix'
+      expect { cat }.to_not output(
+        /warning: Using the last argument as keyword parameters is deprecated/
+      ).to_stderr
+      expect(cat.name).to eq('Felix')
+    end
+  end
 end


### PR DESCRIPTION
This change marks the methods which construct user middleware, so they are called with the 2.6 keyword argument behaviour in 2.7 (and avoid printing a warning about it).

Some users add their own middleware & write their own constructors with named parameters, and use keyword arguments when adding their middleware to the builder:

```
class MyMiddleware < Faraday::Middleware
  def initialize(app, my_argument:)
    @app = app
    @my_argument = my_argument
  end

[...]

connection = Faraday.new() do |configuration|
  configuration.use MyMiddleware, my_argument: 'hello'
end
```

This works great in 2.6 & 2.7, but 2.7 prints a deprecation warning:
```
/Users/danielholz/.gem/ruby/2.7.0/gems/faraday-1.0.1/lib/faraday/dependency_loader.rb:21: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/danielholz/code/some_project/lib/some_project/faraday_middleware.rb:2: warning: The called method `initialize' is defined here
```
The warning is a bit frustrating, since the calling code is not in the user's code, so they cannot add `**` to the call. The best option for them is to change their middleware to accept a Hash as a positional parameter & pass a Hash when adding their middleware (and checking for required parameters themselves).

I tried an alternative to `ruby2_keywords` by adding an explicit `**kwargs` argument to `Faraday::RackBuilder#use`, `Faraday::RackBuilder#use_symbol`, `Faraday::RackBuilder::Handler#initialize`, and `Faraday::DependencyLoader#new`, but it hit the explicit delegation of keyword arguments issue (https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#why-deprecated) in 2.6.
