### PR TITLE
NetHttpPersistent: ConnectionError on OpenTimeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test, :development do
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
   gem 'multipart-parser'
-  gem 'net-http-persistent'
+  gem 'net-http-persistent', '~> 4.0'
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack', '< 2.1'
   gem 'rack-test', '>= 0.6', require: 'rack/test'

--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -53,6 +53,8 @@ module Faraday
         http.request env[:url], create_request(env)
       rescue Errno::ETIMEDOUT => e
         raise Faraday::TimeoutError, e
+      rescue Net::OpenTimeout => e
+        raise Faraday::ConnectionFailed, e
       rescue Net::HTTP::Persistent::Error => e
         raise Faraday::TimeoutError, e if e.message.include? 'Timeout'
 

--- a/spec/support/shared_examples/request_method.rb
+++ b/spec/support/shared_examples/request_method.rb
@@ -99,7 +99,7 @@ shared_examples 'a request method' do |http_method|
   it 'supports timeout option' do
     conn_options[:request] = { timeout: 1 }
     request_stub.to_timeout
-    exc = adapter == 'NetHttp' ? Faraday::ConnectionFailed : Faraday::TimeoutError
+    exc = %w[NetHttp NetHttpPersistent].include?(adapter) ? Faraday::ConnectionFailed : Faraday::TimeoutError
     expect { conn.public_send(http_method, '/') }.to raise_error(exc)
   end
 
@@ -108,7 +108,7 @@ shared_examples 'a request method' do |http_method|
   it 'supports open_timeout option' do
     conn_options[:request] = { open_timeout: 1 }
     request_stub.to_timeout
-    exc = adapter == 'NetHttp' ? Faraday::ConnectionFailed : Faraday::TimeoutError
+    exc = %w[NetHttp NetHttpPersistent].include?(adapter) ? Faraday::ConnectionFailed : Faraday::TimeoutError
     expect { conn.public_send(http_method, '/') }.to raise_error(exc)
   end
 


### PR DESCRIPTION
## Description

This PR adds a special-case from the net-http adapter to the net-http-persistent adapter.

[open timeout](https://rubyapi.org/2.7/o/net/opentimeout) was treated as a failure to connect, but our tests required it to be a timeout. Turns out, that was a call which was necessary before 4.0.0 of net-http-persistent.

[There was a 4.0 released of net-http-timeout.](https://github.com/drbrain/net-http-persistent/blob/master/History.txt)

This change fixes the build by reraising as ConnectionError, just like in Faraday's `net-http` adapter.

Fixes #1152 by making the build pass.

## Questions for reviewer

- The 4.0.0 release requires Ruby 2.5 (I think that it mentions the 2.4 going out of support as a reason to be able to let go of the exception handling it had in itself)
- This is a **breaking change** for this adapter