### PR TITLE
Do not package examples and specs in builds

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
   spec.add_dependency 'ruby2_keywords'
 
-  spec.files = Dir['CHANGELOG.md', '{examples,lib,spec}/**/*', 'LICENSE.md', 'Rakefile', 'README.md']
+  spec.files = Dir['CHANGELOG.md', 'lib/**/*', 'LICENSE.md', 'Rakefile', 'README.md']
   spec.require_paths = %w[lib spec/external_adapters]
   spec.metadata = {
     'homepage_uri' => 'https://lostisland.github.io/faraday',


### PR DESCRIPTION
## Description
It's common practice to only include production code in Rubygem builds. The default behavior of Bundler, for example, is to [ignore "test|spec|features"](https://github.com/rubygems/rubygems/blob/61447f3f1b19390a128d0239d0cbea250e265ae6/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt#L28) when capturing files to include in the builds.

After the #1183 PR in the 1.1.0 release, I noticed this was not being done – not that the PR changed the previous behavior, mind you – and that test files are being unnecessarily included in the released builds.

This PR removes examples and spec files from the Rubygems build.