### PR TITLE
Replace Hash#merge with Utils#deep_merge for connection options

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -92,7 +92,7 @@ module Faraday
     #               params: { page: 1 }
     #   # => Faraday::Connection to http://faraday.com?page=1
     def new(url = nil, options = {}, &block)
-      options = default_connection_options.merge(options)
+      options = Utils.deep_merge(default_connection_options, options)
       Faraday::Connection.new(url, options, &block)
     end
 

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -64,7 +64,7 @@ module Faraday
       options = ConnectionOptions.from(options)
 
       if url.is_a?(Hash) || url.is_a?(ConnectionOptions)
-        options = options.merge(url)
+        options = Utils.deep_merge(options, url)
         url     = options.url
       end
 

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -101,7 +101,7 @@ module Faraday
     # Recursive hash update
     def deep_merge!(target, hash)
       hash.each do |key, value|
-        target[key] = if value.is_a?(Hash) && target[key].is_a?(Hash)
+        target[key] = if value.is_a?(Hash) && (target[key].is_a?(Hash) || target[key].is_a?(Options))
                         deep_merge(target[key], value)
                       else
                         value

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -639,6 +639,24 @@ RSpec.describe Faraday::Connection do
 
       it_behaves_like 'default connection options'
     end
+
+    context 'preserving a user_agent assigned via default_conncetion_options' do
+      context 'when url is a Hash' do
+        let(:conn) { Faraday.new(url: 'http://example.co', headers: { 'CustomHeader' => 'CustomValue' }) }
+
+        before { Faraday.default_connection_options = { headers: { user_agent: 'My Agent 1.2' } } }
+
+        it { expect(conn.headers).to eq('CustomHeader' => 'CustomValue', 'User-Agent' => 'My Agent 1.2') }
+      end
+
+      context 'when url is a String' do
+        let(:conn) { Faraday.new('http://example.co', headers: { 'CustomHeader' => 'CustomValue' }) }
+
+        before { Faraday.default_connection_options = { headers: { user_agent: 'My Agent 1.2' } } }
+
+        it { expect(conn.headers).to eq('CustomHeader' => 'CustomValue', 'User-Agent' => 'My Agent 1.2') }
+      end
+    end
   end
 
   describe 'request params' do

--- a/spec/faraday/utils_spec.rb
+++ b/spec/faraday/utils_spec.rb
@@ -53,4 +53,65 @@ RSpec.describe Faraday::Utils do
       expect(headers).not_to have_key('authorization')
     end
   end
+
+  describe '.deep_merge!' do
+    let(:connection_options) { Faraday::ConnectionOptions.new }
+    let(:url) do
+      {
+        url: 'http://example.com/abc',
+        headers: { 'Mime-Version' => '1.0' },
+        request: { oauth: { consumer_key: 'anonymous' } },
+        ssl: { version: '2' }
+      }
+    end
+
+    it 'recursively merges the headers' do
+      connection_options.headers = { user_agent: 'My Agent 1.0' }
+      deep_merge = Faraday::Utils.deep_merge!(connection_options, url)
+
+      expect(deep_merge.headers).to eq('Mime-Version' => '1.0', user_agent: 'My Agent 1.0')
+    end
+
+    context 'when a target hash has an Options Struct value' do
+      let(:request) do
+        {
+          params_encoder: nil,
+          proxy: nil,
+          bind: nil,
+          timeout: nil,
+          open_timeout: nil,
+          read_timeout: nil,
+          write_timeout: nil,
+          boundary: nil,
+          oauth: { consumer_key: 'anonymous' },
+          context: nil,
+          on_data: nil
+        }
+      end
+      let(:ssl) do
+        {
+          verify: nil,
+          ca_file: nil,
+          ca_path: nil,
+          verify_mode: nil,
+          cert_store: nil,
+          client_cert: nil,
+          client_key: nil,
+          certificate: nil,
+          private_key: nil,
+          verify_depth: nil,
+          version: '2',
+          min_version: nil,
+          max_version: nil
+        }
+      end
+
+      it 'does not overwrite an Options Struct value' do
+        deep_merge = Faraday::Utils.deep_merge!(connection_options, url)
+
+        expect(deep_merge.request.to_h).to eq(request)
+        expect(deep_merge.ssl.to_h).to eq(ssl)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
This is an attempt to close the https://github.com/lostisland/faraday/issues/1248 issue by following the proposed solution `#1` in [this comment](https://github.com/lostisland/faraday/issues/1248#issuecomment-799362164). 

Prior to this change:
```ruby
Faraday.default_connection_options = { headers: { user_agent: 'My Agent 1.2' } }
Faraday.new('http://example.co', headers: { 'CustomHeader' => 'CustomValue' }).headers 
# => { 'CustomHeader' => 'CustomValue', 'User-Agent' => 'Faraday v2.0.0.alpha-2' }
Faraday.new(url: 'http://example.co', headers: { 'CustomHeader' => 'CustomValue' }).headers 
# => { 'CustomHeader' => 'CustomValue', 'User-Agent' => 'Faraday v2.0.0.alpha-2' }
```
After this change:
```ruby
Faraday.default_connection_options = { headers: { user_agent: 'My Agent 1.2' } }
Faraday.new('http://example.co', headers: { 'CustomHeader' => 'CustomValue' }).headers 
# => { 'CustomHeader' => 'CustomValue', 'User-Agent' => 'My Agent 1.2' }
Faraday.new(url: 'http://example.co', headers: { 'CustomHeader' => 'CustomValue' }).headers 
# => { 'CustomHeader' => 'CustomValue', 'User-Agent' => 'My Agent 1.2' }
```

The only issue with the proposed solution was that the `deep_merge` from `Faraday::Utils` didn't work out of the box for an `Options Struct` like `RequestOptions` and `SSLOptions` from `Faraday::ConnectionOptions`. 
