### PR TITLE
Add Faraday 1.x examples in authentication.md docs

### DIFF
--- a/docs/middleware/request/authentication.md
+++ b/docs/middleware/request/authentication.md
@@ -11,6 +11,8 @@ top_link: ./list
 
 The `Faraday::Request::Authorization` middleware allows you to automatically add an `Authorization` header
 to your requests. It also features a handy helper to manage Basic authentication.
+**Please note the way you use this middleware in Faraday 1.x is different**,
+examples are available at the bottom of this page.
 
 ```ruby
 Faraday.new(...) do |conn|
@@ -35,5 +37,30 @@ The middleware will automatically Base64 encode your Basic username and password
 ```ruby
 Faraday.new(...) do |conn|
   conn.request :authorization, :basic, 'username', 'password'
+end
+```
+
+### Faraday 1.x usage
+
+In Faraday 1.x, the way you use this middleware is slightly different:
+
+```ruby
+# Basic Auth request
+# Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
+Faraday.new(...) do |conn|
+  conn.request :basic_auth, 'username', 'password'
+end
+
+# Token Auth request
+# `options` are automatically converted into `key=value` format
+# Authorization: Token authentication-token <options>
+Faraday.new(...) do |conn|
+  conn.request :token_auth, 'authentication-token', **options
+end
+
+# Generic Auth Request
+# Authorization: Bearer authentication-token
+Faraday.new(...) do |conn|
+  conn.request :authorization, 'Bearer', 'authentication-token'
 end
 ```


### PR DESCRIPTION
## Description
The online documentation describes the behaviour for Faraday 2.x, but most of our users still use Faraday 1.x.
This is causing confusion, so this PR reintroduces examples for Faraday 1.x in the doc to help.

Fixes #1317
Fixes #1314