### PR TITLE
default proxy to http:// if necessary, fixes #1282

### DIFF
--- a/lib/faraday/options/proxy_options.rb
+++ b/lib/faraday/options/proxy_options.rb
@@ -19,6 +19,13 @@ module Faraday
           value[:uri] = Utils.URI(uri)
         end
       end
+
+      # URIs without a scheme should default to http (like 'example:123'). This
+      # fixes #1282 and prevents a silent failure in some adapters.
+      if value && !value[:uri].to_s.include?('://')
+        value[:uri] = Utils.URI("http://#{value[:uri]}")
+      end
+
       super(value)
     end
 

--- a/lib/faraday/options/proxy_options.rb
+++ b/lib/faraday/options/proxy_options.rb
@@ -11,6 +11,9 @@ module Faraday
     def self.from(value)
       case value
       when String
+        # URIs without a scheme should default to http (like 'example:123').
+        # This fixes #1282 and prevents a silent failure in some adapters.
+        value = "http://#{value}" if !value.include?('://')
         value = { uri: Utils.URI(value) }
       when URI
         value = { uri: value }
@@ -18,12 +21,6 @@ module Faraday
         if (uri = value.delete(:uri))
           value[:uri] = Utils.URI(uri)
         end
-      end
-
-      # URIs without a scheme should default to http (like 'example:123'). This
-      # fixes #1282 and prevents a silent failure in some adapters.
-      if value && !value[:uri].to_s.include?('://')
-        value[:uri] = Utils.URI("http://#{value[:uri]}")
       end
 
       super(value)

--- a/lib/faraday/options/proxy_options.rb
+++ b/lib/faraday/options/proxy_options.rb
@@ -13,7 +13,7 @@ module Faraday
       when String
         # URIs without a scheme should default to http (like 'example:123').
         # This fixes #1282 and prevents a silent failure in some adapters.
-        value = "http://#{value}" if !value.include?('://')
+        value = "http://#{value}" unless value.include?('://')
         value = { uri: Utils.URI(value) }
       when URI
         value = { uri: value }

--- a/spec/faraday/options/proxy_options_spec.rb
+++ b/spec/faraday/options/proxy_options_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe Faraday::ProxyOptions do
       expect(options.inspect).to match('#<Faraday::ProxyOptions uri=')
     end
 
+    it 'defaults to http' do
+      options = Faraday::ProxyOptions.from 'example.org'
+      expect(options.port).to eq(80)
+      expect(options.host).to eq('example.org')
+      expect(options.scheme).to eq('http')
+    end
+
     it 'works with nil' do
       options = Faraday::ProxyOptions.from nil
       expect(options).to be_a_kind_of(Faraday::ProxyOptions)


### PR DESCRIPTION
Previously, the proxy setting was silently ignored if you accidentally left off the scheme (`something:1234`). This change fills in the `http://` if it seems to be missing. Fixes #1282.