### PR TITLE
Improve request info in exceptions raised by RaiseError Middleware

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -52,6 +52,7 @@ module Faraday
     #              :body    - Optional string HTTP response body.
     #              :request - Hash
     #                           :method   - Symbol with the request HTTP method.
+    #                           :url      - URI object with the url requested.
     #                           :url_path - String with the url path requested.
     #                           :params   - String key/value hash of query params
     #                                     present in the request.

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -44,12 +44,18 @@ module Faraday
           body: env.body,
           request: {
             method: env.method,
+            url: env.url,
             url_path: env.url.path,
-            params: env.params,
+            params: query_params(env),
             headers: env.request_headers,
             body: env.request_body
           }
         }
+      end
+
+      def query_params(env)
+        env.request.params_encoder ||= Faraday::Utils.default_params_encoder
+        env.params_encoder.decode(env[:url].query)
       end
     end
   end

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -55,7 +55,7 @@ module Faraday
 
       def query_params(env)
         env.request.params_encoder ||= Faraday::Utils.default_params_encoder
-        env.params_encoder.decode(env[:url].query)
+        env.params_encoder.decode(env.url.query)
       end
     end
   end

--- a/spec/faraday/response/raise_error_spec.rb
+++ b/spec/faraday/response/raise_error_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Faraday::Response::RaiseError do
       Faraday.new do |b|
         b.response :raise_error
         b.adapter :test do |stub|
-          stub.post('request?full=true', request_body, request_headers) do
+          stub.post(url, request_body, request_headers) do
             [400, { 'X-Reason' => 'because' }, 'keep looking']
           end
         end
@@ -147,11 +147,13 @@ RSpec.describe Faraday::Response::RaiseError do
     end
     let(:request_body) { JSON.generate({ 'item' => 'sth' }) }
     let(:request_headers) { { 'Authorization' => 'Basic 123' } }
+    let(:url_path) { 'request' }
+    let(:query_params) { 'full=true' }
+    let(:url) { "#{url_path}?#{query_params}" }
 
     subject(:perform_request) do
-      conn.post 'request' do |req|
+      conn.post url do |req|
         req.headers['Authorization'] = 'Basic 123'
-        req.params[:full] = true
         req.body = request_body
       end
     end
@@ -159,7 +161,8 @@ RSpec.describe Faraday::Response::RaiseError do
     it 'returns the request info in the exception' do
       expect { perform_request }.to raise_error(Faraday::BadRequestError) do |ex|
         expect(ex.response[:request][:method]).to eq(:post)
-        expect(ex.response[:request][:url_path]).to eq('/request')
+        expect(ex.response[:request][:url]).to eq(URI("http:/#{url}"))
+        expect(ex.response[:request][:url_path]).to eq("/#{url_path}")
         expect(ex.response[:request][:params]).to eq({ 'full' => 'true' })
         expect(ex.response[:request][:headers]).to match(a_hash_including(request_headers))
         expect(ex.response[:request][:body]).to eq(request_body)


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.
Link to related issues if any. (As `fixes #XXX `)

Fixes #1249

Add URI object with the url requested and fix query string params. In [test adapter](https://github.com/lostisland/faraday/blob/main/lib/faraday/adapter/test.rb#L240), the params already was treated which means the specs was biased. With default adapter, the params problem occurred as described in Issue #1249.

## Todos
List any remaining work that needs to be done, i.e:
- [X] Tests
- [X] Documentation

## Additional Notes
Optional section
