### PR TITLE
Update documentation using basic auth middleware

### DIFF
--- a/docs/middleware/request/authentication.md
+++ b/docs/middleware/request/authentication.md
@@ -34,6 +34,6 @@ The middleware will automatically Base64 encode your Basic username and password
 
 ```ruby
 Faraday.new(...) do |conn|
-  conn.request :authorization, :basic, 'username', 'password'
+  conn.request :basic_auth, 'username', 'password'
 end
 ```


### PR DESCRIPTION
Documentation on using basic auth is incorrect. The deprecation warning shows the right information though. This PR updates the documentation so it matches the deprecation warning and works as expected.

When using the current documented basic auth middleware it will render the following error: 

```
ArgumentError: wrong number of arguments (given 4, expected 3)
```