### PR TITLE
Convert `self[key]` to a String with `#<<` on `#add_parsed`

### DIFF
--- a/lib/faraday/utils/headers.rb
+++ b/lib/faraday/utils/headers.rb
@@ -132,7 +132,12 @@ module Faraday
 
       # Join multiple values with a comma.
       def add_parsed(key, value)
-        self[key] ? self[key] << ', ' << value : self[key] = value
+        if key?(key)
+          self[key] = self[key].to_s
+          self[key] << ', ' << value
+        else
+          self[key] = value
+        end
       end
     end
   end

--- a/spec/faraday/utils/headers_spec.rb
+++ b/spec/faraday/utils/headers_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe Faraday::Utils::Headers do
   end
 
   describe '#parse' do
-    before { subject.parse(headers) }
-
     context 'when response headers leave http status line out' do
       let(:headers) { "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" }
+
+      before { subject.parse(headers) }
 
       it { expect(subject.keys).to eq(%w[Content-Type]) }
       it { expect(subject['Content-Type']).to eq('text/html') }
@@ -70,13 +70,31 @@ RSpec.describe Faraday::Utils::Headers do
     context 'when response headers values include a colon' do
       let(:headers) { "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nLocation: http://httpbingo.org/\r\n\r\n" }
 
+      before { subject.parse(headers) }
+
       it { expect(subject['location']).to eq('http://httpbingo.org/') }
     end
 
     context 'when response headers include a blank line' do
       let(:headers) { "HTTP/1.1 200 OK\r\n\r\nContent-Type: text/html\r\n\r\n" }
 
+      before { subject.parse(headers) }
+
       it { expect(subject['content-type']).to eq('text/html') }
+    end
+
+    context 'when response headers include already stored keys' do
+      let(:headers) { "HTTP/1.1 200 OK\r\nX-Numbers: 123\r\n\r\n" }
+
+      before do
+        h = subject
+        h[:x_numbers] = 8
+        h.parse(headers)
+      end
+
+      it do
+        expect(subject[:x_numbers]).to eq('8, 123')
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

I want to handle [this problem](https://github.com/lostisland/faraday/pull/1456#issuecomment-1309567153).

As I said in #1456, an instance of `Faraday::Utils::Headers` may have non-string values. So, an error might happen when the instance calls `#parse` with such existing values. For example, this code will raise an error before this PR is merged.

```
irb(main):001:0> h = Faraday::Utils::Headers.new
=> {}
irb(main):002:0> h[:foo] = 123
=> 123
irb(main):003:0> h.parse 'foo: 89'
/Users/yutaka.kamei/git/Fork/faraday/lib/faraday/utils/headers.rb:135:in `<<': no implicit conversion of String into Integer (TypeError)
	from /Users/yutaka.kamei/git/Fork/faraday/lib/faraday/utils/headers.rb:135:in `add_parsed'
	from /Users/yutaka.kamei/git/Fork/faraday/lib/faraday/utils/headers.rb:124:in `block in parse'
	from /Users/yutaka.kamei/git/Fork/faraday/lib/faraday/utils/headers.rb:124:in `each'
	from /Users/yutaka.kamei/git/Fork/faraday/lib/faraday/utils/headers.rb:124:in `parse'
	from (irb):3:in `<main>'
	from ./bin/console:15:in `<main>'
```


## Todos

List any remaining work that needs to be done, i.e:

- [x] Tests
- ~[ ] Documentation~

