### PR TITLE
add `Faraday#Deprecate` to `1.x`

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'faraday/deprecate'
+
 module Faraday
   # Connection objects manage the default properties and the middleware
   # stack for fulfilling an HTTP request.
@@ -297,13 +299,11 @@ module Faraday
     #
     # @return [void]
     def basic_auth(login, pass)
-      warn <<~TEXT
-        WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
-        While initializing your connection, use `#request(:basic_auth, ...)` instead.
-        See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
-      TEXT
       set_authorization_header(:basic_auth, login, pass)
     end
+
+    extend Faraday::Deprecate
+    deprecate :basic_auth, '#request(:basic_auth, ...)', '2.0'
 
     # Sets up the Authorization header with the given token.
     #

--- a/lib/faraday/deprecate.rb
+++ b/lib/faraday/deprecate.rb
@@ -54,7 +54,6 @@ module Faraday
         else :skip
         end
       end
-      @skip = :warn
       @skip == :skip
     end
 
@@ -65,7 +64,7 @@ module Faraday
     # Temporarily turn off warnings. Intended for tests only.
     def skip_during
       original = Faraday::Deprecate.skip
-      Faraday::Deprecate.skip, = true
+      Faraday::Deprecate.skip = true
       yield
     ensure
       Faraday::Deprecate.skip = original

--- a/lib/faraday/deprecate.rb
+++ b/lib/faraday/deprecate.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Faraday
+  # @param new_klass [Class] new Klass to use
+  #
+  # @return [Class] A modified version of new_klass that warns on
+  #   usage about deprecation.
+  # @see Faraday::Deprecate
+  module DeprecatedClass
+    def self.proxy_class(origclass, ver = '1.0')
+      proxy = Class.new(origclass) do
+        const_set('ORIG_CLASS', origclass)
+
+        class << self
+          extend Faraday::Deprecate
+
+          def ===(other)
+            (superclass == const_get('ORIG_CLASS') && other.is_a?(superclass)) || super
+          end
+        end
+      end
+      proxy.singleton_class.send(:deprecate, :new, "#{origclass}.new", ver)
+      proxy.singleton_class.send(:deprecate, :inherited, origclass.name, ver)
+      proxy
+    end
+  end
+
+  # Deprecation using semver instead of date, based on Gem::Deprecate
+  # Provides a single method +deprecate+ to be used to declare when
+  # something is going away.
+  #
+  #     class Legacy
+  #       def self.klass_method
+  #         # ...
+  #       end
+  #
+  #       def instance_method
+  #         # ...
+  #       end
+  #
+  #       extend Faraday::Deprecate
+  #       deprecate :instance_method, "X.z", '1.0'
+  #
+  #       class << self
+  #         extend Faraday::Deprecate
+  #         deprecate :klass_method, :none, '1.0'
+  #       end
+  #     end
+  module Deprecate
+    def self.skip # :nodoc:
+      @skip ||= begin
+        case ENV['FARADAY_DEPRECATE'].to_s.downcase
+        when '1', 'warn' then :warn
+        else :skip
+        end
+      end
+      @skip = :warn
+      @skip == :skip
+    end
+
+    def self.skip=(value) # :nodoc:
+      @skip = value ? :skip : :warn
+    end
+
+    # Temporarily turn off warnings. Intended for tests only.
+    def skip_during
+      original = Faraday::Deprecate.skip
+      Faraday::Deprecate.skip, = true
+      yield
+    ensure
+      Faraday::Deprecate.skip = original
+    end
+
+    # Simple deprecation method that deprecates +name+ by wrapping it up
+    # in a dummy method. It warns on each call to the dummy method
+    # telling the user of +repl+ (unless +repl+ is :none) and the
+    # semver that it is planned to go away.
+    # @param name [Symbol] the method symbol to deprecate
+    # @param repl [#to_s, :none] the replacement to use, when `:none` it will
+    #   alert the user that no replacemtent is present.
+    # @param ver [String] the semver the method will be removed.
+    def deprecate(name, repl, ver)
+      class_eval do
+        gem_ver = Gem::Version.new(ver)
+        old = "_deprecated_#{name}"
+        alias_method old, name
+        define_method name do |*args, &block|
+          mod = is_a? Module
+          target = mod ? "#{self}." : "#{self.class}#"
+          target_message = if name == :inherited
+                             "Inheriting #{self}"
+                           else
+                             "#{target}#{name}"
+                           end
+
+          msg = [
+            "NOTE: #{target_message} is deprecated",
+            repl == :none ? ' with no replacement' : "; use #{repl} instead. ",
+            "It will be removed in or after version #{gem_ver}",
+            "\n#{target}#{name} called from #{Gem.location_of_caller.join(':')}"
+          ]
+          warn "#{msg.join}." unless Faraday::Deprecate.skip
+          send old, *args, &block
+        end
+      end
+    end
+
+    module_function :deprecate, :skip_during
+  end
+end

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday/deprecate'
-
 # Faraday namespace.
 module Faraday
   # Faraday error base class.

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'faraday/deprecate'
+
 # Faraday namespace.
 module Faraday
   # Faraday error base class.
