### PR TITLE
Forward the env to Request::Authorization#header_from

### DIFF
--- a/docs/middleware/request/authentication.md
+++ b/docs/middleware/request/authentication.md
@@ -30,6 +30,14 @@ Faraday.new(...) do |conn|
 end
 ```
 
+If the proc takes an argument, it will receive the forwarded `env`
+
+```ruby
+Faraday.new(...) do |conn|
+  conn.request :authorization, 'Bearer', ->(env) { MyAuthStorage.get_auth_token(env) }
+end
+```
+
 ### Basic Authentication
 
 The middleware will automatically Base64 encode your Basic username and password:

--- a/spec/faraday/request/authorization_spec.rb
+++ b/spec/faraday/request/authorization_spec.rb
@@ -72,6 +72,41 @@ RSpec.describe Faraday::Request::Authorization do
       include_examples 'does not interfere with existing authentication'
     end
 
+    context 'with an argument' do
+      let(:response) { conn.get('/auth-echo', nil, 'middle' => 'crunchy surprise') }
+
+      context 'when passed a proc' do
+        let(:auth_config) { [proc { |env| "proc #{env.request_headers['middle']}" }] }
+
+        it { expect(response.body).to eq('Bearer proc crunchy surprise') }
+
+        include_examples 'does not interfere with existing authentication'
+      end
+
+      context 'when passed a lambda' do
+        let(:auth_config) { [->(env) { "lambda #{env.request_headers['middle']}" }] }
+
+        it { expect(response.body).to eq('Bearer lambda crunchy surprise') }
+
+        include_examples 'does not interfere with existing authentication'
+      end
+
+      context 'when passed a callable with an argument' do
+        let(:callable) do
+          Class.new do
+            def call(env)
+              "callable #{env.request_headers['middle']}"
+            end
+          end.new
+        end
+        let(:auth_config) { [callable] }
+
+        it { expect(response.body).to eq('Bearer callable crunchy surprise') }
+
+        include_examples 'does not interfere with existing authentication'
+      end
+    end
+
     context 'when passed too many arguments' do
       let(:auth_config) { %w[baz foo] }
 


### PR DESCRIPTION
This will allow more sophisticated signing when calculating the Authorization header that can depend on the parameters of the request (or anything else in the `env`)

## Description
Suggested in #1449 to a generally positive response. I included a specs for both procs and lambdas since it came up in that discussion. I tried to update the website. Sorry I was slow to be getting on with it, but here it is
