### PR TITLE
Doc: Added raise_error middleware configuration

### DIFF
--- a/docs/middleware/response/raise_error.md
+++ b/docs/middleware/response/raise_error.md
@@ -14,6 +14,10 @@ response returns with a 4xx or 5xx status code. All exceptions are initialized
 providing the response `status`, `headers`, and `body`.
 
 ```ruby
+conn = Faraday.new(url: 'http://sushi.com') do |faraday|
+  faraday.response :raise_error # raise Faraday::Error on status code 4xx or 5xx
+end
+
 begin
   conn.get('/wrong-url') # => Assume this raises a 404 response
 rescue Faraday::ResourceNotFound => e

--- a/docs/middleware/response/raise_error.md
+++ b/docs/middleware/response/raise_error.md
@@ -14,7 +14,7 @@ response returns with a 4xx or 5xx status code. All exceptions are initialized
 providing the response `status`, `headers`, and `body`.
 
 ```ruby
-conn = Faraday.new(url: 'http://sushi.com') do |faraday|
+conn = Faraday.new(url: 'http://httpbingo.org') do |faraday|
   faraday.response :raise_error # raise Faraday::Error on status code 4xx or 5xx
 end
 


### PR DESCRIPTION
## Description
Increased documentation for raise_error middleware. [Logger.md](https://github.com/lostisland/faraday/blob/main/docs/middleware/response/logger.md) already have this useful configuration line

## Todos
None