### PR TITLE
Remove unnecessary `require 'pp'`

### DIFF
--- a/lib/faraday/logging/formatter.rb
+++ b/lib/faraday/logging/formatter.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'pp'
-
 module Faraday
   module Logging
     # Serves as an integration point to customize logging


### PR DESCRIPTION
## Description
Fix the `Lint/RedundantRequireStatement` cop introduced in Rubocop 1.38.0:
```
lib/faraday/logging/formatter.rb:3:1: W: [Correctable] Lint/RedundantRequireStatement: Remove unnecessary require statement.
require 'pp'
^^^^^^^^^^^^
```