### PR TITLE
Subclass Options structs using a block

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,8 +18,12 @@ Layout/LineLength:
     - examples/**/*.rb
 Metrics/BlockLength:
   Exclude:
+    - lib/faraday/options/env.rb
     - spec/**/*.rb
     - examples/**/*.rb
+Metrics/ModuleLength:
+  Exclude:
+    - lib/faraday/options/env.rb
 Style/Documentation:
   Exclude:
     - 'spec/**/*'

--- a/lib/faraday/logging/formatter.rb
+++ b/lib/faraday/logging/formatter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pp' # rubocop:disable Lint/RedundantRequireStatement
+require 'pp'
 
 module Faraday
   module Logging

--- a/lib/faraday/options/connection_options.rb
+++ b/lib/faraday/options/connection_options.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 module Faraday
-  # ConnectionOptions contains the configurable properties for a Faraday
-  # connection object.
-  class ConnectionOptions < Options.new(:request, :proxy, :ssl, :builder, :url,
-                                        :parallel_manager, :params, :headers,
-                                        :builder_class)
-
+  # @!parse
+  #   # ConnectionOptions contains the configurable properties for a Faraday
+  #   # connection object.
+  #   class ConnectionOptions < Options; end
+  ConnectionOptions = Options.new(:request, :proxy, :ssl, :builder, :url,
+                                  :parallel_manager, :params, :headers,
+                                  :builder_class) do
     options request: RequestOptions, ssl: SSLOptions
 
     memoized(:request) { self.class.options_for(:request).new }

--- a/lib/faraday/options/proxy_options.rb
+++ b/lib/faraday/options/proxy_options.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 module Faraday
-  # ProxyOptions contains the configurable properties for the proxy
-  # configuration used when making an HTTP request.
-  class ProxyOptions < Options.new(:uri, :user, :password)
+  # @!parse
+  #   # ProxyOptions contains the configurable properties for the proxy
+  #   # configuration used when making an HTTP request.
+  #   class ProxyOptions < Options; end
+  ProxyOptions = Options.new(:uri, :user, :password) do
     extend Forwardable
     def_delegators :uri, :scheme, :scheme=, :host, :host=, :port, :port=,
                    :path, :path=

--- a/lib/faraday/options/request_options.rb
+++ b/lib/faraday/options/request_options.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 module Faraday
-  # RequestOptions contains the configurable properties for a Faraday request.
-  class RequestOptions < Options.new(:params_encoder, :proxy, :bind,
-                                     :timeout, :open_timeout, :read_timeout,
-                                     :write_timeout, :boundary, :oauth,
-                                     :context, :on_data)
-
+  # @!parse
+  #   # RequestOptions contains the configurable properties for a Faraday request.
+  #   class RequestOptions < Options; end
+  RequestOptions = Options.new(:params_encoder, :proxy, :bind,
+                               :timeout, :open_timeout, :read_timeout,
+                               :write_timeout, :boundary, :oauth,
+                               :context, :on_data) do
     def []=(key, value)
       if key && key.to_sym == :proxy
         super(key, value ? ProxyOptions.from(value) : nil)

--- a/lib/faraday/options/ssl_options.rb
+++ b/lib/faraday/options/ssl_options.rb
@@ -1,56 +1,57 @@
 # frozen_string_literal: true
 
 module Faraday
