### PR TITLE
Fix incorrect use of logger middleware in docs

### DIFF
--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -28,7 +28,7 @@ require 'faraday'
 
 conn = Faraday.new do |f|
   f.request :json # encode req bodies as JSON
-  f.request :logger # logs request and responses
+  f.response :logger # logs request and responses
   f.response :json # decode response bodies as JSON
   f.adapter :net_http # Use the Net::HTTP adapter
 end


### PR DESCRIPTION
`f.request :logger` as originally suggested in the docs does not work.

```
:logger is not registered on Faraday::Request (Faraday::Error)
```

The correct usage is `f.response :logger`