### PR TITLE
escape colon in path segment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
 
     - name: Build
       run: |
-        sudo apt-get install libcurl4-openssl-dev
         gem install bundler -v '<2'
         bundle install --jobs 4 --retry 3
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 4
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 236
+  Max: 235
 
 # Offense count: 17
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 4
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 234
+  Max: 236
 
 # Offense count: 17
 Metrics/CyclomaticComplexity:

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -524,7 +524,6 @@ module Faraday
       end
       url = url && URI.parse(url.to_s).opaque ? url.to_s.gsub(':', '%3A') : url
       uri = url ? base + url : base
-      uri = URI.parse(CGI.unescape(uri.to_s))
       if params
         uri.query = params.to_query(params_encoder || options.params_encoder)
       end

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -522,7 +522,9 @@ module Faraday
         base = base.dup
         base.path = "#{base.path}/" # ensure trailing slash
       end
+      url = url && URI.parse(url.to_s).opaque ? url.to_s.gsub(':', '%3A') : url
       uri = url ? base + url : base
+      uri = URI.parse(CGI.unescape(uri.to_s))
       if params
         uri.query = params.to_query(params_encoder || options.params_encoder)
       end

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -270,6 +270,29 @@ RSpec.describe Faraday::Connection do
         expect(uri.to_s).to eq('http://sushi.com/sake/')
       end
     end
+
+    context 'with colon in path' do
+      let(:url) { 'http://service.com' }
+
+      it 'joins url to base when used absolute path' do
+        conn = Faraday.new(url: url)
+        uri = conn.build_exclusive_url('/service:search?limit=400')
+        expect(uri.to_s).to eq('http://service.com/service:search?limit=400')
+      end
+
+      it 'joins url to base when used relative path' do
+        conn = Faraday.new(url: url)
+        uri = conn.build_exclusive_url('service:search?limit=400')
+        expect(uri.to_s).to eq('http://service.com/service:search?limit=400')
+      end
+
+      it 'joins url to base when used with path prefix' do
+        conn = Faraday.new(url: url)
+        conn.path_prefix = '/api'
+        uri = conn.build_exclusive_url('service:search?limit=400')
+        expect(uri.to_s).to eq('http://service.com/api/service:search?limit=400')
+      end
+    end
   end
 
   describe '#build_url' do

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -283,14 +283,14 @@ RSpec.describe Faraday::Connection do
       it 'joins url to base when used relative path' do
         conn = Faraday.new(url: url)
         uri = conn.build_exclusive_url('service:search?limit=400')
-        expect(uri.to_s).to eq('http://service.com/service:search?limit=400')
+        expect(uri.to_s).to eq('http://service.com/service%3Asearch?limit=400')
       end
 
       it 'joins url to base when used with path prefix' do
         conn = Faraday.new(url: url)
         conn.path_prefix = '/api'
         uri = conn.build_exclusive_url('service:search?limit=400')
-        expect(uri.to_s).to eq('http://service.com/api/service:search?limit=400')
+        expect(uri.to_s).to eq('http://service.com/api/service%3Asearch?limit=400')
       end
     end
   end


### PR DESCRIPTION
## Description
Considering example
```ruby
f =  Faraday.new(url: 'https://service.com/') do |faraday|
    faraday.adapter(Faraday.default_adapter)
  end
f.post('service:search')
```
`URI.parse` parses relative path `service:search` as opaque_part (according to https://tools.ietf.org/html/rfc2396#section-3) (eg `mailto:foo@example.com`), so `Faraday::Connection#build_exclusive_url` produces wrong URI as result and passing query params leads to `InvalidURIError`

```
irb(main):004:0> URI.parse('mailto:foo@example.com').opaque
=> "foo@example.com"
irb(main):005:0> URI.parse('service:search').opaque
=> "search"
```
Fixes https://github.com/lostisland/faraday/issues/1214

## Todos
List any remaining work that needs to be done, i.e:
- [x] Rubocop (not sure what to do with ClassLength)