### PR TITLE
Silence Multipart/Post depreciation warnings

### DIFF
--- a/lib/faraday/upload_io.rb
+++ b/lib/faraday/upload_io.rb
@@ -1,6 +1,5 @@
 begin
-  require 'composite_io'
-  require 'parts'
+  require 'multipart/post'
   require 'stringio'
 rescue LoadError
   $stderr.puts "Install the multipart-post gem."
@@ -62,6 +61,6 @@ module Faraday
     end
   end
 
-  UploadIO = ::UploadIO
-  Parts = ::Parts
+  UploadIO = ::Multipart::Post::UploadIO
+  Parts = ::Multipart::Post::Parts
 end

--- a/lib/faraday/upload_io.rb
+++ b/lib/faraday/upload_io.rb
@@ -2,8 +2,14 @@ begin
   require 'multipart/post'
   require 'stringio'
 rescue LoadError
-  $stderr.puts "Install the multipart-post gem."
-  raise
+  begin
+    require 'composite_io'
+    require 'parts'
+    require 'stringio'
+  rescue LoadError
+    $stderr.puts "Install the multipart-post gem."
+    raise
+  end
 end
 
 module Faraday
@@ -61,6 +67,11 @@ module Faraday
     end
   end
 
-  UploadIO = ::Multipart::Post::UploadIO
-  Parts = ::Multipart::Post::Parts
+  if defined?(::Multipart::Post::UploadIO)
+    UploadIO = ::Multipart::Post::UploadIO
+    Parts = ::Multipart::Post::Parts
+  else
+    UploadIO = ::UploadIO
+    Parts = ::Parts
+  end
 end


### PR DESCRIPTION
When starting up an app, you get:

```
Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
Top level ::Parts is deprecated, require 'multipart/post' and use `Multipart::Post::Parts` instead!
.../faraday-0.17.5/lib/faraday/upload_io.rb:65: warning: constant ::UploadIO is deprecated
.../faraday-0.17.5/lib/faraday/upload_io.rb:66: warning: constant ::Parts is deprecated
```

## Description
A few sentences describing the overall goals of the pull request's commits.
Link to related issues if any. (As `Fixes #XXX`)

## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests
- [ ] Documentation

## Additional Notes
Optional section
