### PR TITLE
Re-add `faraday-net_http` as default adapter

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6'
 
+  spec.add_dependency 'faraday-net_http', '~> 2.0'
   spec.add_dependency 'ruby2_keywords', '>= 0.0.4'
 
   # Includes `examples` and `spec` to allow external adapter gems to run Faraday unit and integration tests

--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -17,7 +17,7 @@ require 'faraday/middleware'
 require 'faraday/adapter'
 require 'faraday/request'
 require 'faraday/response'
-
+require 'faraday/net_http'
 # This is the main namespace for Faraday.
 #
 # It provides methods to create {Connection} objects, and HTTP-related
@@ -148,4 +148,5 @@ module Faraday
   self.ignore_env_proxy = false
   self.root_path = File.expand_path __dir__
   self.lib_path = File.expand_path 'faraday', __dir__
+  self.default_adapter = :net_http
 end


### PR DESCRIPTION
## Description
Re-add `faraday-net_http` as default adapter
Fixes https://twitter.com/getajobmike/status/1478586924998688768?s=20