### PR TITLE
Always assume the existence of `URI::Generic#find_proxy`

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -514,22 +514,17 @@ module Faraday
       return if Faraday.ignore_env_proxy
 
       uri = nil
-      if URI.parse('').respond_to?(:find_proxy)
-        case url
-        when String
-          uri = Utils.URI(url)
-          uri = if uri.host.nil?
-                  find_default_proxy
-                else
-                  URI.parse("#{uri.scheme}://#{uri.host}").find_proxy
-                end
-        when URI
-          uri = url.find_proxy
-        when nil
-          uri = find_default_proxy
-        end
-      else
-        warn 'no_proxy is unsupported' if ENV['no_proxy'] || ENV['NO_PROXY']
+      case url
+      when String
+        uri = Utils.URI(url)
+        uri = if uri.host.nil?
+                find_default_proxy
+              else
+                URI.parse("#{uri.scheme}://#{uri.host}").find_proxy
+              end
+      when URI
+        uri = url.find_proxy
+      when nil
         uri = find_default_proxy
       end
       ProxyOptions.from(uri) if uri


### PR DESCRIPTION
## Description

Previously, the method `#proxy_from_env` checked the existence of `URI::Generic#find_proxy` by using `respond_to?(:find_proxy)`; this method was introduced in Ruby 2.0.0.

Since the latest Faraday requires Ruby 2.6, as specified in `faraday.gemspec`, there is no need for `#proxy_from_env` to handle the case where `URI::Generic#find_proxy` doesn't exist.

## Additional Notes

I recommend reviewing this pull request changes with "Hide whitespace."

<img width="247" alt="Screenshot 2023-05-18 at 12 31 28" src="https://github.com/lostisland/faraday/assets/13130705/a09c9019-b0b2-4222-adda-7ed85ec452ff">
