### PR TITLE
Make `Headers#[]=` set a value as String

### DIFF
--- a/lib/faraday/utils/headers.rb
+++ b/lib/faraday/utils/headers.rb
@@ -59,7 +59,7 @@ module Faraday
         key = (@names[key.downcase] ||= key)
         # join multiple values with a comma
         val = val.to_ary.join(', ') if val.respond_to?(:to_ary)
-        super(key, val)
+        super(key, val.to_s)
       end
 
       def fetch(key, *args, &block)

--- a/spec/faraday/utils/headers_spec.rb
+++ b/spec/faraday/utils/headers_spec.rb
@@ -23,6 +23,28 @@ RSpec.describe Faraday::Utils::Headers do
     it { is_expected.to include('content-type') }
   end
 
+  describe '#[]=' do
+    it 'returns the string value' do
+      h = subject.tap { |s| s['Foo'] = '!' }
+      expect(h[:foo]).to eq('!')
+    end
+
+    it 'returns the string value if an integer is passed' do
+      h = subject.tap { |s| s['Foo'] = 123 }
+      expect(h[:foo]).to eq('123')
+    end
+
+    it 'returns the string value if a symbol is passed' do
+      h = subject.tap { |s| s['Foo'] = :test }
+      expect(h[:foo]).to eq('test')
+    end
+
+    it 'returns the string value if an array is passed' do
+      h = subject.tap { |s| s['Foo'] = [1, 2, 3, :h] }
+      expect(h[:foo]).to eq('1, 2, 3, h')
+    end
+  end
+
   describe '#fetch' do
     before { subject['Content-Type'] = 'application/json' }
 


### PR DESCRIPTION
## Description

`Faraday::Utils::Headers#[]=` has converted a passed value into a String separated with `", "` if the value is an array. On the other hand, `#[]=` had stored the value as is if the value is not an array.

This is the previous behavior:

```ruby
h = Faraday::Utils::Headers.new
h[:length] = 123
h[:length] # => 123

h[:length] = [123, 234]
h[:length] # => "123, 234"
```

I think this is a bit confusing, and it should consistently store a value as string.

With this patch, we will get the headers with all stored values as string.

```ruby
h = Faraday::Utils::Headers.new
h[:length] = 123
h[:length] # => "123"

h[:length] = [123, 234]
h[:length] # => "123, 234"
```

It might be a breaking change, but I think it's worth discussing.

What do you think?

## Todos

List any remaining work that needs to be done, i.e:
- [x] Tests
- ~[ ] Documentation~
- [ ] Maybe, CHANGELOG should be updated

