### PR TITLE
Respect the `params_encoder` in `Faraday::Adapter::Test`

### DIFF
--- a/examples/client_spec.rb
+++ b/examples/client_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Client do
     end
   end
 
-  context 'When the Faraday is configured with FlatParamsEncoder' do
+  context 'When the Faraday connection is configured with FlatParamsEncoder' do
     let(:conn) { Faraday.new(request: { params_encoder: Faraday::FlatParamsEncoder }) { |b| b.adapter(:test, stubs) } }
 
     it 'handles the same multiple URL parameters' do

--- a/examples/client_spec.rb
+++ b/examples/client_spec.rb
@@ -81,4 +81,17 @@ RSpec.describe Client do
       stubs.verify_stubbed_calls
     end
   end
+
+  context 'When the Faraday is configured with FlatParamsEncoder' do
+    let(:conn) { Faraday.new(request: { params_encoder: Faraday::FlatParamsEncoder }) { |b| b.adapter(:test, stubs) } }
+
+    it 'handles the same multiple URL parameters' do
+      stubs.get('/ebi?a=x&a=y&a=z') { [200, { 'Content-Type' => 'application/json' }, '{"name": "shrimp"}'] }
+
+      # uncomment to raise Stubs::NotFound
+      # expect(client.sushi('ebi', params: { a: %w[x y] })).to eq('shrimp')
+      expect(client.sushi('ebi', params: { a: %w[x y z] })).to eq('shrimp')
+      stubs.verify_stubbed_calls
+    end
+  end
 end


### PR DESCRIPTION
Close #1312 

Faraday provides a feature to let its callers configure
`params_encoder`, but `Faraday::Adapter::Test` had always created test
stubs with `#parse_nested_query` (`NestedParamsEncoder`). So, we had not
able to test such a connection with `Faraday::Adapter::Test`. This might
be inconvenient for users who want to use non-default `params_encoder`,
such as `Faraday::FlatParamsEncoder`.

This patch changed the adapter to use the same `params_encoder` as its
connection in order to solve the problem.

## Todos

- [x] Tests
- [x] Documentation (I thought the update of documentation is not required in this PR)
