### PR TITLE
Register json middleware

### DIFF
--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -132,6 +132,7 @@ end
 
 require 'faraday/request/authorization'
 require 'faraday/request/instrumentation'
+require 'faraday/request/json'
 require 'faraday/request/multipart'
 require 'faraday/request/retry'
 require 'faraday/request/url_encoded'

--- a/lib/faraday/request/json.rb
+++ b/lib/faraday/request/json.rb
@@ -51,3 +51,5 @@ module Faraday
     end
   end
 end
+
+Faraday::Request.register_middleware(json: Faraday::Request::Json)

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -85,5 +85,6 @@ module Faraday
   end
 end
 
+require 'faraday/response/json'
 require 'faraday/response/logger'
 require 'faraday/response/raise_error'

--- a/lib/faraday/response/json.rb
+++ b/lib/faraday/response/json.rb
@@ -50,3 +50,5 @@ module Faraday
     end
   end
 end
+
+Faraday::Response.register_middleware(json: Faraday::Response::Json)


### PR DESCRIPTION
I was quite surprised to realize I had to do register this middleware manually, as I didn't have to do that for the other middleware in core.
