### PR TITLE
Rename Faraday::Logger::Formatter#error to #exception

### DIFF
--- a/docs/middleware/response/logger.md
+++ b/docs/middleware/response/logger.md
@@ -96,7 +96,8 @@ end
 You can also provide a custom formatter to control how requests, responses and errors are logged.
 Any custom formatter MUST implement the `request` and `response` method, with one argument which
 will be passed being the Faraday environment.
-Any custom formatter CAN implement the `error` method, with one argument which will be passed being the Faraday error.
+Any custom formatter CAN implement the `exception` method,
+with one argument which will be passed being the exception (StandardError).
 If you make your formatter inheriting from `Faraday::Logging::Formatter`,
 then the methods `debug`, `info`, `warn`, `error` and `fatal` are automatically delegated to the logger.
 
@@ -112,8 +113,8 @@ class MyFormatter < Faraday::Logging::Formatter
     info('Response') { 'Response Received' }
   end
 
-  def error(error)
-    # Build a custom message using `error`
+  def exception(exc)
+    # Build a custom message using `exc`
     info('Error') { 'Error Raised' }
   end
 end

--- a/lib/faraday/logging/formatter.rb
+++ b/lib/faraday/logging/formatter.rb
@@ -37,16 +37,16 @@ module Faraday
         log_body('response', env[:body]) if env[:body] && log_body?(:response)
       end
 
-      def error(error)
+      def exception(exc)
         return unless log_errors?
 
-        error_log = proc { error.full_message }
+        error_log = proc { exc.full_message }
         public_send(log_level, 'error', &error_log)
 
-        log_headers('error', error.response_headers) if error.respond_to?(:response_headers) && log_headers?(:error)
-        return unless error.respond_to?(:response_body) && error.response_body && log_body?(:error)
+        log_headers('error', exc.response_headers) if exc.respond_to?(:response_headers) && log_headers?(:error)
+        return unless exc.respond_to?(:response_body) && exc.response_body && log_body?(:error)
 
-        log_body('error', error.response_body)
+        log_body('error', exc.response_body)
       end
 
       def filter(filter_word, filter_replacement)

--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -27,8 +27,8 @@ module Faraday
         @formatter.response(env)
       end
 
-      def on_error(error)
-        @formatter.error(error) if @formatter.respond_to?(:error)
+      def on_error(exc)
+        @formatter.exception(exc) if @formatter.respond_to?(:exception)
       end
     end
   end

--- a/spec/faraday/response/logger_spec.rb
+++ b/spec/faraday/response/logger_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Faraday::Response::Logger do
     context 'when no route' do
       it 'delegates logging to the formatter' do
         expect(formatter).to receive(:request).with(an_instance_of(Faraday::Env))
-        expect(formatter).to receive(:error).with(an_instance_of(Faraday::Adapter::Test::Stubs::NotFound))
+        expect(formatter).to receive(:exception).with(an_instance_of(Faraday::Adapter::Test::Stubs::NotFound))
 
         expect { conn.get '/noroute' }.to raise_error(Faraday::Adapter::Test::Stubs::NotFound)
       end


### PR DESCRIPTION
## Description
Rename Faraday::Logger::Formatter#error to #exception
This is because #error is already delegated to the internal Logger, and could cause an infinite loop when the log_level is set to "error".

Fixes #1467

## Additional Notes

Although this is technically a breaking change, I'll still release this as a hotfix release (2.7.2) because of the following:

1. The Middleware API is unchanged (`on_error`)
2. The current implementation could cause infinite loops if the `log_level` is set to "error"
3. The only affected projects will have a custom formatter implementing the `error` method. Considering this feature was released very recently, the chances of this happening are extremely small.

cc @epaew in case you've built a custom formatter following your PR