-  # SSL-related options.
-  #
-  # @!attribute verify
-  #   @return [Boolean] whether to verify SSL certificates or not
-  #
-  # @!attribute verify_hostname
-  #   @return [Boolean] whether to enable hostname verification on server certificates
-  #           during the handshake or not (see https://github.com/ruby/openssl/pull/60)
-  #
-  # @!attribute ca_file
-  #   @return [String] CA file
-  #
-  # @!attribute ca_path
-  #   @return [String] CA path
-  #
-  # @!attribute verify_mode
-  #   @return [Integer] Any `OpenSSL::SSL::` constant (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL.html)
-  #
-  # @!attribute cert_store
-  #   @return [OpenSSL::X509::Store] certificate store
-  #
-  # @!attribute client_cert
-  #   @return [String, OpenSSL::X509::Certificate] client certificate
-  #
-  # @!attribute client_key
-  #   @return [String, OpenSSL::PKey::RSA, OpenSSL::PKey::DSA] client key
-  #
-  # @!attribute certificate
-  #   @return [OpenSSL::X509::Certificate] certificate (Excon only)
-  #
-  # @!attribute private_key
-  #   @return [OpenSSL::PKey::RSA, OpenSSL::PKey::DSA] private key (Excon only)
-  #
-  # @!attribute verify_depth
-  #   @return [Integer] maximum depth for the certificate chain verification
-  #
-  # @!attribute version
-  #   @return [String, Symbol] SSL version (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-ssl_version-3D)
-  #
-  # @!attribute min_version
-  #   @return [String, Symbol] minimum SSL version (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-min_version-3D)
-  #
-  # @!attribute max_version
-  #   @return [String, Symbol] maximum SSL version (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-max_version-3D)
-  class SSLOptions < Options.new(:verify, :verify_hostname,
-                                 :ca_file, :ca_path, :verify_mode,
-                                 :cert_store, :client_cert, :client_key,
-                                 :certificate, :private_key, :verify_depth,
-                                 :version, :min_version, :max_version)
-
+  # @!parse
+  #   # SSL-related options.
+  #   #
+  #   # @!attribute verify
+  #   #   @return [Boolean] whether to verify SSL certificates or not
+  #   #
+  #   # @!attribute verify_hostname
+  #   #   @return [Boolean] whether to enable hostname verification on server certificates
+  #   #           during the handshake or not (see https://github.com/ruby/openssl/pull/60)
+  #   #
+  #   # @!attribute ca_file
+  #   #   @return [String] CA file
+  #   #
+  #   # @!attribute ca_path
+  #   #   @return [String] CA path
+  #   #
+  #   # @!attribute verify_mode
+  #   #   @return [Integer] Any `OpenSSL::SSL::` constant (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL.html)
+  #   #
+  #   # @!attribute cert_store
+  #   #   @return [OpenSSL::X509::Store] certificate store
+  #   #
+  #   # @!attribute client_cert
+  #   #   @return [String, OpenSSL::X509::Certificate] client certificate
+  #   #
+  #   # @!attribute client_key
+  #   #   @return [String, OpenSSL::PKey::RSA, OpenSSL::PKey::DSA] client key
+  #   #
+  #   # @!attribute certificate
+  #   #   @return [OpenSSL::X509::Certificate] certificate (Excon only)
+  #   #
+  #   # @!attribute private_key
+  #   #   @return [OpenSSL::PKey::RSA, OpenSSL::PKey::DSA] private key (Excon only)
+  #   #
+  #   # @!attribute verify_depth
+  #   #   @return [Integer] maximum depth for the certificate chain verification
+  #   #
+  #   # @!attribute version
+  #   #   @return [String, Symbol] SSL version (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-ssl_version-3D)
+  #   #
+  #   # @!attribute min_version
+  #   #   @return [String, Symbol] minimum SSL version (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-min_version-3D)
+  #   #
+  #   # @!attribute max_version
+  #   #   @return [String, Symbol] maximum SSL version (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-max_version-3D)
+  #   class SSLOptions < Options; end
+  SSLOptions = Options.new(:verify, :verify_hostname,
+                           :ca_file, :ca_path, :verify_mode,
+                           :cert_store, :client_cert, :client_key,
+                           :certificate, :private_key, :verify_depth,
+                           :version, :min_version, :max_version) do
     # @return [Boolean] true if should verify
     def verify?
       verify != false

--- a/lib/faraday/request/instrumentation.rb
+++ b/lib/faraday/request/instrumentation.rb
@@ -5,7 +5,7 @@ module Faraday
     # Middleware for instrumenting Requests.
     class Instrumentation < Faraday::Middleware
       # Options class used in Request::Instrumentation class.
-      class Options < Faraday::Options.new(:name, :instrumenter)
+      Options = Faraday::Options.new(:name, :instrumenter) do
         # @return [String]
         def name
           self[:name] ||= 'request.faraday'

--- a/spec/faraday/options/options_spec.rb
+++ b/spec/faraday/options/options_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Faraday::Options do
   SubOptions = Class.new(Faraday::Options.new(:sub_a, :sub_b))
-  class ParentOptions < Faraday::Options.new(:a, :b, :c)
+  ParentOptions = Faraday::Options.new(:a, :b, :c) do
     options c: SubOptions
   end
 


### PR DESCRIPTION
## Description
As recommended on https://ruby-doc.org/core-2.2.2/Struct.html#method-c-new and https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/StructInheritance

Has the nice side-effect of making the methods defined by `Struct.new` discoverable by [Tapioca](https://github.com/Shopify/tapioca), which is how I came across the issue in the first place.

## Todos
N/A