### PR TITLE
Fix infinite recursion and NameError on load when running with `-rdebug`

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -115,9 +115,7 @@ module Faraday
       # When running under debugger with a breakpoint set,
       # self.to_str is called repeatedly during module load,
       # including the time before the default_connection getter below is loaded
-      if name == :default_connection
-        return nil
-      end
+      return nil if name == :default_connection
 
       if default_connection.respond_to?(name)
         default_connection.send(name, *args, &block)
@@ -146,9 +144,7 @@ module Faraday
     # self.to_str is called repeatedly during module load,
     # including the time after this getter is loaded but
     # before the libs delay-loading below fires
-    unless const_defined?(:Connection)
-      return nil
-    end
+    return nil unless const_defined?(:Connection)
 
     @default_connection ||= Connection.new(default_connection_options)
   end


### PR DESCRIPTION
## Description
Fixes https://github.com/lostisland/faraday/issues/1107

When running with `ruby -rdebug` with a breakpoint set, `self.to_str` (which is not defined) is called repeatedly during module load, including the time after the `class << self` block is loaded but before further blocks that add more bits to `self` are.
As such, the dynamic method resolution machinery has to not break in this partially initialized state.

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
If this needs to be autotested, some pointers would be welcome: I've no idea how to load the module under test in a separate Ruby invocation from within RSpec.
- [ ] Documentation
