### PR TITLE
Remove retry_change_requests from documentation

### DIFF
--- a/docs/adapters/net_http_persistent.md
+++ b/docs/adapters/net_http_persistent.md
@@ -14,7 +14,6 @@ conn = Faraday.new(...) do |f|
   f.adapter :net_http_persistent, pool_size: 5 do |http|
     # yields Net::HTTP::Persistent
     http.idle_timeout = 100
-    http.retry_change_requests = true
   end
 end
 ```


### PR DESCRIPTION
## Description
The net-http-persistent gem removed the #retry_change_requests adapter configuration with https://github.com/drbrain/net-http-persistent/pull/100 in v4.0.0.
