### PR TITLE
[1.x] Deprecate Authorization helpers in Faraday::Connection

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Metrics/AbcSize:
 # Offense count: 5
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 250
+  Max: 256
 
 # Offense count: 15
 # Configuration parameters: IgnoredMethods.

--- a/docs/middleware/request/authentication.md
+++ b/docs/middleware/request/authentication.md
@@ -9,9 +9,19 @@ top_name: Back to Middleware
 top_link: ./list
 ---
 
-Basic and Token authentication are handled by Faraday::Request::BasicAuthentication
-and Faraday::Request::TokenAuthentication respectively.
-These can be added as middleware manually or through the helper methods.
+The `Faraday::Request::Authentication` middleware allows you to automatically add an `Authorization` header
+to your requests. It also feature 2 specialised sub-classes that provide useful extra features for Basic Authentication
+and Token Authentication requests.
+
+### Any Authentication
+
+The generic `Authorization` middleware allows you to add any type of Authorization header.
+
+```ruby
+Faraday.new(...) do |conn|
+  conn.request :authorization, 'Bearer', 'authentication-token'
+end
+```
 
 ### Basic Authentication
 
@@ -32,15 +42,5 @@ This is not used anymore in modern web and have been replaced by Bearer tokens.
 ```ruby
 Faraday.new(...) do |conn|
   conn.request :token_auth, 'authentication-token', **options
-end
-```
-
-### Custom Authentication
-
-The generic `Authorization` middleware allows you to add any other type of Authorization header.
-
-```ruby
-Faraday.new(...) do |conn|
-  conn.request :authorization, 'Bearer', 'authentication-token'
 end
 ```

--- a/docs/middleware/request/authentication.md
+++ b/docs/middleware/request/authentication.md
@@ -9,8 +9,8 @@ top_name: Back to Middleware
 top_link: ./list
 ---
 
-The `Faraday::Request::Authentication` middleware allows you to automatically add an `Authorization` header
-to your requests. It also feature 2 specialised sub-classes that provide useful extra features for Basic Authentication
+The `Faraday::Request::Authorization` middleware allows you to automatically add an `Authorization` header
+to your requests. It also features 2 specialised sub-classes that provide useful extra features for Basic Authentication
 and Token Authentication requests.
 
 ### Any Authentication

--- a/docs/middleware/request/authentication.md
+++ b/docs/middleware/request/authentication.md
@@ -15,16 +15,32 @@ These can be added as middleware manually or through the helper methods.
 
 ### Basic Authentication
 
+`TokenAuthentication` adds a 'Basic' type Authorization header to a Faraday request.
+
 ```ruby
 Faraday.new(...) do |conn|
-  conn.basic_auth('username', 'password')
+  conn.request :basic_auth, 'username', 'password'
 end
 ```
 
 ### Token Authentication
 
+`TokenAuthentication` adds a 'Token' type Authorization header to a Faraday request.
+You can optionally provide a hash of `options` that will be appended to the token.
+This is not used anymore in modern web and have been replaced by Bearer tokens.
+
 ```ruby
 Faraday.new(...) do |conn|
-  conn.token_auth('authentication-token')
+  conn.request :token_auth, 'authentication-token', **options
+end
+```
+
+### Custom Authentication
+
+The generic `Authorization` middleware allows you to add any other type of Authorization header.
+
+```ruby
+Faraday.new(...) do |conn|
+  conn.request :authorization, 'Bearer', 'authentication-token'
 end
 ```

--- a/docs/middleware/request/authentication.md
+++ b/docs/middleware/request/authentication.md
@@ -15,7 +15,7 @@ These can be added as middleware manually or through the helper methods.
 
 ### Basic Authentication
 
-`TokenAuthentication` adds a 'Basic' type Authorization header to a Faraday request.
+`BasicAuthentication` adds a 'Basic' type Authorization header to a Faraday request.
 
 ```ruby
 Faraday.new(...) do |conn|

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -300,7 +300,7 @@ module Faraday
       warn <<~TEXT
         WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
         While initializing your connection, use `#request(:basic_auth, ...)` instead.
-        See https://lostisland.github.io/faraday/middleware/authentication or more usage info.
+        See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
       TEXT
       set_authorization_header(:basic_auth, login, pass)
     end
@@ -322,7 +322,7 @@ module Faraday
       warn <<~TEXT
         WARNING: `Faraday::Connection#token_auth` is deprecated; it will be removed in version 2.0.
         While initializing your connection, use `#request(:token_auth, ...)` instead.
-        See https://lostisland.github.io/faraday/middleware/authentication or more usage info.
+        See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
       TEXT
       set_authorization_header(:token_auth, token, options)
     end
@@ -349,7 +349,7 @@ module Faraday
       warn <<~TEXT
         WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
         While initializing your connection, use `#request(:authorization, ...)` instead.
-        See https://lostisland.github.io/faraday/middleware/authentication or more usage info.
+        See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
       TEXT
       set_authorization_header(:authorization, type, token)
     end

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -297,6 +297,11 @@ module Faraday
     #
     # @return [void]
     def basic_auth(login, pass)
+      warn <<~TEXT
+        WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
+        While initializing your connection, use `#request(:basic_auth, ...)` instead.
+        See https://lostisland.github.io/faraday/middleware/authentication or more usage info.
+      TEXT
       set_authorization_header(:basic_auth, login, pass)
     end
 
@@ -314,6 +319,11 @@ module Faraday
     #
     # @return [void]
     def token_auth(token, options = nil)
+      warn <<~TEXT
+        WARNING: `Faraday::Connection#token_auth` is deprecated; it will be removed in version 2.0.
+        While initializing your connection, use `#request(:token_auth, ...)` instead.
+        See https://lostisland.github.io/faraday/middleware/authentication or more usage info.
+      TEXT
       set_authorization_header(:token_auth, token, options)
     end
 
@@ -336,6 +346,11 @@ module Faraday
     #
     # @return [void]
     def authorization(type, token)
+      warn <<~TEXT
+        WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
+        While initializing your connection, use `#request(:authorization, ...)` instead.
+        See https://lostisland.github.io/faraday/middleware/authentication or more usage info.
+      TEXT
       set_authorization_header(:authorization, type, token)
     end
 


### PR DESCRIPTION
## Description

After reviewing the authorisation part of middleware, I realised we currently expose helpers in `Faraday::Connection` to setup the `Authorization` header. The implementation is quite old (I couldn't find any reference to the `Token` type, it seems it has been replaced by `Bearer`), with intra-dependencies that make the code hard to read and maintain.

I believe in v2.0 we should remove the helpers and rework the middleware, but in the meantime this PR will add a deprecation warning to the `1.x` branch:

* Deprecate auth helpers in Faraday::Connection
* Update docs to show correct usage of the authorization middleware
