### PR TITLE
Replace actions/setup-ruby with ruby/setup-ruby

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
 


### PR DESCRIPTION
## Description
`actions/setup-ruby` is already deprecated and cannot be used. Therefore, switch to `ruby/setup-ruby`.

> Please note: This action is deprecated and should no longer be used. The team at GitHub has ceased making and accepting code contributions or maintaining issues tracker. Please, migrate your workflows to the [ruby/setup-ruby](https://github.com/ruby/setup-ruby), which is being actively maintained by the official Ruby organization.

From https://github.com/actions/setup-ruby
