### PR TITLE
Fix syntax to use correct doc link for url_encoded

### DIFF
--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -182,6 +182,6 @@ middleware used for the default connection is `:url_encoded`, which encodes
 those form hashes, and the `default_adapter`.
 
 Note that if you create your own connection with middleware, it won't encode
-form bodies unless you too include the [`:url_encoded`](encoding) middleware!
+form bodies unless you too include the [`:url_encoded`][encoding] middleware!
 
 [encoding]:   ../middleware/url-encoded


### PR DESCRIPTION
## Description

`:url_encoded` link on [usage](https://lostisland.github.io/faraday/usage/) page redirected to 404 page

<img width="1105" alt="Screenshot 2022-07-25 at 7 34 16 PM" src="https://user-images.githubusercontent.com/5279284/180796699-84d38510-6474-4a9e-b7cd-50aa918d6c79.png">
<img width="1176" alt="Screenshot 2022-07-25 at 7 35 34 PM" src="https://user-images.githubusercontent.com/5279284/180796728-130f6f1d-6044-4136-9f09-38071ced84a7.png">

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [x] Documentation

## Additional Notes
Not sure how to verify on local
