### PR TITLE
avoid 1 use of keyword hackery

### DIFF
--- a/lib/faraday/dependency_loader.rb
+++ b/lib/faraday/dependency_loader.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ruby2_keywords'
-
 module Faraday
   # DependencyLoader helps Faraday adapters and middleware load dependencies.
   module DependencyLoader
@@ -15,7 +13,7 @@ module Faraday
       self.load_error = e
     end
 
-    ruby2_keywords def new(*)
+    def new(*)
       unless loaded?
         raise "missing dependency for #{self}: #{load_error.message}"
       end


### PR DESCRIPTION
based on https://github.com/lostisland/faraday/pull/1208
https://github.com/lostisland/faraday/pull/1209 has some funky errors, but this change at least seems to work on old and new ruby alike