### PR TITLE
Fix #1219 Net::HTTP still uses env proxy

### DIFF
--- a/spec/support/shared_examples/adapter.rb
+++ b/spec/support/shared_examples/adapter.rb
@@ -33,6 +33,7 @@ shared_examples 'adapter examples' do |**options|
 
   let(:protocol) { ssl_mode? ? 'https' : 'http' }
   let(:remote) { "#{protocol}://example.com" }
+  let(:stub_remote) { remote }
 
   let(:conn) do
     conn_options[:ssl] ||= {}
@@ -46,7 +47,7 @@ shared_examples 'adapter examples' do |**options|
     end
   end
 
-  let!(:request_stub) { stub_request(http_method, remote) }
+  let!(:request_stub) { stub_request(http_method, stub_remote) }
 
   after do
     expect(request_stub).to have_been_requested unless request_stub.disabled?

--- a/spec/support/shared_examples/request_method.rb
+++ b/spec/support/shared_examples/request_method.rb
@@ -3,6 +3,7 @@
 shared_examples 'proxy examples' do
   it 'handles requests with proxy' do
     res = conn.public_send(http_method, '/')
+
     expect(res.status).to eq(200)
   end
 
@@ -233,7 +234,7 @@ shared_examples 'a request method' do |http_method|
 
   context 'when a proxy is provided as option' do
     before do
-      conn_options[:proxy] = 'http://google.co.uk'
+      conn_options[:proxy] = 'http://env-proxy.com:80'
     end
 
     include_examples 'proxy examples'


### PR DESCRIPTION
## Description
Ensures that the `proxy_address` is passed as `nil` to `Net::HTTP` to avoid that it picks the one from the environment.
Also, since Net::HTTP::Proxy is obsolete (https://ruby-doc.org/stdlib-2.3.2/libdoc/net/http/rdoc/Net/HTTP.html#method-c-Proxy), it has now been replaced with a different call to `.new`.
Fixes #1219