### PR TITLE
Automatically refresh website Team page on commit to default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,6 @@ env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
 jobs:
-  refresh_stats:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Refresh Team Stats
-        run: |
-          curl "https://api.github.com/repos/${{ github.repository }}/stats/contributors"
-    if: github.ref == 'refs/heads/main'
   linting:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       id: refresh_stats
       with:
         route: GET /repos/{github.repository}/stats/contributors
-    if: github.ref == 'refs/heads/main'
+#    if: github.ref == 'refs/heads/main'
   linting:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         id: refresh_stats
         with:
           route: GET /repos/{github.repository}/stats/contributors
+        env:
+          GITHUB_TOKEN: xxx
 #    if: github.ref == 'refs/heads/main'
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Refresh Team Stats
         run: |
           curl "https://api.github.com/repos/${{ github.repository }}/stats/contributors"
-#    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
   linting:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,9 @@ jobs:
   refresh_stats:
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/request-action@v2.x
-        id: refresh_stats
-        with:
-          route: GET /repos/{github.repository}/stats/contributors
-        env:
-          GITHUB_TOKEN: xxx
+      - name: Refresh Team Stats
+        run: |
+          curl "https://api.github.com/repos/${{ github.repository }}/stats/contributors"
 #    if: github.ref == 'refs/heads/main'
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
   push:
-    branches: [main, 1.x, 0.1x]
+    branches: [ main, 1.x, 0.1x ]
 
 env:
   GIT_COMMIT_SHA: ${{ github.sha }}
@@ -12,6 +12,14 @@ env:
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
 jobs:
+  refresh_stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/request-action@v2.x
+      id: refresh_stats
+      with:
+        route: GET /repos/{github.repository}/stats/contributors
+    if: github.ref == 'refs/heads/main'
   linting:
     runs-on: ubuntu-latest
     env:
@@ -19,37 +27,37 @@ jobs:
       BUNDLE_WITHOUT: development:test
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Ruby 2.7
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
-        bundler-cache: true
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
 
-    - name: Rubocop
-      run: bundle exec rubocop --format progress
+      - name: Rubocop
+        run: bundle exec rubocop --format progress
 
-    - name: Yard-Junk
-      run: bundle exec yard-junk --path lib
+      - name: Yard-Junk
+        run: bundle exec yard-junk --path lib
 
   build:
-    needs: [linting]
+    needs: [ linting ]
     runs-on: ubuntu-latest
     name: build ${{ matrix.ruby }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0']
+        ruby: [ '2.6', '2.7', '3.0' ]
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
 
-    - name: Test
-      continue-on-error: ${{ matrix.experimental }}
-      run: bundle exec rake
+      - name: Test
+        continue-on-error: ${{ matrix.experimental }}
+        run: bundle exec rake
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: octokit/request-action@v2.x
-      id: refresh_stats
-      with:
-        route: GET /repos/{github.repository}/stats/contributors
+        id: refresh_stats
+        with:
+          route: GET /repos/{github.repository}/stats/contributors
 #    if: github.ref == 'refs/heads/main'
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/refresh_team_page.yml
+++ b/.github/workflows/refresh_team_page.yml
@@ -1,0 +1,14 @@
+name: Refresh Team Page
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Refresh Contributors Stats
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call GitHub API
+        run: |
+          curl "https://api.github.com/repos/${{ github.repository }}/stats/contributors"


### PR DESCRIPTION
## Description
According to [the doc](https://docs.github.com/en/rest/reference/repos#a-word-about-caching), the `stats` endpoint is quite heavy and it's content is cached.
We rely on this endpoint to render our [team page](https://lostisland.github.io/faraday/team/), however the cache is invalidated after each commit to `main` and it takes several minutes to rebuild it.
This process is only kicked off on the first visit to the team page, rendering it unavailable for some users.

Solution, as part of our CI build, only in case of a push to `main`, we should make an API call to trigger the cache rebuild.
This will increase the chances of the cache being available when someone visits the team page.