### PR TITLE
CI: add "head" Ruby to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7']
+        ruby: ['2.4', '2.5', '2.6', '2.7', 'head']
 
     steps:
     - uses: actions/checkout@v1

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :test, :development do
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
   gem 'multipart-parser'
-  gem 'net-http-persistent', '~> 3.0'
+  gem 'net-http-persistent', '>= 3.0' # Ruby 3 requires 4.0.0+
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :test, :development do
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
   gem 'multipart-parser'
-  gem 'net-http-persistent', '>= 3.0' # Ruby 3 requires 4.0.0+
+  gem 'net-http-persistent', RUBY_VERSION.start_with?('3') ? '~> 4.0' : '~> 3.0' # Ruby 3 requires 4.0.0+
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,8 @@ group :test, :development do
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
   gem 'multipart-parser'
-  gem 'net-http-persistent', RUBY_VERSION.start_with?('3') ? '~> 4.0' : '~> 3.0' # Ruby 3 requires 4.0.0+
+  # This does not currently work, since there's no .gemspec file in the repo:
+  gem 'net-http-persistent', (RUBY_VERSION.start_with?('3') ? '>= 3.0' : '~> 3.0'), **(RUBY_VERSION.start_with?('3') ? { github: 'drbrain/net-http-persistent' } : {})
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'


### PR DESCRIPTION
## Description

Fixes #1189 by adding Ruby 3 (aka "head") to build matrix.


<img width="880" alt="bild" src="https://user-images.githubusercontent.com/211/96681791-20aacd80-1378-11eb-801a-eeacad195ca2.png">


## TODO

- fix this: https://github.com/drbrain/net-http-persistent has a v4.0.0 – which includes support for Ruby 3.

```
Resolving dependencies...
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    Ruby (~> 3.0.0.0) java
    net-http-persistent (~> 3.0) java was resolved to 3.1.0, which depends on
      Ruby (~> 2.1)
Error: Process completed with exit code 6.
```