### PR TITLE
Fix NoMethodError undefined method 'coverage'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :lint, :development do
 end
 
 group :test, :development do
-  gem 'coveralls', require: false
+  gem 'coveralls_reborn', require: false
   gem 'em-http-request', '>= 1.1', require: 'em-http'
   gem 'em-synchrony', '>= 1.0.3', require: %w[em-synchrony em-synchrony/em-http]
   gem 'excon', '>= 0.27.4'


### PR DESCRIPTION
## Description
This is a fix for https://github.com/lostisland/faraday/issues/1254
As mentioned in coveralls-ruby issue: https://github.com/lemurheavy/coveralls-ruby/issues/161, using coveralls-ruby-rebon should fix the problem.

Here is a screenshot from the CI logs as a proof :) 
![coveralls-logs](https://user-images.githubusercontent.com/7128972/112728291-29a75880-8f2f-11eb-9d9c-6fbe25ee27e6.png)



