### PR TITLE
connection: Handle IPv6 address String on #proxy_from_env

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -577,7 +577,7 @@ module Faraday
         case url
         when String
           uri = Utils.URI(url)
-          uri = URI.parse("#{uri.scheme}://#{uri.hostname}").find_proxy
+          uri = URI.parse("#{uri.scheme}://#{uri.host}").find_proxy
         when URI
           uri = url.find_proxy
         when nil

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -18,6 +18,13 @@ shared_examples 'initializer with url' do
     it { expect(subject.path_prefix).to eq('/fish') }
     it { expect(subject.params).to eq('a' => '1') }
   end
+
+  context 'with IPv6 address' do
+    let(:address) { 'http://[::1]:85/' }
+
+    it { expect(subject.host).to eq('[::1]') }
+    it { expect(subject.port).to eq(85) }
+  end
 end
 
 shared_examples 'default connection options' do


### PR DESCRIPTION
## Description

The following error occurs with current master:

```log
/Users/cosmo/.rbenv/versions/3.0.0/lib/ruby/3.0.0/uri/rfc3986_parser.rb:67:in `split': bad URI(is not URI?): "http://::1" (URI::InvalidURIError)
	from /Users/cosmo/.rbenv/versions/3.0.0/lib/ruby/3.0.0/uri/rfc3986_parser.rb:72:in `parse'
	from /Users/cosmo/.rbenv/versions/3.0.0/lib/ruby/3.0.0/uri/common.rb:171:in `parse'
	from /Users/cosmo/GitHub/faraday/lib/faraday/connection.rb:580:in `proxy_from_env'
	from /Users/cosmo/GitHub/faraday/lib/faraday/connection.rb:100:in `initialize_proxy'
	from /Users/cosmo/GitHub/faraday/lib/faraday/connection.rb:87:in `initialize'
	from /Users/cosmo/GitHub/faraday/lib/faraday.rb:103:in `new'
	from /Users/cosmo/GitHub/faraday/lib/faraday.rb:103:in `new'
	from (irb):2:in `<main>'
	from /Users/cosmo/GitHub/fluent-plugin-elasticsearch/vendor/bundle/ruby/3.0.0/gems/irb-1.3.4/exe/irb:11:in `<top (required)>'
	from /Users/cosmo/GitHub/fluent-plugin-elasticsearch/vendor/bundle/ruby/3.0.0/bin/irb:23:in `load'
	from /Users/cosmo/GitHub/fluent-plugin-elasticsearch/vendor/bundle/ruby/3.0.0/bin/irb:23:in `<top (required)>'
	from /Users/cosmo/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
	from /Users/cosmo/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
	from /Users/cosmo/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
	from /Users/cosmo/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/cli.rb:497:in `exec'
	from /Users/cosmo/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	... 10 levels...
```

This is because, in IPv6 world, URI::XXX#host and URI::XXX#hostname
should be different:

```irb
irb> uri = URI.parse("http://[::1]:9200")
irb> uri.host
=> "[::1]"
irb> uri.hostname
=> "::1"
```

This difference causes the following invalid URI:

When using `uri.host` case,

```irb
irb> "#{uri.scheme}://#{uri.host}"
=> "http://[::1]"
irb> URI.parse("#{uri.scheme}://#{uri.host}")
=> #<URI::HTTP http://[::1]>
```

we got succeeded to parse created URI with `URI.parse`.

When using `uri.hostname` case,

```irb
irb> "#{uri.scheme}://#{uri.hostname}"
=> "http://::1"
irb> > URI.parse("#{uri.scheme}://#{uri.hostname}")
/Users/cosmo/.rbenv/versions/3.0.0/lib/ruby/3.0.0/uri/rfc3986_parser.rb:67:in `split': bad URI(is not URI?): "http://::1" (URI::InvalidURIError)
 <snip>
```

we got failing to parse created URI with `URI.parse`.

This problematic behavior breaks our use case which passes URL as IPv6
address String.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests

## Additional Notes
Optional section
