### PR TITLE
Fix test adapter thread safety

### DIFF
--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -71,13 +71,13 @@ module Faraday
           stack = @stack[request_method]
           consumed = (@consumed[request_method] ||= [])
 
-          stub, meta = matches?(stack, env)
-          if stub
-            @stubs_mutex.synchronize do
+          @stubs_mutex.synchronize do
+            stub, meta = matches?(stack, env)
+            if stub
               removed = stack.delete(stub)
               consumed << removed unless removed.nil?
+              return stub, meta
             end
-            return stub, meta
           end
           matches?(consumed, env)
         end


### PR DESCRIPTION
## Description
Fix test adapter thread safety.
This is a follow-up attempt from #1379 
Fixes #1365 

## Additional Notes
Tested locally using "Steps to reproduce" from #1365.
Below are the benchmark results:

```
# With sleep
            user     system      total        real
Before: 3.547856   0.051316   3.599172 ( 13.638507)
After:  4.511469   0.051330   4.562799 ( 14.601563)

# Without sleep
            user     system      total        real
Before: 2.324904   0.034064   2.358968 (  2.357287)
After:  2.897183   0.030553   2.927736 (  2.925748)
```

The change does, as expected, slow down the test adapter, but this doesn't seem to be too much (~ 24%).
Considering this is mostly used in test environments rather than production ones, it should be safe to have a small dip in performance. It's also worth noting that this only applies to a multi-threaded environment.
Most applications will use the test adapter in a single thread and normally recreate the connection for each test example, so there would be no performance impact in that scenario
