### PR TITLE
Handle verify_hostname in SSLOption

### DIFF
--- a/lib/faraday/adapter/excon.rb
+++ b/lib/faraday/adapter/excon.rb
@@ -48,6 +48,11 @@ module Faraday
         env[:body].respond_to?(:read) ? env[:body].read : env[:body]
       end
 
+      # To be public for tests.
+      def handles_ssl_verify_hostname?
+        Gem::Version.new(::Excon::VERSION) >= Gem::Version.new('0.76.0')
+      end
+
       private
 
       def opts_from_env(env)
@@ -83,6 +88,10 @@ module Faraday
         # https://github.com/geemus/excon/issues/106
         # https://github.com/jruby/jruby-ossl/issues/19
         opts[:nonblock] = false
+        # https://github.com/excon/excon/pull/722
+        if handles_ssl_verify_hostname?
+          opts[:ssl_verify_hostname] = !!ssl.fetch(:verify_hostname, false)
+        end
 
         OPTS_KEYS.each do |(key_in_opts, key_in_ssl)|
           next unless ssl[key_in_ssl]

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -174,6 +174,7 @@ module Faraday
         http.ssl_version = ssl[:version] if ssl[:version]
         http.min_version = ssl[:min_version] if ssl[:min_version]
         http.max_version = ssl[:max_version] if ssl[:max_version]
+        http.verify_hostname = ssl[:verify_hostname] if http.respond_to?(:verify_hostname=) && ssl[:verify_hostname]
       end
 
       def configure_request(http, req)

--- a/lib/faraday/options/ssl_options.rb
+++ b/lib/faraday/options/ssl_options.rb
@@ -6,6 +6,10 @@ module Faraday
   # @!attribute verify
   #   @return [Boolean] whether to verify SSL certificates or not
   #
+  # @!attribute verify_hostname
+  #   @return [Boolean] whether to enable hostname verification on server certificates
+  #           during the handshake or not (see https://github.com/ruby/openssl/pull/60)
+  #
   # @!attribute ca_file
   #   @return [String] CA file
   #
@@ -41,7 +45,8 @@ module Faraday
   #
   # @!attribute max_version
   #   @return [String, Symbol] maximum SSL version (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-max_version-3D)
