### PR TITLE
Update connection.rb documentation to use PUT in an example 

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -261,14 +261,13 @@ module Faraday
     # @param headers [Hash, nil] unencoded HTTP header key/value pairs.
     #
     # @example
-    #   # TODO: Make it a PUT example
-    #   conn.post '/items', data, content_type: 'application/json'
+    #   conn.put '/products/123', data, content_type: 'application/json'
     #
-    #   # Simple ElasticSearch indexing sample.
-    #   conn.post '/twitter/tweet' do |req|
-    #     req.headers[:content_type] = 'application/json'
-    #     req.params[:routing] = 'kimchy'
-    #     req.body = JSON.generate(user: 'kimchy', ...)
+    #   # Star a gist.
+    #   conn.put 'https://api.github.com/gists/GIST_ID/star' do |req|
+    #     req.headers['Accept'] = 'application/vnd.github+json'
+    #     req.headers['Authorization'] = 'Bearer <YOUR-TOKEN>'
+    #     req.headers['X-GitHub-Api-Version'] = '2022-11-28'
     #   end
     #
     # @yield [Faraday::Request] for further request customizations


### PR DESCRIPTION
Updates connection.rb documentation with PUT example

## Description
TODO found in API documentation looking for PUT example: [Star a gist](https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28#star-a-gist) was chosen because is an up-to-date example of a PUT request method.

Many examples used the PUT method to update resource data. However, it is typical to use the PATCH method nowadays; another PR with a PATCH example would be interesting.

## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests
- [ ] Documentation

## Additional Notes
Optional section
