### PR TITLE
Encode `false` to `"false"` in `Faraday::Request::Json`

### DIFF
--- a/lib/faraday/request/json.rb
+++ b/lib/faraday/request/json.rb
@@ -40,7 +40,16 @@ module Faraday
       end
 
       def body?(env)
-        (body = env[:body]) && !(body.respond_to?(:to_str) && body.empty?)
+        body = env[:body]
+        case body
+        when true, false
+          true
+        when nil
+          # NOTE: nil can be converted to `"null"`, but this middleware doesn't process `nil` for the compatibility.
+          false
+        else
+          !(body.respond_to?(:to_str) && body.empty?)
+        end
       end
 
       def request_type(env)

--- a/spec/faraday/request/json_spec.rb
+++ b/spec/faraday/request/json_spec.rb
@@ -73,6 +73,30 @@ RSpec.describe Faraday::Request::Json do
     end
   end
 
+  context 'true body' do
+    let(:result) { process(true) }
+
+    it 'encodes body' do
+      expect(result_body).to eq('true')
+    end
+
+    it 'adds content type' do
+      expect(result_type).to eq('application/json')
+    end
+  end
+
+  context 'false body' do
+    let(:result) { process(false) }
+
+    it 'encodes body' do
+      expect(result_body).to eq('false')
+    end
+
+    it 'adds content type' do
+      expect(result_type).to eq('application/json')
+    end
+  end
+
   context 'object body with json type' do
     let(:result) { process({ a: 1 }, 'application/json; charset=utf-8') }
 


### PR DESCRIPTION
Close #1503

Previously, `Faraday::Request::Json` doesn't encode the value `false` while it encodes `true` to `"true"`.

This patch fixes the inconsistent behavior to make the middleware encode `false` to `"false"`.

