### PR TITLE
Trivial refactor: Range is guaranteed to be immutable

### DIFF
--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -6,8 +6,8 @@ module Faraday
     # client or server error responses.
     class RaiseError < Middleware
       # rubocop:disable Naming/ConstantName
-      ClientErrorStatuses = (400...500).freeze
-      ServerErrorStatuses = (500...600).freeze
+      ClientErrorStatuses = (400...500)
+      ServerErrorStatuses = (500...600)
       # rubocop:enable Naming/ConstantName
 
       def on_complete(env)


### PR DESCRIPTION
* https://github.com/ruby/ruby/blob/8900a25581822759daca528d46a75e0b743fc22e/range.c#L76

## Description

Refactor internal implementation details to be less confusing and easier to maintain for future by removing unnecessary code and simplifying.

## Todos

N/A

## Additional Notes

According to the git blame, it seems to have been added when rubocop suggested don't use mutable values for constant. Since these values had been already immutable, we should have kept that unchanged actually :)