### PR TITLE
docs: fix usage page to match latest version's default adapter specification

### DIFF
--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -10,6 +10,28 @@ a Faraday response object. Adapters are typically implemented with common Ruby
 HTTP clients, but can have custom implementations. Adapters can be configured
 either globally or per Faraday Connection through the configuration block.
 
+For example, consider using `httpclient` as an adapter. Note that [faraday-httpclient](https://github.com/lostisland/faraday-httpclient) must be installed beforehand.
+
+If you wants to configure it globally, do the following:
+
+```ruby
+require 'faraday'
+require 'faraday/httpclient'
+
+Faraday.default_adapter = :httpclient
+```
+
+If you want to configure it per Faraday Connection, do the following:
+
+```ruby
+require 'faraday'
+require 'faraday/httpclient'
+
+conn = Faraday.new do |f|
+  f.adapter :httpclient
+end
+```
+
 {: .mt-60}
 ## Fantastic adapters and where to find them
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -10,22 +10,7 @@ order: 1
 Let's fetch the home page for the wonderful
 [httpbingo.org](https://httpbingo.org) service.
 
-First of all, you need to tell Faraday which [`adapter`](../adapters) you wish to use.
-Adapters are responsible for actually executing HTTP requests.
-There are many different adapters you can choose from.
-Just pick the one you like and install it, or add it to your project Gemfile.
-You might want to use Faraday with the `Net::HTTP` adapter, for example.
-[Learn more about Adapters](../adapters).
-
-Remember you'll need to install the corresponding adapter gem before you'll be able to use it.
-
-```ruby
-require 'faraday'
-require 'faraday/net_http'
-Faraday.default_adapter = :net_http
-```
-
-Next, you can make a simple `GET` request using `Faraday.get`:
+You can make a simple `GET` request using `Faraday.get`:
 
 ```ruby
 response = Faraday.get('http://httpbingo.org')
@@ -134,6 +119,13 @@ response = conn.post('post') do |req|
 end
 # => POST http://httpbingo.org/post?limit=100
 ```
+
+### Adapters
+
+Adapters are responsible for actually executing HTTP requests. The default
+adapter uses Ruby's `Net::HTTP`, but there are many different adapters
+available. You might want to use Faraday with the Typhoeus adapter, for example.
+[Learn more about Adapters](../adapters).
 
 ### Middleware
 


### PR DESCRIPTION
## Description

Since https://github.com/lostisland/faraday/pull/1366, the default value for default_adapter is :net_http.

## Additional Notes

The added Adapters section was referenced [here](https://github.com/lostisland/faraday/pull/1353/files#diff-15c410571e14efe1076710d52f0e43cef4068175812ffde74ca941b62e494a44L131).
