### PR TITLE
Adjust the retry documentation and spec to align with implementation

### DIFF
--- a/docs/middleware/request/retry.md
+++ b/docs/middleware/request/retry.md
@@ -21,7 +21,7 @@ The middleware can also handle the [`Retry-After`](https://developer.mozilla.org
 ### Example Usage
 
 This example will result in a first interval that is random between 0.05 and 0.075
-and a second interval that is random between 0.1 and 0.15.
+and a second interval that is random between 0.1 and 0.125.
 
 ```ruby
 retry_options = {

--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -21,7 +21,7 @@ module Faraday
     #   end
     #
     # This example will result in a first interval that is random between 0.05
-    # and 0.075 and a second interval that is random between 0.1 and 0.15.
+    # and 0.075 and a second interval that is random between 0.1 and 0.125.
     class Retry < Faraday::Middleware
       DEFAULT_EXCEPTIONS = [
         Errno::ETIMEDOUT, 'Timeout::Error',

--- a/spec/faraday/request/retry_spec.rb
+++ b/spec/faraday/request/retry_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Faraday::Request::Retry do
       let(:options) { { max: 2, interval: 0.1, interval_randomness: 0.05 } }
       let(:middleware) { Faraday::Request::Retry.new(nil, options) }
 
-      it { expect(middleware.send(:calculate_retry_interval, 2)).to be_between(0.1, 0.15) }
+      it { expect(middleware.send(:calculate_retry_interval, 2)).to be_between(0.1, 0.105) }
     end
   end
 


### PR DESCRIPTION
## Description
Fixes #1197 

The documentation on the range for the second retry iteration is a bit off and the spec related to the retry is as well. This PR corrects that.

