### PR TITLE
docs: Correct default default_adapter value

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -47,7 +47,7 @@ module Faraday
 
     # @overload default_adapter
     #   Gets the Symbol key identifying a default Adapter to use
-    #   for the default {Faraday::Connection}. Defaults to `:test`.
+    #   for the default {Faraday::Connection}. Defaults to `:net_http`.
     #   @return [Symbol] the default adapter
     # @overload default_adapter=(adapter)
     #   Updates default adapter while resetting {.default_connection}.


### PR DESCRIPTION
Since https://github.com/lostisland/faraday/pull/1366, the default value for `default_adapter` is `:net_http`.

Fixes https://www.rubydoc.info/gems/faraday/Faraday#default_adapter-class_method
