### PR TITLE
Connection#build_exclusive_url: replace simple syntax

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -471,10 +471,10 @@ module Faraday
     def build_exclusive_url(url = nil, params = nil, params_encoder = nil)
       url = nil if url.respond_to?(:empty?) && url.empty?
       base = url_prefix.dup
-      if url && base.path && base.path !~ %r{/$}
+      if url && !base.path.end_with?('/')
         base.path = "#{base.path}/" # ensure trailing slash
       end
-      url = url.to_s.gsub(':', '%3A') if url && URI.parse(url.to_s).opaque
+      url = url.to_s.gsub(':', '%3A') if Utils.URI(url.to_s).opaque
       uri = url ? base + url : base
       if params
         uri.query = params.to_query(params_encoder || options.params_encoder)


### PR DESCRIPTION
## Description
apply the advice about `Connection#build_exclusive_url`'s syntax in https://github.com/lostisland/faraday/issues/1349#issuecomment-1002170559

> On a side note, the regex to check for a trailing slash [here](https://github.com/lostisland/faraday/blob/main/lib/faraday/connection.rb#L474) could be replaced with a simple base.path.end_with?('/') which probably is faster and more readable. Also [here](https://github.com/lostisland/faraday/blob/main/lib/faraday/connection.rb#L477) there's a direct call to URI.parse instead of Utils.URI(...) circumventing the custom URL parser.


## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests
- [ ] Documentation

## Additional Notes
Optional section
