### PR TITLE
restore jruby support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 ruby RUBY_VERSION
 
-gem 'jruby-openssl', '~> 0.8.8', platforms: :jruby
+gem 'jruby-openssl', '~> 0.10.7', platforms: :jruby
 
 group :development, :test do
   gem 'pry'
@@ -20,8 +20,8 @@ end
 
 group :test, :development do
   gem 'coveralls_reborn', require: false
-  gem 'em-http-request', '>= 1.1', require: 'em-http'
-  gem 'em-synchrony', '>= 1.0.3', require: %w[em-synchrony em-synchrony/em-http]
+  gem 'em-http-request', '>= 1.1', require: 'em-http', platform: :ruby
+  gem 'em-synchrony', '>= 1.0.3', require: %w[em-synchrony em-synchrony/em-http], platform: :ruby
   gem 'excon', '>= 0.27.4'
   gem 'httpclient', '>= 2.2'
   gem 'multipart-parser'

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -27,8 +27,10 @@ require 'faraday/error'
 require 'faraday/file_part'
 require 'faraday/param_part'
 
-require 'faraday/em_http'
-require 'faraday/em_synchrony'
+unless defined?(JRUBY_VERSION)
+  require 'faraday/em_http'
+  require 'faraday/em_synchrony'
+end
 require 'faraday/excon'
 require 'faraday/httpclient'
 require 'faraday/net_http'

--- a/spec/faraday/adapter/em_http_spec.rb
+++ b/spec/faraday/adapter/em_http_spec.rb
@@ -1,47 +1,49 @@
 # frozen_string_literal: true
 
-RSpec.describe Faraday::Adapter::EMHttp do
-  features :request_body_on_query_methods, :reason_phrase_parse, :trace_method,
-           :skip_response_body_on_head, :parallel, :local_socket_binding
+unless defined?(JRUBY_VERSION)
+  RSpec.describe Faraday::Adapter::EMHttp do
+    features :request_body_on_query_methods, :reason_phrase_parse, :trace_method,
+             :skip_response_body_on_head, :parallel, :local_socket_binding
 
-  it_behaves_like 'an adapter'
+    it_behaves_like 'an adapter'
 
-  it 'allows to provide adapter specific configs' do
-    url = URI('https://example.com:1234')
-    adapter = described_class.new nil, inactivity_timeout: 20
-    req = adapter.create_request(url: url, request: {})
+    it 'allows to provide adapter specific configs' do
+      url = URI('https://example.com:1234')
+      adapter = described_class.new nil, inactivity_timeout: 20
+      req = adapter.create_request(url: url, request: {})
 
-    expect(req.connopts.inactivity_timeout).to eq(20)
+      expect(req.connopts.inactivity_timeout).to eq(20)
+    end
+
+    context 'Options' do
+      let(:request) { Faraday::RequestOptions.new }
+      let(:env) { { request: request } }
+      let(:options) { {} }
+      let(:adapter) { Faraday::Adapter::EMHttp.new }
+
+      it 'configures timeout' do
+        request.timeout = 5
+        adapter.configure_timeout(options, env)
+        expect(options[:inactivity_timeout]).to eq(5)
+        expect(options[:connect_timeout]).to eq(5)
+      end
+
+      it 'configures timeout and open_timeout' do
+        request.timeout = 5
+        request.open_timeout = 1
+        adapter.configure_timeout(options, env)
+        expect(options[:inactivity_timeout]).to eq(5)
+        expect(options[:connect_timeout]).to eq(1)
+      end
+
+      it 'configures all timeout settings' do
+        request.timeout = 5
+        request.read_timeout = 3
+        request.open_timeout = 1
+        adapter.configure_timeout(options, env)
+        expect(options[:inactivity_timeout]).to eq(3)
+        expect(options[:connect_timeout]).to eq(1)
+      end
+    end
   end
