### PR TITLE
Retry middleware should handle string exception class name consistently

### DIFF
--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -184,7 +184,7 @@ module Faraday
               if ex.is_a? Module
                 error.is_a? ex
               else
-                error.class.to_s == ex.to_s
+                Object.const_defined?(ex.to_s) && error.is_a?(Object.const_get(ex.to_s))
               end
             end
           end

--- a/spec/faraday/request/retry_spec.rb
+++ b/spec/faraday/request/retry_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe Faraday::Request::Retry do
 
       it { expect(times_called).to eq(3) }
     end
+
+    context 'and this is passed as a string custom exception' do
+      let(:options) { [{ exceptions: 'StandardError' }] }
+
+      it { expect(times_called).to eq(3) }
+    end
+
+    context 'and a non-existent string custom exception is passed' do
+      let(:options) { [{ exceptions: 'WrongStandardErrorNotExisting' }] }
+
+      it { expect(times_called).to eq(1) }
+    end
   end
 
   context 'when an expected error happens' do


### PR DESCRIPTION
Closes #1330
