### PR TITLE
Don't call retry_block unless a retry is going to happen

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -38,7 +38,7 @@ We did our best to make this transition as painless as possible for you, so here
 * If you're relying on `Faraday.default_adapter` (e.g. if you use `Faraday.get` or other verb class methods, or not
   specifying an adapter in your connection initializer), then you'll now need to set it yourself. It previously
   defaulted to `:net_http`, but it now defaults to `:test`. You can do so simply by using the setter:
-  
+
   ```ruby
   # For example, to use net_http (previous default value, will now require `gem 'faraday-net_http'` in your gemfile)
   Faraday.default_adapter = :net_http
@@ -86,6 +86,7 @@ For more details, see https://github.com/lostisland/faraday/pull/1306
 * Remove `Faraday::Response::Middleware`. You can now use the new `on_complete` callback provided by `Faraday::Middleware`.
 * Drop `Faraday::UploadIO` in favour of `Faraday::FilePart`.
 * `Faraday.default_connection_options` will now be deep-merged into new connections to avoid overriding them (e.g. headers).
+* Retry middleware `retry_block` is not called if retry will not happen due to `max_interval`. (#1350)
 
 ## Faraday 1.0
 

--- a/lib/faraday/request/retry.rb
+++ b/lib/faraday/request/retry.rb
@@ -154,8 +154,8 @@ module Faraday
           if retries.positive? && retry_request?(env, e)
             retries -= 1
             rewind_files(request_body)
-            @options.retry_block.call(env, @options, retries, e)
             if (sleep_amount = calculate_sleep_amount(retries + 1, env))
+              @options.retry_block.call(env, @options, retries, e)
               sleep sleep_amount
               retry
             end

--- a/spec/faraday/request/retry_spec.rb
+++ b/spec/faraday/request/retry_spec.rb
@@ -85,6 +85,16 @@ RSpec.describe Faraday::Request::Retry do
 
       it { expect(Time.now - @started).to be_within(0.04).of(0.2) }
     end
+
+    context 'and retry_block is set' do
+      let(:options) { [{ retry_block: ->(env, options, retries, exc) { retry_block_calls << [env, options, retries, exc] } }] }
+      let(:retry_block_calls) { [] }
+      let(:retry_block_times_called) { retry_block_calls.size }
+
+      it 'calls retry block for each retry' do
+        expect(retry_block_times_called).to eq(2)
+      end
+    end
   end
 
   context 'when no exception raised' do
@@ -249,6 +259,24 @@ RSpec.describe Faraday::Request::Retry do
       let(:options) { [{ max: 2, interval: 0.1, max_interval: 5, retry_statuses: 504 }] }
 
       it { expect(times_called).to eq(1) }
+
+      context 'and retry_block is set' do
+        let(:options) do
+          [{
+            retry_block: ->(env, options, retries, exc) { retry_block_calls << [env, options, retries, exc] },
+            max: 2,
+            max_interval: 5,
+            retry_statuses: 504
+          }]
+        end
+
+        let(:retry_block_calls) { [] }
+        let(:retry_block_times_called) { retry_block_calls.size }
+
+        it 'retry_block is not called' do
+          expect(retry_block_times_called).to eq(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

Prior to this PR, `retry_block` could be called in some cases where a retry would not happen. I consider it a bug, and thus not a backwards incompat to change, but feedback welcome?

Prior to PR, `retry_block` would _not_ be called if for instance a custom `retry_if` said not to retry.  But it still *would* be called if if a `retry-after` header would exceed `max_interval`, even though no retry would be taking place. 

After this PR, a present `retry_block` is only called if and only if a retry is actually going to happen. It will not be called if a retry is not going to happen because `max_interval` has been exceeded by a `retry-after` header. 

## Additional Notes
With basic retry_block specs that didn't exist before.

What I *really* wanted is the actual `sleep_amount` to be available to the `retry_block`, so i could log `"retrying again in #{sleep_amount}"`.  Looking for a way to do that is what made me spot this bug.  But I am not sure if there's any way to add that in a backwards-compatible way -- adding another arg to the block is probably not backwards compatible? Is there any other way to slip it in there? 

Appreciate any advice on if there's a feasible way to make `sleep_amount` available to the `retry_block`, for a possible subsequent PR. 
