### PR TITLE
deprecate three methods for version 2.0

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -319,13 +319,10 @@ module Faraday
     #
     # @return [void]
     def token_auth(token, options = nil)
-      warn <<~TEXT
-        WARNING: `Faraday::Connection#token_auth` is deprecated; it will be removed in version 2.0.
-        While initializing your connection, use `#request(:token_auth, ...)` instead.
-        See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
-      TEXT
       set_authorization_header(:token_auth, token, options)
     end
+
+    deprecate :token_auth, '#request(:token_auth, ...)', '2.0'
 
     # Sets up a custom Authorization header.
     #
@@ -346,13 +343,10 @@ module Faraday
     #
     # @return [void]
     def authorization(type, token)
-      warn <<~TEXT
-        WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
-        While initializing your connection, use `#request(:authorization, ...)` instead.
-        See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
-      TEXT
       set_authorization_header(:authorization, type, token)
     end
+
+    deprecate :authorization, '#request(:authorization, ...)', '2.0'
 
     # Check if the adapter is parallel-capable.
     #

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -322,7 +322,10 @@ module Faraday
       set_authorization_header(:token_auth, token, options)
     end
 
-    deprecate :token_auth, '#request(:token_auth, ...)', '2.0'
+    deprecate :token_auth,
+              '#request(:token_auth, ...)',
+              '2.0',
+              'See https://lostisland.github.io/faraday/middleware/authentication for more usage info.'
 
     # Sets up a custom Authorization header.
     #
@@ -346,7 +349,10 @@ module Faraday
       set_authorization_header(:authorization, type, token)
     end
 
-    deprecate :authorization, '#request(:authorization, ...)', '2.0'
+    deprecate :authorization,
+              '#request(:authorization, ...)',
+              '2.0',
+              'See https://lostisland.github.io/faraday/middleware/authentication for more usage info.'
 
     # Check if the adapter is parallel-capable.
     #

--- a/lib/faraday/deprecate.rb
+++ b/lib/faraday/deprecate.rb
@@ -78,7 +78,7 @@ module Faraday
     # @param repl [#to_s, :none] the replacement to use, when `:none` it will
     #   alert the user that no replacement is present.
     # @param ver [String] the semver the method will be removed.
-    def deprecate(name, repl, ver)
+    def deprecate(name, repl, ver, custom_message = nil)
       class_eval do
         gem_ver = Gem::Version.new(ver)
         old = "_deprecated_#{name}"
@@ -95,7 +95,8 @@ module Faraday
           msg = [
             "NOTE: #{target_message} is deprecated",
             repl == :none ? ' with no replacement' : "; use #{repl} instead. ",
-            "It will be removed in or after version #{gem_ver}",
+            "It will be removed in or after version #{gem_ver} ",
+            custom_message,
             "\n#{target}#{name} called from #{Gem.location_of_caller.join(':')}"
           ]
           warn "#{msg.join}." unless Faraday::Deprecate.skip

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -58,12 +58,11 @@ module Faraday
     end
 
     def method
-      warn <<~TEXT
-        WARNING: `Faraday::Request##{__method__}` is deprecated; use `#http_method` instead. It will be removed in or after version 2.0.
-        `Faraday::Request##{__method__}` called from #{caller_locations(1..1).first}
-      TEXT
       http_method
     end
+
+    extend Faraday::Deprecate
+    deprecate :method, :http_method, '2.0'
 
     # Replace params, preserving the existing hash type.
     #

--- a/spec/faraday/request_spec.rb
+++ b/spec/faraday/request_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Faraday::Request do
   describe 'deprecate method for HTTP method' do
     let(:http_method) { :post }
     let(:expected_warning) do
-      %r{WARNING: `Faraday::Request#method` is deprecated; use `#http_method` instead. It will be removed in or after version 2.0.\n`Faraday::Request#method` called from .+/spec/faraday/request_spec.rb:\d+.}
+      %r{NOTE: Faraday::Request#method is deprecated; use http_method instead\. It will be removed in or after version 2.0\nFaraday::Request#method called from .+/spec/faraday/request_spec.rb:\d+.}
     end
 
     it { expect(subject.method).to eq(:post) }

--- a/spec/faraday/request_spec.rb
+++ b/spec/faraday/request_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Faraday::Request do
   describe 'deprecate method for HTTP method' do
     let(:http_method) { :post }
     let(:expected_warning) do
-      %r{NOTE: Faraday::Request#method is deprecated; use http_method instead\. It will be removed in or after version 2.0\nFaraday::Request#method called from .+/spec/faraday/request_spec.rb:\d+.}
+      %r{NOTE: Faraday::Request#method is deprecated; use http_method instead\. It will be removed in or after version 2.0 \nFaraday::Request#method called from .+/spec/faraday/request_spec.rb:\d+.}
     end
 
     it { expect(subject.method).to eq(:post) }


### PR DESCRIPTION
## Description
apply `Faraday#deprecate` to three deprecated methods for version 2.0.

- `Request#method`
- `Connection#token_auth`
- `Connection#authorization`

related with https://github.com/lostisland/faraday/pull/1438

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [ ] Documentation

## Additional Notes
Optional section
