### PR TITLE
CI: Use latest jruby-openssl release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 # Even though we don't officially support JRuby, this dependency makes Faraday
 # compatible with it, so we're leaving it in for jruby users to use it.
-gem 'jruby-openssl', '~> 0.10.7', platforms: :jruby
+gem 'jruby-openssl', '~> 0.11.0', platforms: :jruby
 
 group :development, :test do
   gem 'coveralls_reborn', require: false


### PR DESCRIPTION
Fixes issues with letsencrypt certificates

## Description
Update the jruby-openssl version in the Gemfile used in CI.

Fixes #1347 

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [?] Documentation (not needed?)
