### PR TITLE
Adds fail-fast = false to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ['2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7']
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        ruby: ['2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7']
+        ruby: ['2.4', '2.5', '2.6', '2.7']
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
## Description
Check if the 0.1x branch CI build is still working
(Linked to #1243)

## Todos
- [x] Always run all matrix combinations to see which Ruby versions are still good and which ones are not
- [x] Decide if removing support for some rubies

