### PR TITLE
Rubocop linting with 0.84.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,8 @@ Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:
   Enabled: true
+Style/IfUnlessModifier:
+  Enabled: false
 
 Style/SlicingWithRange: # (0.83)
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,12 +13,24 @@ Metrics/BlockLength:
     - spec/**/*.rb
     - examples/**/*.rb
 
+Layout/EmptyLinesAroundAttributeAccessor: # (0.83)
+  Enabled: true
+
 Layout/LineLength:
   Exclude:
     - spec/**/*.rb
     - examples/**/*.rb
 
 Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant: # (0.84)
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
   Enabled: true
 
 Style/DoubleNegation:
@@ -38,7 +50,6 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: true
 
-Lint/RaiseException:
+Style/SlicingWithRange: # (0.83)
   Enabled: true
-Lint/StructNewOverride:
-  Enabled: true
+

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
 end
 
 group :lint, :development do
-  gem 'rubocop', '~> 0.82.0'
+  gem 'rubocop', '~> 0.84.0'
   gem 'rubocop-performance', '~> 1.0'
 end
 

--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -27,6 +27,7 @@ module Faraday
     # This module marks an Adapter as supporting parallel requests.
     module Parallelism
       attr_writer :supports_parallel
+
       def supports_parallel?
         @supports_parallel
       end

--- a/lib/faraday/utils/headers.rb
+++ b/lib/faraday/utils/headers.rb
@@ -114,7 +114,7 @@ module Faraday
         headers = header_string.split(/\r\n/)
 
         # Find the last set of response headers.
-        start_index = headers.rindex { |x| x.match(%r{^HTTP/}) } || 0
+        start_index = headers.rindex { |x| x.start_with?('HTTP/') } || 0
         last_response = headers.slice(start_index, headers.size)
 
         last_response

--- a/script/generate_certs
+++ b/script/generate_certs
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+
 # frozen_string_literal: true
 
 # Usage: generate_certs [options]
@@ -22,7 +23,7 @@ def create_self_signed_cert(bits, cname, _comment)
   cert.not_before = Time.now
   cert.not_after = Time.now + (365 * 24 * 60 * 60)
   cert.public_key = rsa.public_key
-  cert.sign(rsa, OpenSSL::Digest::SHA1.new)
+  cert.sign(rsa, OpenSSL::Digest.new('SHA1'))
   [cert, rsa]
 end
 

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -200,6 +200,7 @@ RSpec.describe Faraday::RackBuilder do
     let(:dog_middleware) do
       Class.new(Faraday::Middleware) do
         attr_accessor :name
+
         def initialize(app, name:)
           super(app)
           @name = name
@@ -225,6 +226,7 @@ RSpec.describe Faraday::RackBuilder do
     let(:cat_request) do
       Class.new(Faraday::Middleware) do
         attr_accessor :name
+
         def initialize(app, name:)
           super(app)
           @name = name
@@ -251,6 +253,7 @@ RSpec.describe Faraday::RackBuilder do
     let(:fish_response) do
       Class.new(Faraday::Response::Middleware) do
         attr_accessor :name
+
         def initialize(app, name:)
           super(app)
           @name = name
@@ -277,6 +280,7 @@ RSpec.describe Faraday::RackBuilder do
     let(:rabbit_adapter) do
       Class.new(Faraday::Adapter) do
         attr_accessor :name
+
         def initialize(app, name:)
           super(app)
           @name = name
@@ -303,6 +307,7 @@ RSpec.describe Faraday::RackBuilder do
     let(:rock_handler) do
       Class.new do
         attr_accessor :name
+
         def initialize(_app, name:)
           @name = name
         end


### PR DESCRIPTION
## Description

This PR tries to get our linting to not fail on existing code with [the latest version of the RuboCop tool](https://github.com/rubocop-hq/rubocop/releases/tag/v0.84.0).


## Todos

If any additional rules, tweaks to this come up, please make a comment, or a PR.


