### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ env:
   GIT_BRANCH: ${{ github.ref }}
   COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,8 @@ on:
   release:
     types: [published]
 
-permissions: {}
+permissions:
+  contents: read  # to checkout the code (actions/checkout)
 jobs:
   build:
     name: Publish to Rubygems

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   release:
     types: [published]
 
+permissions: {}
 jobs:
   build:
     name: Publish to Rubygems

--- a/.github/workflows/refresh_team_page.yml
+++ b/.github/workflows/refresh_team_page.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
 
+permissions: {}
 jobs:
   build:
     name: Refresh Contributors Stats


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.