### PR TITLE
test against ruby head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,15 @@ jobs:
   build:
     needs: [linting]
     runs-on: ubuntu-latest
+    name: build ${{ matrix.ruby }}
     strategy:
+      fail-fast: false
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7', 'head']
+        ruby: ['2.4', '2.5', '2.6', '2.7']
+        experimental: [false]
+        include:
+        - ruby: head
+          experimental: true
 
     steps:
     - uses: actions/checkout@v1
@@ -49,11 +55,9 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
 
-
     - name: Install dependencies
       run: |
         sudo apt-get install libcurl4-openssl-dev
-
 
     - name: Build
       run: |
@@ -62,6 +66,6 @@ jobs:
         bundle install --jobs 4 --retry 3
 
     - name: Test
-      run: |
-        bundle exec rake
+      continue-on-error: ${{ matrix.experimental }}
+      run: bundle exec rake
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7']
+        ruby: ['2.4', '2.5', '2.6', '2.7', 'head']
 
     steps:
     - uses: actions/checkout@v1

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :test, :development do
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
   gem 'multipart-parser'
-  gem 'net-http-persistent', '~> 3.0'
+  gem 'net-http-persistent', '>= 3.0' # Ruby 3 requires 4.0.0+
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'

--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,9 @@ group :test, :development do
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
   gem 'multipart-parser'
-  # This does not currently work, since there's no .gemspec file in the repo:
-  gem 'net-http-persistent', (RUBY_VERSION.start_with?('3') ? '>= 3.0' : '~> 3.0'), **(RUBY_VERSION.start_with?('3') ? { github: 'drbrain/net-http-persistent' } : {})
+  # TODO: remove this once v4 is released
+  options = (RUBY_VERSION.start_with?('3') ? { github: 'grosser/net-http-persistent', branch: 'grosser/spec' } : {})
+  gem 'net-http-persistent', (RUBY_VERSION.start_with?('3') ? '>= 3.0' : '~> 3.0'), **options
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :test, :development do
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
   gem 'multipart-parser'
-  gem 'net-http-persistent', '>= 3.0' # Ruby 3 requires 4.0.0+
+  gem 'net-http-persistent', RUBY_VERSION.start_with?('3') ? '~> 4.0' : '~> 3.0' # Ruby 3 requires 4.0.0+
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,8 @@ group :test, :development do
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
   gem 'multipart-parser'
-  gem 'net-http-persistent', RUBY_VERSION.start_with?('3') ? '~> 4.0' : '~> 3.0' # Ruby 3 requires 4.0.0+
+  # This does not currently work, since there's no .gemspec file in the repo:
+  gem 'net-http-persistent', (RUBY_VERSION.start_with?('3') ? '>= 3.0' : '~> 3.0'), **(RUBY_VERSION.start_with?('3') ? { github: 'drbrain/net-http-persistent' } : {})
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'


### PR DESCRIPTION
Fixes #1189
replaces https://github.com/lostisland/faraday/pull/1191

net-http-persistent does not support gemspec builds, so using a branch, see https://github.com/drbrain/net-http-persistent/pull/101