### PR TITLE
silence warning - fix #1285

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -73,6 +73,7 @@ module Faraday
       @options = options.request
       @ssl = options.ssl
       @default_parallel_manager = options.parallel_manager
+      @manual_proxy = nil
 
       @builder = options.builder || begin
         # pass an empty block to Builder so it doesn't assume default middleware


### PR DESCRIPTION
## Description

Set @manual_proxy a bit higher up to avoid ruby warnings. Fixes #1285
