### PR TITLE
Include request info in exceptions raised by RaiseError Middleware

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -38,6 +38,14 @@ module Faraday
     #              :headers - String key/value hash of HTTP response header
     #                         values.
     #              :body    - Optional string HTTP response body.
+    #              :request - Hash
+    #                           :method   - Symbol with the request HTTP method.
+    #                           :url_path - String with the url path requested.
+    #                           :params   - String key/value hash of query params
+    #                                     present in the request.
+    #                           :headers  - String key/value hash of HTTP request
+    #                                     header values.
+    #                           :body     - String HTTP request body.
     #
     # If a subclass has to call this, then it should pass a string message
     # to `super`. See NilStatusError.

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -38,7 +38,18 @@ module Faraday
       end
 
       def response_values(env)
-        { status: env.status, headers: env.response_headers, body: env.body }
+        {
+          status: env.status,
+          headers: env.response_headers,
+          body: env.body,
+          request: {
+            method: env.method,
+            url_path: env.url.path,
+            params: env.params,
+            headers: env.request_headers,
+            body: env.request_body
+          }
+        }
       end
     end
   end


### PR DESCRIPTION
## Description
When using the `RaiseError` middleware, the error raised contains only information about the response. This should not be a problem if we had just made a single request, or if we caught the error close to where it was raised, so that we can know for sure what the problematic request was. But things can get more tricky if the request was made along with other ones, or as part of a batch process.
When using an error tracker, it's very important to track as much information as we can about the error, so having information about the request as well as the response is critical.
Thus, considering that it would also be very easy for the middleware to include that information, I think it would be a very handy addition. 
