### PR TITLE
Remove direct struct subclassing

### DIFF
--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -184,7 +184,7 @@ module Faraday
       end
 
       # Stub request
-      class Stub < Struct.new(:host, :path, :query, :headers, :body, :strict_mode, :block) # rubocop:disable Style/StructInheritance
+      Stub = Struct.new(:host, :path, :query, :headers, :body, :strict_mode, :block) do
         # @param env [Faraday::Env]
         def matches?(env)
           request_host = env[:url].host

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -24,12 +24,13 @@ module Faraday
   #   @return [String] body
   # @!attribute options
   #   @return [RequestOptions] options
-  #
-  # rubocop:disable Style/StructInheritance
-  class Request < Struct.new(:http_method, :path, :params, :headers, :body, :options)
-    # rubocop:enable Style/StructInheritance
-
+  Request = Struct.new(:http_method, :path, :params, :headers, :body, :options) do
     extend MiddlewareRegistry
+
+    alias_method :member_get, :[]
+    private :member_get
+    alias_method :member_set, :[]=
+    private :member_set
 
     # @param request_method [String]
     # @yield [request] for block customization, if block given
@@ -48,7 +49,7 @@ module Faraday
       if params
         params.replace hash
       else
-        super
+        member_set(:params, hash)
       end
     end
 
@@ -59,7 +60,7 @@ module Faraday
       if headers
         headers.replace hash
       else
-        super
+        member_set(:headers, hash)
       end
     end
 


### PR DESCRIPTION
## Description
This is a follow-up to https://github.com/lostisland/faraday/pull/1489 - I noticed I was still missing `Faraday::Request#body=` from Tapioca's generated definitions. 

~Since it also overrides `#[]` and `#[]=` it was impossible to set Struct members, so refactored this to a PORO that mostly (but [not exactly](https://ruby-doc.org/core-2.6/Struct.html)) looks like the struct it used to be.~ 
Edit: aliased the original member getter/setters so we can override `#[]` and `#[]=`. This retains methods inherited from Struct people might be relying on (like `#==` which is tested in Faraday via Marshal dump/load).

Also did `Faraday::Adapter::Test::Stub` while I was here for consistency.
