### PR TITLE
Add strict_mode to Test::Stubs

### DIFF
--- a/docs/adapters/testing.md
+++ b/docs/adapters/testing.md
@@ -64,6 +64,33 @@ initialized. This is useful for testing.
 stubs.get('/uni') { |env| [ 200, {}, 'urchin' ]}
 ```
 
+If you want to stub requests that exactly match a path, parameters, and headers,
+`strict_mode` would be useful.
+
+```ruby
+stubs = Faraday::Adapter::Test::Stubs.new(strict_mode: true) do |stub|
+  stub.get('/ikura?nori=true', 'X-Soy-Sauce' => '5ml' ) { |env| [200, {}, 'ikura gunkan maki'] }
+end
+```
+
+This stub expects the connection will be called like this:
+
+```ruby
+conn.get('/ikura', { nori: 'true' }, { 'X-Soy-Sauce' => '5ml' } )
+```
+
+If there are other parameters or headers included, the Faraday Test adapter
+will raise `Faraday::Test::Stubs::NotFound`. It also raises the error
+if the specified parameters (`nori`) or headers (`X-Soy-Sauce`) are omitted.
+
+You can also enable `strict_mode` after initializing the connection.
+In this case, all requests, including ones that have been already stubbed,
+will be handled in a strict way.
+
+```ruby
+stubs.strict_mode = true
+```
+
 Finally, you can treat your stubs as mocks by verifying that all of the stubbed
 calls were made. NOTE: this feature is still fairly experimental. It will not
 verify the order or count of any stub.

--- a/examples/client_spec.rb
+++ b/examples/client_spec.rb
@@ -12,8 +12,8 @@ class Client
     @conn = conn
   end
 
-  def sushi(jname)
-    res = @conn.get("/#{jname}")
+  def sushi(jname, params: {})
+    res = @conn.get("/#{jname}", params)
     data = JSON.parse(res.body)
     data['name']
   end
@@ -61,5 +61,24 @@ RSpec.describe Client do
 
     expect { client.sushi('ebi') }.to raise_error(Faraday::ConnectionFailed)
     stubs.verify_stubbed_calls
+  end
+
+  context 'When the test stub is run in strict_mode' do
+    let(:stubs) { Faraday::Adapter::Test::Stubs.new(strict_mode: true) }
+
+    it 'verifies the all parameter values are identical' do
+      stubs.get('/ebi?abc=123') do
+        [
+          200,
+          { 'Content-Type': 'application/javascript' },
+          '{"name": "shrimp"}'
+        ]
+      end
+
+      # uncomment to raise Stubs::NotFound
+      # expect(client.sushi('ebi', params: { abc: 123, foo: 'Kappa' })).to eq('shrimp')
+      expect(client.sushi('ebi', params: { abc: 123 })).to eq('shrimp')
+      stubs.verify_stubbed_calls
+    end
   end
 end

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -15,7 +15,7 @@ module Faraday
   class Connection
     # A Set of allowed HTTP verbs.
     METHODS = Set.new %i[get post put delete head patch options trace]
-    USER_AGENT = "Faraday v#{VERSION}".freeze
+    USER_AGENT = "Faraday v#{VERSION}"
 
     # @return [Hash] URI query unencoded key/value pairs.
     attr_reader :params

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -15,6 +15,7 @@ module Faraday
   class Connection
     # A Set of allowed HTTP verbs.
     METHODS = Set.new %i[get post put delete head patch options trace]
+    USER_AGENT = "Faraday v#{VERSION}".freeze
 
     # @return [Hash] URI query unencoded key/value pairs.
     attr_reader :params
@@ -89,7 +90,7 @@ module Faraday
 
       yield(self) if block_given?
 
-      @headers[:user_agent] ||= "Faraday v#{VERSION}"
+      @headers[:user_agent] ||= USER_AGENT
     end
 
     def initialize_proxy(url, options)


### PR DESCRIPTION
## Description

Close #1291
Backport to 1.x of #1298 

Sometimes, users might want to check whether stubbed requests exactly
match the parameters and headers. In this case, they expect
`Test::Stubs` to raise an error when they add a new parameter in a
request. This patch introduces `strict_mode` for the purpose of the
expectation. With `strict_mode`, `Test::Stubs` tries to check all a
path, parameters, and headers exactly.

## Todos

- [x] Tests
- [x] Documentation
