### PR TITLE
Reintroduce the possibility to register middleware with symbols, strings or procs

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -39,7 +39,7 @@ We did our best to make this transition as painless as possible for you, so here
   # Gemfile
   gem 'faraday'
   gem 'faraday-net_http_persistent'
-  
+
   # Code
   require 'faraday'
   require 'faraday/net_http_persistent'
@@ -101,6 +101,10 @@ This change should not affect you directly, but if you're registering middleware
 # This method can also be called on `Faraday::Adapter`, `Faraday::Request` and `Faraday::Response`
 Faraday::Middleware.register_middleware(name: klass)
 ```
+
+The `register_middleware` method also previously allowed to provide a symbol, string, proc, or array
+but this has been removed from the v2.0 release to simplify the interface.
+(EDIT: symbol/string/proc have subsequently been reintroduced in v2.2, but not the array).
 
 ### Authentication helper methods in Connection have been removed
 

--- a/spec/faraday/middleware_registry_spec.rb
+++ b/spec/faraday/middleware_registry_spec.rb
@@ -1,30 +1,31 @@
 # frozen_string_literal: true
 
-class CustomMiddleware < Faraday::Middleware
-end
-
 RSpec.describe Faraday::MiddlewareRegistry do
+  before do
+    stub_const('CustomMiddleware', custom_middleware_klass)
+  end
+  let(:custom_middleware_klass) { Class.new(Faraday::Middleware) }
   let(:dummy) { Class.new { extend Faraday::MiddlewareRegistry } }
 
   after { dummy.unregister_middleware(:custom) }
 
   it 'allows to register with constant' do
-    dummy.register_middleware(custom: CustomMiddleware)
-    expect(dummy.lookup_middleware(:custom)).to eq(CustomMiddleware)
+    dummy.register_middleware(custom: custom_middleware_klass)
+    expect(dummy.lookup_middleware(:custom)).to eq(custom_middleware_klass)
   end
 
   it 'allows to register with symbol' do
     dummy.register_middleware(custom: :CustomMiddleware)
-    expect(dummy.lookup_middleware(:custom)).to eq(CustomMiddleware)
+    expect(dummy.lookup_middleware(:custom)).to eq(custom_middleware_klass)
   end
 
   it 'allows to register with string' do
     dummy.register_middleware(custom: 'CustomMiddleware')
-    expect(dummy.lookup_middleware(:custom)).to eq(CustomMiddleware)
+    expect(dummy.lookup_middleware(:custom)).to eq(custom_middleware_klass)
   end
 
   it 'allows to register with Proc' do
-    dummy.register_middleware(custom: -> { CustomMiddleware })
-    expect(dummy.lookup_middleware(:custom)).to eq(CustomMiddleware)
+    dummy.register_middleware(custom: -> { custom_middleware_klass })
+    expect(dummy.lookup_middleware(:custom)).to eq(custom_middleware_klass)
   end
 end

--- a/spec/faraday/middleware_registry_spec.rb
+++ b/spec/faraday/middleware_registry_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CustomMiddleware < Faraday::Middleware
+end
+
+RSpec.describe Faraday::MiddlewareRegistry do
+  let(:dummy) { Class.new { extend Faraday::MiddlewareRegistry } }
+
+  after { dummy.unregister_middleware(:custom) }
+
+  it 'allows to register with constant' do
+    dummy.register_middleware(custom: CustomMiddleware)
+    expect(dummy.lookup_middleware(:custom)).to eq(CustomMiddleware)
+  end
+
+  it 'allows to register with symbol' do
+    dummy.register_middleware(custom: :CustomMiddleware)
+    expect(dummy.lookup_middleware(:custom)).to eq(CustomMiddleware)
+  end
+
+  it 'allows to register with string' do
+    dummy.register_middleware(custom: 'CustomMiddleware')
+    expect(dummy.lookup_middleware(:custom)).to eq(CustomMiddleware)
+  end
+
+  it 'allows to register with Proc' do
+    dummy.register_middleware(custom: -> { CustomMiddleware })
+    expect(dummy.lookup_middleware(:custom)).to eq(CustomMiddleware)
+  end
+end

--- a/spec/faraday/rack_builder_spec.rb
+++ b/spec/faraday/rack_builder_spec.rb
@@ -110,18 +110,6 @@ RSpec.describe Faraday::RackBuilder do
     end
   end
 
-  context 'with custom registered middleware' do
-    let(:conn) { Faraday::Connection.new {} }
-
-    after { Faraday::Middleware.unregister_middleware(:apple) }
-
-    it 'allows to register with constant' do
-      Faraday::Middleware.register_middleware(apple: Apple)
-      subject.use(:apple)
-      expect(subject.handlers).to eq([Apple])
-    end
-  end
-
   context 'when having two handlers' do
     let(:conn) { Faraday::Connection.new {} }
 


### PR DESCRIPTION
## Description

* Reintroduce the possibility to register middleware with symbols, strings or procs
* Update UPGRADING.md to explain the original removal from v2.0
* Update CHANGELOG.md to point to the `releases` page

Fixes #1389

## Additional notes

This was originally removed in #1301 