### PR TITLE
Require 'date' to avoid retry exception

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'cgi'
+require 'date'
 require 'set'
 require 'forwardable'
 require 'faraday/middleware_registry'


### PR DESCRIPTION
Without requiring 'date', we get an exception in the retry middleware
when it tries to use DateTime for handling the Retry-After header.

## Description

This simple script can be used to reproduce the bug:

```ruby
#!/usr/bin/env ruby

require 'faraday'

conn = Faraday.new('https://amazon.com') do |f|
  f.request :retry, {
    retry_statuses: [301],
    max: 1,
    interval: 1.0,
    backoff_factor: 2
  }
end

conn.get('gp/css/order-history')
```

The fix is to simply add a require for Ruby's `date` library so we don't get an exception during retries.

I'm not certain this warrants a spec change (or if that'd even be possible?) but please let me know!