### PR TITLE
Add URL to to_hash in Faraday::Response (#1474)

### DIFF
--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -61,7 +61,8 @@ module Faraday
     def to_hash
       {
         status: env.status, body: env.body,
-        response_headers: env.response_headers
+        response_headers: env.response_headers,
+        url: env.url
       }
     end
 

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Faraday::Response do
   subject { Faraday::Response.new(env) }
 
   let(:env) do
-    Faraday::Env.from(status: 404, body: 'yikes',
+    Faraday::Env.from(status: 404, body: 'yikes', url: Faraday::Utils.URI('https://lostisland.github.io/faraday'),
                       response_headers: { 'Content-Type' => 'text/plain' })
   end
 
@@ -30,6 +30,7 @@ RSpec.describe Faraday::Response do
     it { expect(hash[:status]).to eq(subject.status) }
     it { expect(hash[:response_headers]).to eq(subject.headers) }
     it { expect(hash[:body]).to eq(subject.body) }
+    it { expect(hash[:url]).to eq(subject.env.url) }
   end
 
   describe 'marshal serialization support' do
@@ -45,6 +46,7 @@ RSpec.describe Faraday::Response do
     it { expect(loaded.env[:body]).to eq(env[:body]) }
     it { expect(loaded.env[:response_headers]).to eq(env[:response_headers]) }
     it { expect(loaded.env[:status]).to eq(env[:status]) }
+    it { expect(loaded.env[:url]).to eq(env[:url]) }
   end
 
   describe '#on_complete' do


### PR DESCRIPTION
## Description
This PR adds the `url` to the `to_hash` method of Faraday::Response as discussed in #1474 

## Todos
Review, commentary & discussion

## Additional Notes
The url is provided to the hash as-is, which means it'll still be a URI object.

See https://github.com/aaronstillwell/faraday/blob/29ac4eec651f367d4be57985297db20f10796f9d/lib/faraday/response.rb#L65

In the spec, we create a URI object to test with: https://github.com/aaronstillwell/faraday/blob/29ac4eec651f367d4be57985297db20f10796f9d/spec/faraday/response_spec.rb#L6-L9

We currently do not explicitly test that the deserialized object has a URI object (rather than the URL as a string), but manual inspection suggests this works as I'd expect as an end user (that we'd get the URI object back and not a string).

Is there any expectation that `to_hash` should not contain an actual URI object?