### PR TITLE
docs link fixed

### DIFF
--- a/docs/middleware/request/url_encoded.md
+++ b/docs/middleware/request/url_encoded.md
@@ -39,4 +39,4 @@ conn.post('/', { a: [1, 3], b: { c: 2, d: 4} })
 # Body: a%5B%5D=1&a%5B%5D=3&b%5Bc%5D=2&b%5Bd%5D=4
 ```
 
-[customize]: ../usage/customize/#changing-how-parameters-are-serialized
+[customize]: ../usage/customize#changing-how-parameters-are-serialized


### PR DESCRIPTION
## Description
a docs page's anchor link ,customized, can't transfer next page.

https://lostisland.github.io/faraday/middleware/url-encoded

before clicking on the anchor link.
![image](https://user-images.githubusercontent.com/30658134/178017820-3f2af760-f91a-45ce-8398-8d0c4d5ac379.png)

after clicking on the anchor link.
![image](https://user-images.githubusercontent.com/30658134/178017920-01d72f02-52a7-4a04-b05e-d32821be36ad.png)

URL is https://lostisland.github.io/faraday/usage/customize/#changing-how-parameters-are-serialized.
but correct URL is https://lostisland.github.io/faraday/usage/customize#changing-how-parameters-are-serialized.

![image](https://user-images.githubusercontent.com/30658134/178018481-6a35f31c-a778-479d-808e-8204cb898a04.png)

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [x] Documentation

## Additional Notes

I tested local Jekyll server.
but local jekyll server works correctly before the PR.

I'm sorry, I don't know the PR is correct.