### PR TITLE
Don't assign to ::Timer

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -9,7 +9,7 @@ require 'faraday/dependency_loader'
 
 unless defined?(::Faraday::Timer)
   require 'timeout'
-  Timer = Timeout
+  ::Faraday::Timer = Timeout
 end
 
 require 'faraday/version'


### PR DESCRIPTION
## Description
The change in 1595e6fc moved the definition of Timer out of the Faraday module definition so that it was being defined in the root namespace. I don't think that was the intention of #1205 where that patch was introduced.

This changes the definition from `::Timer` to `::Faraday::Timer`.

I discovered this when a separately defined `::Timer` in my app was overridden in Faraday v1.2.0
