### PR TITLE
Clarify diff between connection settings `timeout` and `open_timeout` 

### DIFF
--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -15,8 +15,14 @@ module Faraday
   #   @return [Hash] options for configuring the request.
   #   Options for configuring the request.
   #
-  #   - `:timeout`      - total timeout for both the connection-opening phase and the reading phase after it added together (Integer in seconds)
-  #   - `:open_timeout` - timeout for only the connection-opening phase (Integer in seconds)
+  #   - `:timeout`      - generic timeout (Integer in seconds) that represents
+  #   different things depending on which Faraday adapter is used. For instance,
+  #   it may represent the timeout for the entire request including both
+  #   time to establish the connection and time to read data from server or it
+  #   may represent the default timeout value for various timeouts like timeout
+  #   for establishing connection and timeout for reading data from server
+  #   - `:open_timeout` - timeout (Integer in seconds) for establishing the
+  #   connection between the client and the server
   #   - `:on_data`      - Proc for streaming
   #   - `:proxy`        - Hash of proxy options
   #       - `:uri`        - Proxy Server URI

--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -15,19 +15,19 @@ module Faraday
   #   @return [Hash] options for configuring the request.
   #   Options for configuring the request.
   #
-  #   - `:timeout`      - generic timeout (Integer in seconds) that represents
-  #   different things depending on which Faraday adapter is used. For instance,
-  #   it may represent the timeout for the entire request including both
-  #   time to establish the connection and time to read data from server or it
-  #   may represent the default timeout value for various timeouts like timeout
-  #   for establishing connection and timeout for reading data from server
-  #   - `:open_timeout` - timeout (Integer in seconds) for establishing the
-  #   connection between the client and the server
-  #   - `:on_data`      - Proc for streaming
-  #   - `:proxy`        - Hash of proxy options
-  #       - `:uri`        - Proxy Server URI
-  #       - `:user`       - Proxy server username
-  #       - `:password`   - Proxy server password
+  #   - `:timeout`       - time limit for the entire request (Integer in
+  #                        seconds)
+  #   - `:open_timeout`  - time limit for just the connection phase (e.g.
+  #                        handshake) (Integer in seconds)
+  #   - `:read_timeout`  - time limit for the first response byte received from
+  #                        the server (Integer in seconds)
+  #   - `:write_timeout` - time limit for the client to send the request to the
+  #                        server (Integer in seconds)
+  #   - `:on_data`       - Proc for streaming
+  #   - `:proxy`         - Hash of proxy options
+  #       - `:uri`         - Proxy Server URI
+  #       - `:user`        - Proxy server username
+  #       - `:password`    - Proxy server password
   #
   # @!attribute request_headers
   #   @return [Hash] HTTP Headers to be sent to the server.

--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -15,7 +15,7 @@ module Faraday
   #   @return [Hash] options for configuring the request.
   #   Options for configuring the request.
   #
-  #   - `:timeout`      - timeout for both the connection-opening phase and the reading phase after it (Integer in seconds)
+  #   - `:timeout`      - total timeout for both the connection-opening phase and the reading phase after it added together (Integer in seconds)
   #   - `:open_timeout` - timeout for only the connection-opening phase (Integer in seconds)
   #   - `:on_data`      - Proc for streaming
   #   - `:proxy`        - Hash of proxy options

--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -25,7 +25,7 @@ module Faraday
   #                        server (Integer in seconds)
   #   - `:on_data`       - Proc for streaming
   #   - `:proxy`         - Hash of proxy options
-  #       - `:uri`         - Proxy Server URI
+  #       - `:uri`         - Proxy server URI
   #       - `:user`        - Proxy server username
   #       - `:password`    - Proxy server password
   #

--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -15,8 +15,8 @@ module Faraday
   #   @return [Hash] options for configuring the request.
   #   Options for configuring the request.
   #
-  #   - `:timeout`  open/read timeout Integer in seconds
-  #   - `:open_timeout` - read timeout Integer in seconds
+  #   - `:timeout`      - timeout for both the connection-opening phase and the reading phase after it (Integer in seconds)
+  #   - `:open_timeout` - timeout for only the connection-opening phase (Integer in seconds)
   #   - `:on_data`      - Proc for streaming
   #   - `:proxy`        - Hash of proxy options
   #       - `:uri`        - Proxy Server URI


### PR DESCRIPTION
## Description

This PR aims to clarify the difference between the config settings `timeout` and `open_timeout`.

I am very confused about the difference between `timeout` and `open_timeout`.

Originally, the comment for these 2 config settings says:

```rb
  #   - `:timeout`  open/read timeout Integer in seconds
  #   - `:open_timeout` - read timeout Integer in seconds
```

- `open_timeout` is described as `read timeout Integer in seconds` but the previous line has the word `open` in it, which suggests that `read` is something other than `open` which is confusing because I expect `open_timeout` to represent `open`.
- `timeout` is described as `open/read` which is slightly ambiguous because I find it hard to tell which one of the following it means:
  - open plus read
  - open or read

Also when I was looking at this, I don't really know about TCP connection phase and reading phase and whether they are exclusive of each so searching online to clarify this is difficult as well. I found it difficult to clarify whether `timeout` actually includes the time in `open_timeout` and I have asked a question in here: https://github.com/lostisland/faraday/issues/1469.

The reason that I think `timeout` includes `open_timeout` is because:

1. I saw `faraday` gem using the `typhoeus` adapter in this file: https://github.com/lostisland/faraday/blob/e7bbb4e7500590b13c47010546e8f75e19c19eb4/lib/faraday/adapter/typhoeus.rb#L12
2. `faraday`'s `timeout` is represented by `timeout_ms` in `typhoeus` and `faraday`'s `open_timeout` is represented by `connecttimeout_ms` in `typhoeus` according to [this file](https://github.com/typhoeus/typhoeus/blob/da478030a750475a63570432f444e3d782a135d0/lib/typhoeus/adapters/faraday.rb#L165-L166)
3. There is [documentation regarding timeout in the `typhoeus` gem README.md](https://github.com/typhoeus/typhoeus/blob/da478030a750475a63570432f444e3d782a135d0/README.md?plain=1#L435-L436). It says

> `timeout` is the time limit for the entire request in seconds.
> `connecttimeout` is the time limit for just the connection phase, again in seconds.