-  class SSLOptions < Options.new(:verify, :ca_file, :ca_path, :verify_mode,
+  class SSLOptions < Options.new(:verify, :verify_hostname,
+                                 :ca_file, :ca_path, :verify_mode,
                                  :cert_store, :client_cert, :client_key,
                                  :certificate, :private_key, :verify_depth,
                                  :version, :min_version, :max_version)
@@ -54,6 +59,11 @@ module Faraday
     # @return [Boolean] true if should not verify
     def disable?
       !verify?
+    end
+
+    # @return [Boolean] true if should verify_hostname
+    def verify_hostname?
+      verify_hostname != false
     end
   end
 end

--- a/spec/faraday/adapter/excon_spec.rb
+++ b/spec/faraday/adapter/excon_spec.rb
@@ -3,7 +3,24 @@
 RSpec.describe Faraday::Adapter::Excon do
   features :request_body_on_query_methods, :reason_phrase_parse, :trace_method
 
-  it_behaves_like 'an adapter'
+  context 'without verify_hostname' do
+    it_behaves_like 'an adapter'
+  end
+
+  context 'with verify_hostname' do
+    before do
+      c = described_class.new
+      unless c.handles_ssl_verify_hostname?
+        request_stub.disable
+        skip 'Using excon gem does not support verify_hostname attributes'
+      end
+      ENV['SSL_VERIFY_HOSTNAME'] = 'yes'
+    end
+
+    after { ENV['SSL_VERIFY_HOSTNAME'] = 'no' }
+
+    it_behaves_like 'an adapter'
+  end
 
   it 'allows to provide adapter specific configs' do
     url = URI('https://example.com:1234')

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -3,7 +3,24 @@
 RSpec.describe Faraday::Adapter::NetHttp do
   features :request_body_on_query_methods, :reason_phrase_parse, :compression, :streaming, :trace_method
 
-  it_behaves_like 'an adapter'
+  context 'without verify_hostname' do
+    it_behaves_like 'an adapter'
+  end
+
+  context 'with verify_hostname' do
+    before do
+      c = Net::HTTP.new('localhost')
+      unless c.respond_to?(:verify_hostname=)
+        request_stub.disable
+        skip 'Using net/http gem does not support verify_hostname attributes'
+      end
+      ENV['SSL_VERIFY_HOSTNAME'] = 'yes'
+    end
+
+    after { ENV['SSL_VERIFY_HOSTNAME'] = 'no' }
+
+    it_behaves_like 'an adapter'
+  end
 
   context 'checking http' do
     let(:url) { URI('http://example.com') }

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -108,6 +108,12 @@ RSpec.describe Faraday::Connection do
       it { expect(subject.ssl.verify?).to be_falsey }
     end
 
+    context 'with verify_hostname false' do
+      let(:options) { { ssl: { verify_hostname: false } } }
+
+      it { expect(subject.ssl.verify_hostname?).to be_falsey }
+    end
+
     context 'with empty block' do
       let(:conn) { Faraday::Connection.new {} }
 

--- a/spec/faraday/options/env_spec.rb
+++ b/spec/faraday/options/env_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Faraday::Env do
   it 'handle verify_hostname when fetching' do
     ssl = Faraday::SSLOptions.new
     ssl.verify_hostname = true
-    expect(ssl.fetch(:verify_hostname, true)).to be_truthy
+    expect(ssl.fetch(:verify_hostname, false)).to be_truthy
   end
 
   it 'retains custom members' do

--- a/spec/faraday/options/env_spec.rb
+++ b/spec/faraday/options/env_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Faraday::Env do
     expect(ssl.fetch(:verify, true)).to be_falsey
   end
 
+  it 'handle verify_hostname when fetching' do
+    ssl = Faraday::SSLOptions.new
+    ssl.verify_hostname = true
+    expect(ssl.fetch(:verify_hostname, true)).to be_truthy
+  end
+
   it 'retains custom members' do
     env[:foo] = 'custom 1'
     env[:bar] = :custom_2

--- a/spec/faraday/request_spec.rb
+++ b/spec/faraday/request_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Faraday::Request do
   context 'when nothing particular is configured' do
     it { expect(subject.http_method).to eq(:get) }
     it { expect(subject.to_env(conn).ssl.verify).to be_falsey }
+    it { expect(subject.to_env(conn).ssl.verify_hostname).to be_falsey }
   end
 
   context 'when HTTP method is post' do

--- a/spec/support/shared_examples/adapter.rb
+++ b/spec/support/shared_examples/adapter.rb
@@ -37,6 +37,7 @@ shared_examples 'adapter examples' do |**options|
   let(:conn) do
     conn_options[:ssl] ||= {}
     conn_options[:ssl][:ca_file] ||= ENV['SSL_FILE']
+    conn_options[:ssl][:verify_hostname] ||= ENV['SSL_VERIFY_HOSTNAME'] == 'yes'
 
     Faraday.new(remote, conn_options) do |conn|
       conn.request :multipart


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

## Description
This had been introduced in CRuby's openssl v2.0.0.
And it has been bundled since CRuby 2.4.

ref: https://docs.ruby-lang.org/en/2.4.0/NEWS.html


## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests
- [ ] Documentation
- [ ] Handle verify_hostname at least net/http and excon adapters 

## Additional Notes

fluent-plugin-elasticserach wants to handle verify_hostname option to handle wildcard certificate. But, without this option, ES plugin complains `does not match the server certificate (OpenSSL::SSL::SSLError)` error and fills up these errors in log. See: https://github.com/uken/fluent-plugin-elasticsearch/issues/770#issuecomment-658807393
