### PR TITLE
CI: Rename default branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
   push:
-    branches: [master, 0.1x]
+    branches: [main, 0.1x]
 
 env:
   GIT_COMMIT_SHA: ${{ github.sha }}


### PR DESCRIPTION
## Description

In order to live up the promise of the Code of Conduct, this PR changes the name of the default branch to `main`.

## Todos

- [x] Update the CI tooling to use the new name for the default branch
- [ ] Change the name of the default branch in Settings.


