### PR TITLE
Remove codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,0 @@
-version: "2"
-plugins:
-  rubocop:
-    enabled: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 env:
   GIT_COMMIT_SHA: ${{ github.sha }}
   GIT_BRANCH: ${{ github.ref }}
-  CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/faraday.svg)](https://rubygems.org/gems/faraday)
 [![GitHub Actions CI](https://github.com/lostisland/faraday/workflows/CI/badge.svg)](https://github.com/lostisland/faraday/actions?query=workflow%3ACI)
-[![Maintainability](https://api.codeclimate.com/v1/badges/f869daab091ceef1da73/maintainability)](https://codeclimate.com/github/lostisland/faraday/maintainability)
 [![Gitter](https://badges.gitter.im/lostisland/faraday.svg)](https://gitter.im/lostisland/faraday?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 


### PR DESCRIPTION
## Description

Since the quality of reporting has gone down, and these fail the
builds, reducing our warning-seeing ability, I now take step of
stopping reporting to CC.

If we want to do any spot-checks, we can run rubycritic, or some other
metrics tool, which does not disrupt our workflow.

## Todos

We can do any or all of these:
- [x] Perhaps remove the now-unused Secret
- [ ] Disable the configured build on CC
- [x] See if codeclimate is a branch protection thing for merging into our default branch (I removed the webhook)

