### PR TITLE
Add indices when arrays are encoded

### DIFF
--- a/lib/faraday/encoders/nested_params_encoder.rb
+++ b/lib/faraday/encoders/nested_params_encoder.rb
@@ -62,11 +62,17 @@ module Faraday
     end
 
     def encode_array(parent, value)
-      new_parent = "#{parent}%5B%5D"
-      return new_parent if value.empty?
+      return "#{parent}%5B%5D" if value.empty?
 
       buffer = +''
-      value.each { |val| buffer << "#{encode_pair(new_parent, val)}&" }
+      value.each_with_index do |val, index|
+        new_parent = if @array_indices
+                       "#{parent}%5B#{index}%5D"
+                     else
+                       "#{parent}%5B%5D"
+                     end
+        buffer << "#{encode_pair(new_parent, val)}&"
+      end
       buffer.chop
     end
   end
@@ -161,7 +167,7 @@ module Faraday
   # for your requests.
   module NestedParamsEncoder
     class << self
-      attr_accessor :sort_params
+      attr_accessor :sort_params, :array_indices
 
       extend Forwardable
       def_delegators :'Faraday::Utils', :escape, :unescape
@@ -169,6 +175,7 @@ module Faraday
 
     # Useful default for OAuth and caching.
     @sort_params = true
+    @array_indices = false
 
     extend EncodeMethods
     extend DecodeMethods

--- a/spec/faraday/params_encoders/nested_spec.rb
+++ b/spec/faraday/params_encoders/nested_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe Faraday::NestedParamsEncoder do
     Faraday::NestedParamsEncoder.sort_params = true
   end
 
+  it 'encodes arrays indices when asked' do
+    params = { a: [0, 1, 2] }
+    expect(subject.encode(params)).to eq('a%5B%5D=0&a%5B%5D=1&a%5B%5D=2')
+    Faraday::NestedParamsEncoder.array_indices = true
+    expect(subject.encode(params)).to eq('a%5B0%5D=0&a%5B1%5D=1&a%5B2%5D=2')
+    Faraday::NestedParamsEncoder.array_indices = false
+  end
+
   shared_examples 'a wrong decoding' do
     it do
       expect { subject.decode(query) }.to raise_error(TypeError) do |e|


### PR DESCRIPTION
## Description
Some services require indices to be given when an array is serialized.
This pull request adds this feature.

For instance instead of passing, for an array `a=[1,2]`: `a[]=1&a[]=2` we can now pass: `a[0]=1&a[1]=2`

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [ ] Documentation

## Additional Notes
Optional section
