### PR TITLE
Remove deprecated Faraday::Request#method

### DIFF
--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -41,14 +41,6 @@ module Faraday
       end
     end
 
-    def method
-      warn <<~TEXT
-        WARNING: `Faraday::Request##{__method__}` is deprecated; use `#http_method` instead. It will be removed in or after version 2.0.
-        `Faraday::Request##{__method__}` called from #{caller_locations(1..1).first}
-      TEXT
-      http_method
-    end
-
     # Replace params, preserving the existing hash type.
     #
     # @param hash [Hash] new params

--- a/spec/faraday/request_spec.rb
+++ b/spec/faraday/request_spec.rb
@@ -22,17 +22,6 @@ RSpec.describe Faraday::Request do
     it { expect(subject.http_method).to eq(:post) }
   end
 
-  describe 'deprecate method for HTTP method' do
-    let(:http_method) { :post }
-    let(:expected_warning) do
-      %r{WARNING: `Faraday::Request#method` is deprecated; use `#http_method` instead. It will be removed in or after version 2.0.\n`Faraday::Request#method` called from .+/spec/faraday/request_spec.rb:\d+.}
-    end
-
-    it { expect(subject.method).to eq(:post) }
-
-    it { expect { subject.method }.to output(expected_warning).to_stderr }
-  end
-
   context 'when setting the url on setup with a URI' do
     let(:block) { proc { |req| req.url URI.parse('foo.json?a=1') } }
 


### PR DESCRIPTION
This PR removes one of the deprecated methods in 2.0.

## Description

This is a part of #1302 - 2.0 Deprecations.

