### PR TITLE
EmHttp adapter: drop superfluous loaded? check

### DIFF
--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -93,17 +93,15 @@ module Faraday
       dependency do
         require 'em-http'
 
-        if Faraday::Adapter::EMHttp.loaded?
-          begin
-            require 'openssl'
-          rescue LoadError
-            warn 'Warning: no such file to load -- openssl. ' \
-              'Make sure it is installed if you want HTTPS support'
-          else
-            require 'em-http/version'
-            if EventMachine::HttpRequest::VERSION < '1.1.6'
-              require 'faraday/adapter/em_http_ssl_patch'
-            end
+        begin
+          require 'openssl'
+        rescue LoadError
+          warn 'Warning: no such file to load -- openssl. ' \
+            'Make sure it is installed if you want HTTPS support'
+        else
+          require 'em-http/version'
+          if EventMachine::HttpRequest::VERSION < '1.1.6'
+            require 'faraday/adapter/em_http_ssl_patch'
           end
         end
       end


### PR DESCRIPTION
This PR removes a conditional, which is always truthy.

## Description

This PR removes a check that I think is superfluous at this point 

We are loaded in this section, and loaded meant "has no load errors".

Follow-up of #1202. 

## Todos

Review.