-
-  context 'Options' do
-    let(:request) { Faraday::RequestOptions.new }
-    let(:env) { { request: request } }
-    let(:options) { {} }
-    let(:adapter) { Faraday::Adapter::EMHttp.new }
-
-    it 'configures timeout' do
-      request.timeout = 5
-      adapter.configure_timeout(options, env)
-      expect(options[:inactivity_timeout]).to eq(5)
-      expect(options[:connect_timeout]).to eq(5)
-    end
-
-    it 'configures timeout and open_timeout' do
-      request.timeout = 5
-      request.open_timeout = 1
-      adapter.configure_timeout(options, env)
-      expect(options[:inactivity_timeout]).to eq(5)
-      expect(options[:connect_timeout]).to eq(1)
-    end
-
-    it 'configures all timeout settings' do
-      request.timeout = 5
-      request.read_timeout = 3
-      request.open_timeout = 1
-      adapter.configure_timeout(options, env)
-      expect(options[:inactivity_timeout]).to eq(3)
-      expect(options[:connect_timeout]).to eq(1)
-    end
-  end
-end unless defined?(JRUBY_VERSION)
+end

--- a/spec/faraday/adapter/em_http_spec.rb
+++ b/spec/faraday/adapter/em_http_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Faraday::Adapter::EMHttp, unless: defined?(JRUBY_VERSION) do
+RSpec.describe Faraday::Adapter::EMHttp do
   features :request_body_on_query_methods, :reason_phrase_parse, :trace_method,
            :skip_response_body_on_head, :parallel, :local_socket_binding
 
@@ -44,4 +44,4 @@ RSpec.describe Faraday::Adapter::EMHttp, unless: defined?(JRUBY_VERSION) do
       expect(options[:connect_timeout]).to eq(1)
     end
   end
-end
+end unless defined?(JRUBY_VERSION)

--- a/spec/faraday/adapter/em_synchrony_spec.rb
+++ b/spec/faraday/adapter/em_synchrony_spec.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-RSpec.describe Faraday::Adapter::EMSynchrony do
-  features :request_body_on_query_methods, :reason_phrase_parse,
-           :skip_response_body_on_head, :parallel, :local_socket_binding
+unless defined?(JRUBY_VERSION)
+  RSpec.describe Faraday::Adapter::EMSynchrony do
+    features :request_body_on_query_methods, :reason_phrase_parse,
+             :skip_response_body_on_head, :parallel, :local_socket_binding
 
-  it_behaves_like 'an adapter'
+    it_behaves_like 'an adapter'
 
-  it 'allows to provide adapter specific configs' do
-    url = URI('https://example.com:1234')
-    adapter = described_class.new nil, inactivity_timeout: 20
-    req = adapter.create_request(url: url, request: {})
+    it 'allows to provide adapter specific configs' do
+      url = URI('https://example.com:1234')
+      adapter = described_class.new nil, inactivity_timeout: 20
+      req = adapter.create_request(url: url, request: {})
 
-    expect(req.connopts.inactivity_timeout).to eq(20)
+      expect(req.connopts.inactivity_timeout).to eq(20)
+    end
   end
-end unless defined?(JRUBY_VERSION)
+end

--- a/spec/faraday/adapter/em_synchrony_spec.rb
+++ b/spec/faraday/adapter/em_synchrony_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Faraday::Adapter::EMSynchrony, unless: defined?(JRUBY_VERSION) do
+RSpec.describe Faraday::Adapter::EMSynchrony do
   features :request_body_on_query_methods, :reason_phrase_parse,
            :skip_response_body_on_head, :parallel, :local_socket_binding
 
@@ -13,4 +13,4 @@ RSpec.describe Faraday::Adapter::EMSynchrony, unless: defined?(JRUBY_VERSION) do
 
     expect(req.connopts.inactivity_timeout).to eq(20)
   end
-end
+end unless defined?(JRUBY_VERSION)


### PR DESCRIPTION
## Description
JRuby doesn't support em-synchrony (existing tests are already skipped)

unfortunately, after https://github.com/lostisland/faraday/pull/1274 faraday can't boot up anymore even with a different adapter.

this PR skips loading these runtime dependencies on JRuby.

I've also increased the version of jruby-openssl which is quite outdated.