### PR TITLE
Add proxy setting when url_prefix is changed

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Metrics/AbcSize:
 # Offense count: 5
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 235
+  Max: 250
 
 # Offense count: 15
 # Configuration parameters: IgnoredMethods.

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -419,6 +419,8 @@ module Faraday
         basic_auth user, password
         uri.user = uri.password = nil
       end
+
+      @proxy = proxy_from_env(url) unless @manual_proxy
     end
 
     # Sets the path prefix and ensures that it always has a leading
@@ -577,7 +579,11 @@ module Faraday
         case url
         when String
           uri = Utils.URI(url)
-          uri = URI.parse("#{uri.scheme}://#{uri.host}").find_proxy
+          uri = if uri.host.nil?
+                  find_default_proxy
+                else
+                  URI.parse("#{uri.scheme}://#{uri.host}").find_proxy
+                end
         when URI
           uri = url.find_proxy
         when nil

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -442,6 +442,14 @@ RSpec.describe Faraday::Connection do
       end
     end
 
+    it 'allows when url in no proxy list with url_prefix' do
+      with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do
+        conn = Faraday::Connection.new
+        conn.url_prefix = 'http://example.com'
+        expect(conn.proxy).to be_nil
+      end
+    end
+
     it 'allows when prefixed url is not in no proxy list' do
       with_env 'http_proxy' => 'http://proxy.com', 'no_proxy' => 'example.com' do
         conn = Faraday::Connection.new('http://prefixedexample.com')


### PR DESCRIPTION
## Description
Without this change, setting the url_prefix after a Faraday::Connection is initialized results in no_proxy settings ignored when using relative paths. This would be one of the "proposed" fixes in #1275.

Fixes #1275

## Todos