### PR TITLE
Add support for Ruby 3.2.0 in Faraday v1.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v1

--- a/lib/faraday/dependency_loader.rb
+++ b/lib/faraday/dependency_loader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ruby2_keywords'
+
 module Faraday
   # DependencyLoader helps Faraday adapters and middleware load dependencies.
   module DependencyLoader
@@ -13,7 +15,7 @@ module Faraday
       self.load_error = e
     end
 
-    def new(*)
+    ruby2_keywords def new(*)
       unless loaded?
         raise "missing dependency for #{self}: #{load_error.message}"
       end


### PR DESCRIPTION
When adding a middleware that receives keyword arguments in the constructor, the call from `DependencyLoader#new` fails because the method is not defined using `ruby2_keywords`.

This adds the required `ruby2_keywords` declaration to `DependencyLoader#new`, fixing the tests and getting Faraday v1.x working with Ruby 3.2.0.

Fixes https://github.com/lostisland/faraday/issues/1479.