### PR TITLE
Refactor parameter sorting

### DIFF
--- a/lib/faraday/encoders/flat_params_encoder.rb
+++ b/lib/faraday/encoders/flat_params_encoder.rb
@@ -35,7 +35,7 @@ module Faraday
         end
         # Useful default for OAuth and caching.
         # Only to be used for non-Array inputs. Arrays should preserve order.
-        params.sort!
+        params.sort! if @sort_params
       end
 
       # The params have form [['key1', 'value1'], ['key2', 'value2']].
@@ -94,5 +94,11 @@ module Faraday
         end
       end
     end
+
+    class << self
+      attr_accessor :sort_params
+    end
   end
+
+  FlatParamsEncoder.sort_params = true
 end

--- a/lib/faraday/encoders/flat_params_encoder.rb
+++ b/lib/faraday/encoders/flat_params_encoder.rb
@@ -33,7 +33,7 @@ module Faraday
           key = key.to_s if key.is_a?(Symbol)
           [key, value]
         end
-        # Useful default for OAuth and caching.
+
         # Only to be used for non-Array inputs. Arrays should preserve order.
         params.sort! if @sort_params
       end
@@ -98,7 +98,8 @@ module Faraday
     class << self
       attr_accessor :sort_params
     end
-  end
 
-  FlatParamsEncoder.sort_params = true
+    # Useful default for OAuth and caching.
+    @sort_params = true
+  end
 end

--- a/lib/faraday/encoders/nested_params_encoder.rb
+++ b/lib/faraday/encoders/nested_params_encoder.rb
@@ -21,7 +21,7 @@ module Faraday
           key = key.to_s if key.is_a?(Symbol)
           [key, value]
         end
-        # Useful default for OAuth and caching.
+
         # Only to be used for non-Array inputs. Arrays should preserve order.
         params.sort! if @sort_params
       end
@@ -167,9 +167,10 @@ module Faraday
       def_delegators :'Faraday::Utils', :escape, :unescape
     end
 
+    # Useful default for OAuth and caching.
+    @sort_params = true
+
     extend EncodeMethods
     extend DecodeMethods
   end
-
-  NestedParamsEncoder.sort_params = true
 end

--- a/lib/faraday/encoders/nested_params_encoder.rb
+++ b/lib/faraday/encoders/nested_params_encoder.rb
@@ -23,7 +23,7 @@ module Faraday
         end
         # Useful default for OAuth and caching.
         # Only to be used for non-Array inputs. Arrays should preserve order.
-        params.sort!
+        params.sort! if @sort_params
       end
 
       # The params have form [['key1', 'value1'], ['key2', 'value2']].
@@ -161,6 +161,8 @@ module Faraday
   # for your requests.
   module NestedParamsEncoder
     class << self
+      attr_accessor :sort_params
+
       extend Forwardable
       def_delegators :'Faraday::Utils', :escape, :unescape
     end
@@ -168,4 +170,6 @@ module Faraday
     extend EncodeMethods
     extend DecodeMethods
   end
+
+  NestedParamsEncoder.sort_params = true
 end

--- a/spec/faraday/params_encoders/flat_spec.rb
+++ b/spec/faraday/params_encoders/flat_spec.rb
@@ -31,4 +31,12 @@ RSpec.describe Faraday::FlatParamsEncoder do
     params = { a: [] }
     expect(subject.encode(params)).to eq('a=')
   end
+
+  it 'encodes unsorted when asked' do
+    params = { b: false, a: true }
+    expect(subject.encode(params)).to eq('a=true&b=false')
+    Faraday::FlatParamsEncoder.sort_params = false
+    expect(subject.encode(params)).to eq('b=false&a=true')
+    Faraday::FlatParamsEncoder.sort_params = true
+  end
 end

--- a/spec/faraday/params_encoders/nested_spec.rb
+++ b/spec/faraday/params_encoders/nested_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe Faraday::NestedParamsEncoder do
     expect(subject.encode(params)).to eq('a%5B%5D=true&a%5B%5D=false')
   end
 
+  it 'encodes unsorted when asked' do
+    params = { b: false, a: true }
+    expect(subject.encode(params)).to eq('a=true&b=false')
+    Faraday::NestedParamsEncoder.sort_params = false
+    expect(subject.encode(params)).to eq('b=false&a=true')
+    Faraday::NestedParamsEncoder.sort_params = true
+  end
+
   shared_examples 'a wrong decoding' do
     it do
       expect { subject.decode(query) }.to raise_error(TypeError) do |e|


### PR DESCRIPTION
## Description
This is a quasi-second attempt at #469 which respects the comment in it https://github.com/lostisland/faraday/pull/469#issuecomment-81458828

As opposed to adding any new options - this simply moves the sort call into a method which can be overridden as opposed to requiring the "cut and paste" of the standard modules into a custom module.

So with this patch one can accomplish no param sorting by simply adding


```
module Faraday
  module NestedParamsEncoder
    def self.sort_params(_); end
  end

  module FlatParamsEncoder
    def self.sort_params(_); end
  end
end
```


To their code, because sort_params can be overridden.

Again, I completely respect the desire to keep it clean - I'm just wondering if this slight refactor would be ok.