### PR TITLE
Fix deprecation warning

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Metrics/AbcSize:
 # Offense count: 5
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 256
+  Max: 260
 
 # Offense count: 15
 # Configuration parameters: IgnoredMethods.

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'jruby-openssl', '~> 0.10.7', platforms: :jruby
 group :development, :test do
   gem 'pry'
   gem 'rake'
+  gem 'irb'
 end
 
 group :lint, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ ruby RUBY_VERSION
 gem 'jruby-openssl', '~> 0.10.7', platforms: :jruby
 
 group :development, :test do
+  gem 'irb'
   gem 'pry'
   gem 'rake'
-  gem 'irb'
 end
 
 group :lint, :development do

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -433,11 +433,16 @@ module Faraday
       uri.query = nil
 
       with_uri_credentials(uri) do |user, password|
-        basic_auth user, password
+        set_basic_auth(user, password)
         uri.user = uri.password = nil
       end
 
       @proxy = proxy_from_env(url) unless @manual_proxy
+    end
+
+    def set_basic_auth(user, password)
+      header = Faraday::Request::BasicAuthentication.header(user, password)
+      headers[Faraday::Request::Authorization::KEY] = header
     end
 
     # Sets the path prefix and ensures that it always has a leading


### PR DESCRIPTION
## Description
Fix deprecation warning when providing basic_auth in url.
This can be tested using `script/console` (which was broken due to missing `irb` dependency in Gemfile).

```ruby
# before
conn = Faraday.new('http://Aladdin:open%20sesame@sushi.com/fish')
  # WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
  # While initializing your connection, use `#request(:basic_auth, ...)` instead.
  # See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
  # => #<Faraday::Connection:0x00007fafe629f9d0

# after
conn = Faraday.new('http://Aladdin:open%20sesame@sushi.com/fish')
  # => #<Faraday::Connection:0x00007fdf352b1f30
```