### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 require:
+  - rubocop-packaging
   - rubocop-performance
 
 AllCops:

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 
 group :lint, :development do
   gem 'rubocop', '~> 0.90.0'
-  gem 'rubocop-packaging', '~> 0.4'
+  gem 'rubocop-packaging', '~> 0.5'
   gem 'rubocop-performance', '~> 1.0'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ end
 
 group :lint, :development do
   gem 'rubocop', '~> 0.90.0'
+  gem 'rubocop-packaging', '~> 0.4'
   gem 'rubocop-performance', '~> 1.0'
 end
 

--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
   spec.add_dependency 'ruby2_keywords'
 
-  files = %w[CHANGELOG.md LICENSE.md README.md Rakefile examples lib spec]
-  spec.files = `git ls-files -z #{files.join(' ')}`.split("\0")
+  spec.files = Dir['CHANGELOG.md', '{examples,lib,spec}/**/*', 'LICENSE.md', 'Rakefile', 'README.md']
   spec.require_paths = %w[lib spec/external_adapters]
   spec.metadata = {
     'homepage_uri' => 'https://lostisland.github.io/faraday',


### PR DESCRIPTION
Hi @iMacTia,

Thanks for your work on this!

Whilst maintaining this in Debian, we found that this library relies on `git` to produce a list of files. Using git in gemspec files in problematic, in general.

It also adds the Packaging extension of RuboCop.
More about it can be found on https://docs.rubocop.org/rubocop-packaging/

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>