### PR TITLE
update docs to a httpbingo on example requests and adding webrick for ruby 3.x support

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -32,3 +32,5 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 # Performance-booster for watching directories on Windows
 gem 'wdm', '~> 0.1.0' if Gem.win_platform?
+
+gem "webrick", "~> 1.7"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -33,4 +33,4 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Performance-booster for watching directories on Windows
 gem 'wdm', '~> 0.1.0' if Gem.win_platform?
 
-gem "webrick", "~> 1.7"
+gem 'webrick', '~> 1.7'

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -33,4 +33,5 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Performance-booster for watching directories on Windows
 gem 'wdm', '~> 0.1.0' if Gem.win_platform?
 
+# Ruby 3.X doesn't come with webrick by default anymore
 gem 'webrick', '~> 1.7'

--- a/docs/usage/customize.md
+++ b/docs/usage/customize.md
@@ -14,15 +14,15 @@ Configuration can be set up with the connection and/or adjusted per request.
 As connection options:
 
 ```ruby
-conn = Faraday.new('http://sushi.com', request: { timeout: 5 })
-conn.get('/search')
+conn = Faraday.new('http://httpbingo.org', request: { timeout: 5 })
+conn.get('/ip')
 ```
 
 Or as per-request options:
 
 ```ruby
 conn.get do |req|
-  req.url '/search'
+  req.url '/ip'
   req.options.timeout = 5
 end
 ```
@@ -32,7 +32,7 @@ This will be available in the `env` on all middleware.
 
 ```ruby
 conn.get do |req|
-  req.url '/search'
+  req.url '/get'
   req.options.context = {
     foo: 'foo',
     bar: 'bar'

--- a/docs/usage/streaming.md
+++ b/docs/usage/streaming.md
@@ -21,7 +21,7 @@ This example implements such a callback:
 # A buffer to store the streamed data
 streamed = []
 
-conn.get('/nigiri/sake.json') do |req|
+conn.get('/stream/10') do |req|
   # Set a callback which will receive tuples of chunk Strings
   # and the sum of characters received so far
   req.options.on_data = Proc.new do |chunk, overall_received_bytes|


### PR DESCRIPTION
## Description
- updating the docs discussed in #1164 
- Update docs gemfile by adding webrick for ruby 3.x jekyll support.