### PR TITLE
Use Uri.parse instead of Utils.URI

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -473,7 +473,7 @@ module Faraday
       if url && !base.path.end_with?('/')
         base.path = "#{base.path}/" # ensure trailing slash
       end
-      url = url.to_s.gsub(':', '%3A') if Utils.URI(url.to_s).opaque
+      url = url.to_s.gsub(':', '%3A') if URI.parse(url.to_s).opaque
       uri = url ? base + url : base
       if params
         uri.query = params.to_query(params_encoder || options.params_encoder)

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -310,6 +310,21 @@ RSpec.describe Faraday::Connection do
         expect(uri.to_s).to eq('http://service.com/api/service%3Asearch?limit=400')
       end
     end
+
+    context 'with a custom `default_uri_parser`' do
+      let(:url) { 'http://httpbingo.org' }
+      let(:parser) { Addressable::URI }
+
+      around do |example|
+        with_default_uri_parser(parser) do
+          example.run
+        end
+      end
+
+      it 'does not raise error' do
+        expect { conn.build_exclusive_url('/nigiri') }.not_to raise_error
+      end
+    end
   end
 
   describe '#build_url' do


### PR DESCRIPTION
## Description
Utils.URI can be configured to use a different parser and return an object that "behaves like a URI". However, `opaque` is not available in other objects (e.g. Addressable::URI), so in this instance we need to use URI.

Fixes #1484 