### PR TITLE
Default value for exc error

### DIFF
--- a/docs/adapters/testing.md
+++ b/docs/adapters/testing.md
@@ -33,7 +33,7 @@ conn = Faraday.new do |builder|
 
     # test exceptions too
     stub.get('/boom') do
-      raise Faraday::ConnectionFailed, nil
+      raise Faraday::ConnectionFailed
     end
   end
 end

--- a/examples/client_spec.rb
+++ b/examples/client_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Client do
 
   it 'handles exception' do
     stubs.get('/ebi') do
-      raise Faraday::ConnectionFailed, nil
+      raise Faraday::ConnectionFailed
     end
 
     expect { client.sushi('ebi') }.to raise_error(Faraday::ConnectionFailed)

--- a/examples/client_test.rb
+++ b/examples/client_test.rb
@@ -60,7 +60,7 @@ class ClientTest < Test::Unit::TestCase
   def test_sushi_exception
     stubs = Faraday::Adapter::Test::Stubs.new
     stubs.get('/ebi') do
-      raise Faraday::ConnectionFailed, nil
+      raise Faraday::ConnectionFailed
     end
 
     cli = client(stubs)

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -6,7 +6,7 @@ module Faraday
   class Error < StandardError
     attr_reader :response, :wrapped_exception
 
-    def initialize(exc, response = nil)
+    def initialize(exc = nil, response = nil)
       @wrapped_exception = nil unless defined?(@wrapped_exception)
       @response = nil unless defined?(@response)
       super(exc_msg_and_response!(exc, response))


### PR DESCRIPTION
## Description
I would like to introduce default value for `exc` in `def initialize` for `Faraday::Error`. 

In some cases it is difficult to find the reason on a first spot when doing `raise Faraday::ConnectionFailed` because it raises `ArgumentError`. In other cases like `raise Faraday::TimeoutError` it works because `Faraday::TimeoutError` sets default value or `exc`. 

Link to related issues if any. (As `Fixes #XXX`) - there was no related issue. 
I found out that someone has been asking why this is happening on Stackoverflow, I spent some time today looking for an answer for myself. 

From my perspective introducing default value does not break anything and simplify codebase. 

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [x] Documentation

## Additional Notes
Optional section
Stackoverflow: https://stackoverflow.com/questions/59176256/unexpected-behaviour-with-faradayconnectionfailed/70427415#70427415