### PR TITLE
gemspec: Pick a good ruby2_keywords release

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday-net_http', '~> 1.0'
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
-  spec.add_dependency 'ruby2_keywords'
+  spec.add_dependency 'ruby2_keywords', '>= 0.0.4'
 
   # Includes `examples` and `spec` to allow external adapter gems to run Faraday unit and integration tests
   spec.files = Dir['CHANGELOG.md', '{examples,lib,spec}/**/*', 'LICENSE.md', 'Rakefile', 'README.md']


### PR DESCRIPTION
## Description

Ensure ruby2_keywords is missing the 0.0.3 release, which failed on Ruby <2.6.

Fixes #1240

