### PR TITLE
Support Proc type for stubbed request body

### DIFF
--- a/docs/adapters/testing.md
+++ b/docs/adapters/testing.md
@@ -64,6 +64,14 @@ initialized. This is useful for testing.
 stubs.get('/uni') { |env| [ 200, {}, 'urchin' ]}
 ```
 
+You can also stub the request body with a string or a proc.
+It would be useful to pass a proc if it's OK only to check the parts of the request body are passed.
+
+```ruby
+stubs.post('/kohada', 'where=sea&temperature=24') { |env| [ 200, {}, 'spotted gizzard shad' ]}
+stubs.post('/anago', -> (request_body) { JSON.parse(request_body).slice('name') == { 'name' => 'Wakamoto' } }) { |env| [200, {}, 'conger eel'] }
+```
+
 If you want to stub requests that exactly match a path, parameters, and headers,
 `strict_mode` would be useful.
 

--- a/examples/client_spec.rb
+++ b/examples/client_spec.rb
@@ -18,7 +18,7 @@ class Client
     data['origin']
   end
 
-  def foo!(params)
+  def foo(params)
     res = @conn.post('/foo', JSON.dump(params))
     res.status
   end
@@ -104,7 +104,7 @@ RSpec.describe Client do
     it 'tests with a string' do
       stubs.post('/foo', '{"name":"YK"}') { [200, {}, ''] }
 
-      expect(client.foo!(name: 'YK')).to eq 200
+      expect(client.foo(name: 'YK')).to eq 200
       stubs.verify_stubbed_calls
     end
 
@@ -112,7 +112,7 @@ RSpec.describe Client do
       check = -> (request_body) { JSON.parse(request_body).slice('name') == { 'name' => 'YK' } }
       stubs.post('/foo', check) { [200, {}, ''] }
 
-      expect(client.foo!(name: 'YK', created_at: Time.now)).to eq 200
+      expect(client.foo(name: 'YK', created_at: Time.now)).to eq 200
       stubs.verify_stubbed_calls
     end
   end

--- a/examples/client_spec.rb
+++ b/examples/client_spec.rb
@@ -17,6 +17,11 @@ class Client
     data = JSON.parse(res.body)
     data['origin']
   end
+
+  def foo!(params)
+    res = @conn.post('/foo', JSON.dump(params))
+    res.status
+  end
 end
 
 RSpec.describe Client do
@@ -91,6 +96,23 @@ RSpec.describe Client do
       # uncomment to raise Stubs::NotFound
       # expect(client.httpbingo('api', params: { a: %w[x y] })).to eq('127.0.0.1')
       expect(client.httpbingo('api', params: { a: %w[x y z] })).to eq('127.0.0.1')
+      stubs.verify_stubbed_calls
+    end
+  end
+
+  context 'When you want to test the body, you can use a proc as well as string' do
+    it 'tests with a string' do
+      stubs.post('/foo', '{"name":"YK"}') { [200, {}, ''] }
+
+      expect(client.foo!(name: 'YK')).to eq 200
+      stubs.verify_stubbed_calls
+    end
+
+    it 'tests with a proc' do
+      check = -> (request_body) { JSON.parse(request_body).slice('name') == { 'name' => 'YK' } }
+      stubs.post('/foo', check) { [200, {}, ''] }
+
+      expect(client.foo!(name: 'YK', created_at: Time.now)).to eq 200
       stubs.verify_stubbed_calls
     end
   end

--- a/examples/client_spec.rb
+++ b/examples/client_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Client do
     end
 
     it 'tests with a proc' do
-      check = -> (request_body) { JSON.parse(request_body).slice('name') == { 'name' => 'YK' } }
+      check = ->(request_body) { JSON.parse(request_body).slice('name') == { 'name' => 'YK' } }
       stubs.post('/foo', check) { [200, {}, ''] }
 
       expect(client.foo(name: 'YK', created_at: Time.now)).to eq 200

--- a/examples/client_test.rb
+++ b/examples/client_test.rb
@@ -19,7 +19,7 @@ class Client
     data['origin']
   end
 
-  def foo!(params)
+  def foo(params)
     res = @conn.post('/foo', JSON.dump(params))
     res.status
   end
@@ -119,7 +119,7 @@ class ClientTest < Test::Unit::TestCase
       stub.post('/foo', '{"name":"YK"}') { [200, {}, ''] }
     end
     cli = client(stubs)
-    assert_equal 200, cli.foo!(name: 'YK')
+    assert_equal 200, cli.foo(name: 'YK')
 
     stubs.verify_stubbed_calls
   end
@@ -130,7 +130,7 @@ class ClientTest < Test::Unit::TestCase
       stub.post('/foo', check) { [200, {}, ''] }
     end
     cli = client(stubs)
-    assert_equal 200, cli.foo!(name: 'YK', created_at: Time.now)
+    assert_equal 200, cli.foo(name: 'YK', created_at: Time.now)
 
     stubs.verify_stubbed_calls
   end

--- a/examples/client_test.rb
+++ b/examples/client_test.rb
@@ -126,7 +126,7 @@ class ClientTest < Test::Unit::TestCase
 
   def test_with_proc_body
     stubs = Faraday::Adapter::Test::Stubs.new do |stub|
-      check = -> (request_body) { JSON.parse(request_body).slice('name') == { 'name' => 'YK' } }
+      check = ->(request_body) { JSON.parse(request_body).slice('name') == { 'name' => 'YK' } }
       stub.post('/foo', check) { [200, {}, ''] }
     end
     cli = client(stubs)

--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -31,7 +31,9 @@ module Faraday
     #
     #      # You can pass a proc as a stubbed body and check the request body in your way.
     #      # In this case, the proc should return true or false.
-    #      stub.post('/foo', -> (request_body) { JSON.parse(request_body).slice('name') == { 'name' => 'YK' } }) { [200, {}, ''] }
+    #      stub.post('/foo', ->(request_body) do
+    #        JSON.parse(request_body).slice('name') == { 'name' => 'YK' } }) { [200, {}, '']
+    #      end
     #
     #       # You can set strict_mode to exactly match the stubbed requests.
     #       stub.strict_mode = true

--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -26,6 +26,13 @@ module Faraday
     #         ]
     #       end
     #
+    #      # Test the request body is the same as the stubbed body
+    #      stub.post('/bar', 'name=YK&word=call') { [200, {}, ''] }
+    #
+    #      # You can pass a proc as a stubbed body and check the request body in your way.
+    #      # In this case, the proc should return true or false.
+    #      stub.post('/foo', -> (request_body) { JSON.parse(request_body).slice('name') == { 'name' => 'YK' } }) { [200, {}, ''] }
+    #
     #       # You can set strict_mode to exactly match the stubbed requests.
     #       stub.strict_mode = true
     #     end
@@ -42,6 +49,12 @@ module Faraday
     #
     #   resp = test.get '/items/2'
     #   resp.body # => 'showing item: 2'
+    #
+    #   resp = test.post '/bar', 'name=YK&word=call'
+    #   resp.status # => 200
+    #
+    #   resp = test.post '/foo', JSON.dump(name: 'YK', created_at: Time.now)
+    #   resp.status # => 200
     class Test < Faraday::Adapter
       attr_accessor :stubs
 
@@ -181,7 +194,7 @@ module Faraday
           [(host.nil? || host == request_host) &&
             path_match?(request_path, meta) &&
             params_match?(env) &&
-            (body.to_s.size.zero? || request_body == body) &&
+            body_match?(request_body) &&
             headers_match?(request_headers), meta]
         end
 
@@ -219,6 +232,17 @@ module Faraday
 
           headers.keys.all? do |key|
             request_headers[key] == headers[key]
+          end
+        end
+
+        def body_match?(request_body)
+          return true if body.to_s.size.zero?
+
+          case body
+          when Proc
+            body.call(request_body)
+          else
+            request_body == body
           end
         end
 

--- a/spec/faraday/adapter/test_spec.rb
+++ b/spec/faraday/adapter/test_spec.rb
@@ -381,8 +381,8 @@ RSpec.describe Faraday::Adapter::Test do
           stubs.post('/with_string', 'abc') { [200, {}, 'ok'] }
           stubs.post(
             '/with_proc',
-            -> (request_body) { JSON.parse(request_body, symbolize_names: true) == { x: '!', a: [{ m: [{ a: true }], n: 123 }] } },
-            { content_type: 'application/json' },
+            ->(request_body) { JSON.parse(request_body, symbolize_names: true) == { x: '!', a: [{ m: [{ a: true }], n: 123 }] } },
+            { content_type: 'application/json' }
           ) do
             [200, {}, 'ok']
           end


### PR DESCRIPTION
## Description

Previously, the Faraday testing adapter compared the request body to the stubbed body just by calling `#==` if the stubbed body is present. Sometimes, I want to check the equality between request and stubbed body in more advanced ways. For example, there is a case that I want to check only the parts of the body are actually passed to Faraday instance like this:

```ruby
stubs = Faraday::Adapter::Test::Stubs.new do |stub|
  stub.post('/foo', '{"name:"YK","created_at":"ANY STRING IS OK"}') { [200, {}, ''] }
end
connection.post('/foo', JSON.dump(name: 'YK', created_at: Time.now))
stubs.verify_stubbed_calls
```

In this case, it's difficult to make tests always pass with `"created_at"` because the value is dynamic. So, I came up with an idea to pass a proc as a stubbed value and compare bodies, inside the proc:

```ruby
stubs = Faraday::Adapter::Test::Stubs.new do |stub|
  check = -> (request_body) { JSON.parse(request_body).slice('name') == { 'name' => 'YK' } }
  stub.post('/foo', check) { [200, {}, ''] }
end
connection.post('/foo', JSON.dump(name: 'YK', created_at: Time.now))
stubs.verify_stubbed_calls
```

I believe this would be flexible but compatible with the previous behavior.

