### PR TITLE
Fix dependencies from external adapter gems (excon, net_http_persistent)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,12 @@ group :test, :development do
   gem 'coveralls_reborn', require: false
   gem 'em-http-request', '>= 1.1', require: 'em-http'
   gem 'em-synchrony', '>= 1.0.3', require: %w[em-synchrony em-synchrony/em-http]
+  gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
   gem 'multipart-parser'
+  # TODO: remove this once v4 is released
+  options = (RUBY_VERSION.start_with?('3') ? { github: 'grosser/net-http-persistent', branch: 'grosser/spec' } : {})
+  gem 'net-http-persistent', '>= 3.0', **options
   gem 'patron', '>= 0.4.2', platforms: :ruby
   gem 'rack-test', '>= 0.6', require: 'rack/test'
   gem 'rspec', '~> 3.7'

--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4'
 
-  spec.add_dependency 'faraday-excon', '~> 1.0'
+  spec.add_dependency 'faraday-excon', '~> 1.1'
   spec.add_dependency 'faraday-net_http', '~> 1.0'
-  spec.add_dependency 'faraday-net_http_persistent', '~> 1.0'
+  spec.add_dependency 'faraday-net_http_persistent', '~> 1.1'
   spec.add_dependency 'multipart-post', '>= 1.2', '< 3'
   spec.add_dependency 'ruby2_keywords', '>= 0.0.4'
 


### PR DESCRIPTION
## Description

Fix dependencies from external adapter gems (excon, net_http_persistent)
Fix https://github.com/lostisland/faraday/pull/1257#issuecomment-821981085

## Additional Notes

This PR relies on the new releases v1.1 I just shipped for both `faraday-excon` and `faraday-net_http_persistent`