### PR TITLE
Adds Ruby 3.2 to the CI matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
         experimental: [false]
         include:
           - ruby: head


### PR DESCRIPTION
## Description

Adds Ruby 3.2 to the CI matrix.

Everything runs green on my fork.

## Todos

None.

## Additional Notes
Optional section
