### PR TITLE
Enforce timeouts in Faraday's test adapter

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -78,8 +78,7 @@ module Faraday
     # @param type [Symbol] Describes which timeout setting to get: :read,
     #                      :write, or :open.
     # @param options [Hash] Hash containing Symbol keys like :timeout,
-    #                       :read_timeout, :write_timeout, :open_timeout, or
-    #                       :timeout
+    #                       :read_timeout, :write_timeout, or :open_timeout
     #
     # @return [Integer, nil] Timeout duration in seconds, or nil if no timeout
     #                        has been set.

--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -280,10 +280,10 @@ module Faraday
 
         block_arity = stub.block.arity
         params = if block_arity >= 0
-          [env, meta].take(block_arity)
-        else
-          [env, meta]
-        end
+                   [env, meta].take(block_arity)
+                 else
+                   [env, meta]
+                 end
 
         timeout = request_timeout(:open, env[:request])
         timeout ||= request_timeout(:read, env[:request])
@@ -296,7 +296,6 @@ module Faraday
           else
             stub.block.call(*params)
           end
-
 
         # We need to explicitly pass `reason_phrase = nil` here to avoid keyword args conflicts.
         #   See https://github.com/lostisland/faraday/issues/1444

--- a/spec/faraday/adapter/test_spec.rb
+++ b/spec/faraday/adapter/test_spec.rb
@@ -410,4 +410,33 @@ RSpec.describe Faraday::Adapter::Test do
       end
     end
   end
+
+  describe 'request timeout' do
+    subject(:request) do
+      connection.get('/sleep') do |req|
+        req.options.timeout = timeout
+      end
+    end
+
+    before do
+      stubs.get('/sleep') do
+        sleep(0.01)
+        [200, {}, '']
+      end
+    end
+
+    context 'when request is within timeout' do
+      let(:timeout) { 1 }
+
+      it { expect(request.status).to eq 200 }
+    end
+
+    context 'when request is too slow' do
+      let(:timeout) { 0.001 }
+
+      it 'raises an exception' do
+        expect { request }.to raise_error(Faraday::TimeoutError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
Upgrade faraday's test adapter to enforce connection timeouts.  Inspired by the [faraday-rack](https://github.com/lostisland/faraday-rack/blob/main/lib/faraday/adapter/rack.rb) implementation.