### PR TITLE
Fix broken Rubydoc.info links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ But before you start coding, please read our [Contributing Guide][contributing]
 [website]:      https://lostisland.github.io/faraday
 [faraday_team]: https://lostisland.github.io/faraday/team
 [contributing]: https://github.com/lostisland/faraday/blob/master/.github/CONTRIBUTING.md
-[apidoc]:       http://www.rubydoc.info/gems/faraday
+[apidoc]:       https://www.rubydoc.info/github/lostisland/faraday
 [actions]:      https://github.com/lostisland/faraday/actions
 [jruby]:        http://jruby.org/
 [rubinius]:     http://rubini.us/

--- a/docs/adapters/em-http.md
+++ b/docs/adapters/em-http.md
@@ -24,4 +24,4 @@ end
 
 [rdoc]: https://www.rubydoc.info/gems/em-http-request
 [src]: https://github.com/igrigorik/em-http-request#readme
-[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/EMHttp
+[adapter_rdoc]: https://www.rubydoc.info/github/lostisland/faraday/Faraday/Adapter/EMHttp

--- a/docs/adapters/em-synchrony.md
+++ b/docs/adapters/em-synchrony.md
@@ -25,4 +25,4 @@ end
 
 [rdoc]: https://www.rubydoc.info/gems/em-synchrony
 [src]: https://github.com/igrigorik/em-synchrony
-[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/EMSynchrony
+[adapter_rdoc]: https://www.rubydoc.info/github/lostisland/faraday/Faraday/Adapter/EMSynchrony

--- a/docs/adapters/excon.md
+++ b/docs/adapters/excon.md
@@ -24,4 +24,4 @@ end
 
 [rdoc]: https://www.rubydoc.info/gems/excon
 [src]: https://github.com/excon/excon
-[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/Excon
+[adapter_rdoc]: https://www.rubydoc.info/github/lostisland/faraday/Faraday/Adapter/Excon

--- a/docs/adapters/httpclient.md
+++ b/docs/adapters/httpclient.md
@@ -27,4 +27,4 @@ end
 
 [rdoc]: https://www.rubydoc.info/gems/httpclient
 [src]: https://github.com/nahi/httpclient
-[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/HTTPClient
+[adapter_rdoc]: https://www.rubydoc.info/github/lostisland/faraday/Faraday/Adapter/HTTPClient

--- a/docs/adapters/net_http.md
+++ b/docs/adapters/net_http.md
@@ -28,4 +28,4 @@ end
 * [Adapter RDoc][adapter_rdoc]
 
 [rdoc]: http://ruby-doc.org/stdlib/libdoc/net/http/rdoc/Net/HTTP.html
-[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/NetHttp
+[adapter_rdoc]: https://www.rubydoc.info/github/lostisland/faraday/Faraday/Adapter/NetHttp

--- a/docs/adapters/net_http_persistent.md
+++ b/docs/adapters/net_http_persistent.md
@@ -26,4 +26,4 @@ end
 
 [rdoc]: https://www.rubydoc.info/gems/net-http-persistent
 [src]: https://github.com/drbrain/net-http-persistent
-[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/NetHttpPersistent
+[adapter_rdoc]: https://www.rubydoc.info/github/lostisland/faraday/Faraday/Adapter/NetHttpPersistent

--- a/docs/adapters/patron.md
+++ b/docs/adapters/patron.md
@@ -26,4 +26,4 @@ end
 
 [rdoc]: https://www.rubydoc.info/gems/patron
 [src]: https://github.com/toland/patron
-[adapter_rdoc]: https://www.rubydoc.info/gems/faraday/Faraday/Adapter/Patron
+[adapter_rdoc]: https://www.rubydoc.info/github/lostisland/faraday/Faraday/Adapter/Patron


### PR DESCRIPTION
For some reason the docs are not being published for this gem anymore,
but they are still reachable when referencing the github path instead.

Fixes #1235