### PR TITLE
CI: Configure the regenerated Coveralls token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   GIT_COMMIT_SHA: ${{ github.sha }}
   GIT_BRANCH: ${{ github.ref }}
   CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+  COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
 jobs:
   linting:


### PR DESCRIPTION
This PR adds a Coveralls API token.

## Description

I noticed that the last Coveralls code coverage stats was from 2019. Then I found there was a token, and regenerated it. I added it as a GitHub Secret and exposed it to ENV vars in the Action.

See #1254 and its follow-up #1255.

## Todos
List any remaining work that needs to be done, i.e:
- [ ] See it work