@@ -142,5 +144,13 @@ module Faraday
 
   # Raised by FaradayMiddleware::ResponseMiddleware
   class ParsingError < Error
+  end
+
+  %i[ClientError ConnectionFailed ResourceNotFound
+     ParsingError TimeoutError SSLError].each do |const|
+    Error.const_set(
+      const,
+      DeprecatedClass.proxy_class(Faraday.const_get(const))
+    )
   end
 end

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -145,12 +145,4 @@ module Faraday
   # Raised by FaradayMiddleware::ResponseMiddleware
   class ParsingError < Error
   end
-
-  %i[ClientError ConnectionFailed ResourceNotFound
-     ParsingError TimeoutError SSLError].each do |const|
-    Error.const_set(
-      const,
-      DeprecatedClass.proxy_class(Faraday.const_get(const))
-    )
-  end
 end

--- a/spec/faraday/deprecate_spec.rb
+++ b/spec/faraday/deprecate_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+RSpec.describe Faraday::DeprecatedClass do
+  class SampleClass < StandardError
+    attr_accessor :foo
+
+    def initialize(foo = nil)
+      @foo = foo || :foo
+    end
+  end
+
+  SampleDeprecatedClass = Faraday::DeprecatedClass.proxy_class(SampleClass)
+
+  it 'does not raise error for deprecated classes but prints an error message' do
+    error_message, foobar = with_warn_squelching { SampleDeprecatedClass.new(:foo_bar) }
+    expect(foobar).to be_a(SampleClass)
+    expect(foobar.foo).to eq(:foo_bar)
+    expect(error_message).to match(
+      Regexp.new(
+        'NOTE: SampleDeprecatedClass.new is deprecated; '\
+        'use SampleClass.new instead. It will be removed in or after version 1.0'
+      )
+    )
+  end
+
+  it 'does not raise an error for inherited error-namespaced classes but prints an error message' do
+    error_message, = with_warn_squelching { Class.new(SampleDeprecatedClass) }
+
+    expect(error_message).to match(
+      Regexp.new(
+        'NOTE: Inheriting SampleDeprecatedClass is deprecated; '\
+        'use SampleClass instead. It will be removed in or after version 1.0'
+      )
+    )
+  end
+
+  it 'allows backward-compatible class to be subclassed' do
+    expect do
+      with_warn_squelching { Class.new(SampleDeprecatedClass) }
+    end.not_to raise_error
+  end
+
+  it 'allows rescuing of a current error with a deprecated error' do
+    expect { raise SampleClass, nil }.to raise_error(SampleDeprecatedClass)
+  end
+
+  it 'allows rescuing of a current error with a current error' do
+    expect { raise SampleClass, nil }.to raise_error(SampleClass)
+  end
+
+  it 'allows rescuing of a deprecated error with a deprecated error' do
+    expect { raise SampleDeprecatedClass, nil }.to raise_error(SampleDeprecatedClass)
+  end
+
+  it 'allows rescuing of a deprecated error with a current error' do
+    expect { raise SampleDeprecatedClass, nil }.to raise_error(SampleClass)
+  end
+
+  describe 'match behavior' do
+    class SampleDeprecatedClassA < SampleDeprecatedClass; end
+    class SampleDeprecatedClassB < SampleDeprecatedClass; end
+
+    class SampleDeprecatedClassAX < SampleDeprecatedClassA; end
+
+    class SampleClassA < SampleClass; end
+
+    describe 'undeprecated class' do
+      it 'is === to instance of deprecated class' do
+        expect(SampleDeprecatedClass.new.is_a?(SampleClass)).to be true
+      end
+
+      it 'is === to instance of subclass of deprecated class' do
+        expect(SampleDeprecatedClassA.new.is_a?(SampleClass)).to be true
+      end
+
+      it 'is === to instance of subclass of subclass of deprecated class' do
+        expect(SampleDeprecatedClassAX.new.is_a?(SampleClass)).to be true
+      end
+    end
+
+    describe 'subclass of undeprecated class' do
+      it 'is not === to instance of undeprecated class' do
+        expect(SampleClass.new.is_a?(SampleClassA)).to be false
+      end
+
+      it 'is not === to instance of deprecated class' do
+        expect(SampleDeprecatedClass.new.is_a?(SampleClassA)).to be false
+      end
+    end
+
+    describe 'deprecated class' do
+      it 'is === to instance of undeprecated class' do
+        expect(SampleDeprecatedClass.new.is_a?(SampleClass)).to be true
+      end
+
+      it 'is === to instance of subclass of undeprecated class' do
+        expect(SampleClassA.superclass == SampleDeprecatedClass.superclass).to be true
+      end
+
+      it 'is === to instance of subclass of deprecated class' do
+        expect(SampleDeprecatedClassA.new.is_a?(SampleDeprecatedClass)).to be true
+      end
+
+      it 'is === to instance of subclass of subclass of deprecated class' do
+        expect(SampleDeprecatedClassAX.new.is_a?(SampleDeprecatedClass)).to be true
+      end
+    end
+
+    describe 'subclass of deprecated class' do
+      it 'is not === to instance of subclass of undeprecated class' do
+        expect(SampleClass.new.is_a?(SampleDeprecatedClassA)).to be false
+      end
+
+      it 'is not === to instance of another subclass of deprecated class' do
+        expect(SampleDeprecatedClassB.new.is_a?(SampleDeprecatedClassA)).to be false
+      end
+
+      it 'is === to instance of its subclass' do
+        expect(SampleDeprecatedClassAX.new.is_a?(SampleDeprecatedClassA)).to be true
+      end
+
+      it 'is === to instance of deprecated class' do
+        expect(SampleDeprecatedClassB.new.is_a?(SampleDeprecatedClass)).to be true
+      end
+    end
+
+    describe 'subclass of subclass of deprecated class' do
+      it 'is not === to instance of subclass of another subclass of deprecated class' do
+        expect(SampleDeprecatedClassB.new.is_a?(SampleDeprecatedClassAX)).to be false
+      end
+
+      it 'is not === to instance of its superclass' do
+        expect(SampleDeprecatedClass.new.is_a?(SampleDeprecatedClassA)).to be false
+      end
+    end
+  end
+
+  def with_warn_squelching
+    stderr_catcher = StringIO.new
+    original_stderr = $stderr
+    $stderr = stderr_catcher
+    result = yield if block_given?
+    [stderr_catcher.tap(&:rewind).string, result]
+  ensure
+    $stderr = original_stderr
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,8 @@ require 'pry'
 
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
+Faraday::Deprecate.skip = false
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## Description
add Faraday#Deprecate to hide deprecate method's warning message

Fixes https://github.com/lostisland/faraday/issues/1410

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [ ] Documentation

## Additional Notes
