### PR TITLE
Add comment in gemspec to explain exposure of `examples` and `spec` folders.

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
   spec.add_dependency 'ruby2_keywords'
 
+  # Includes `examples` and `spec` to allow external adapter gems to run Faraday unit and integration tests
   spec.files = Dir['CHANGELOG.md', '{examples,lib,spec}/**/*', 'LICENSE.md', 'Rakefile', 'README.md']
   spec.require_paths = %w[lib spec/external_adapters]
   spec.metadata = {


### PR DESCRIPTION
## Description
Add comment in gemspec to explain exposure of `examples` and `spec` folders.
Fixes #1190 