### PR TITLE
docs: Add one more require to the quickstart to make this whole thing work immediately

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -20,6 +20,7 @@ You might want to use Faraday with the `Net::HTTP` adapter, for example.
 Remember you'll need to install the corresponding adapter gem before you'll be able to use it.
 
 ```ruby
+require 'faraday'
 require 'faraday/net_http'
 Faraday.default_adapter = :net_http
 ```


### PR DESCRIPTION


## Description

I wanted the quickstart to work with no thinking. I got confused when I copied in the original code and got the following:

```
/Users/jbremer/.rvm/gems/ruby-2.7.5/gems/faraday-net_http-2.0.1/lib/faraday/net_http.rb:8:in `<module:NetHttp>': undefined method `register_middleware' for Faraday::Adapter:Class (NoMethodError)
```

In hindsight, it's pretty obvious that I forgot to require `faraday`, but I like it when quickstarts give you everything you need to get your "hello world" to run, and then adds onto that afterwards.

## Todos

None!

