### PR TITLE
Fix "method redefined" warnings introduced in Faraday 2.7.5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@
 
 require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |task|
+  task.ruby_opts = %w[-W]
+end
 
 task default: :spec

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -174,6 +174,7 @@ module Faraday
 
       memoized_attributes[key.to_sym] = block
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        remove_method(key) if method_defined?(key, false)
         def #{key}() self[:#{key}]; end
       RUBY
     end

--- a/lib/faraday/request.rb
+++ b/lib/faraday/request.rb
@@ -42,6 +42,7 @@ module Faraday
       end
     end
 
+    remove_method :params=
     # Replace params, preserving the existing hash type.
     #
     # @param hash [Hash] new params
@@ -53,6 +54,7 @@ module Faraday
       end
     end
 
+    remove_method :headers=
     # Replace request headers, preserving the existing hash type.
     #
     # @param hash [Hash] new headers

--- a/lib/faraday/request/instrumentation.rb
+++ b/lib/faraday/request/instrumentation.rb
@@ -6,11 +6,13 @@ module Faraday
     class Instrumentation < Faraday::Middleware
       # Options class used in Request::Instrumentation class.
       Options = Faraday::Options.new(:name, :instrumenter) do
+        remove_method :name
         # @return [String]
         def name
           self[:name] ||= 'request.faraday'
         end
 
+        remove_method :instrumenter
         # @return [Class]
         def instrumenter
           self[:instrumenter] ||= ActiveSupport::Notifications


### PR DESCRIPTION
## Description

Faraday 2.7.5 prints warnings about redefined methods. This was reported in #1505.

```
faraday-2.7.5/lib/faraday/options.rb:177: warning: method redefined; discarding old user
faraday-2.7.5/lib/faraday/options.rb:177: warning: method redefined; discarding old password
faraday-2.7.5/lib/faraday/options.rb:177: warning: method redefined; discarding old request
faraday-2.7.5/lib/faraday/options.rb:177: warning: method redefined; discarding old ssl
faraday-2.7.5/lib/faraday/options.rb:177: warning: method redefined; discarding old builder_class
faraday-2.7.5/lib/faraday/request.rb:48: warning: method redefined; discarding old params=
faraday-2.7.5/lib/faraday/request.rb:59: warning: method redefined; discarding old headers=
faraday-2.7.5/lib/faraday/request/instrumentation.rb:10: warning: method redefined; discarding old name
faraday-2.7.5/lib/faraday/request/instrumentation.rb:15: warning: method redefined; discarding old instrumenter
```

The underlying problem is that these methods are implicitly defined by `Struct`. When Faraday attempts to redefine them to alter the default Struct behavior, the warnings are printed.

Fix by using [`remove_method`](https://ruby-doc.org/3.2.2/Module.html#method-i-remove_method) to remove the default Struct implementation before Faraday's are declared.

I tested that the warnings are no longer printed on Ruby 2.6 and 2.7 (via Docker) and 3.0, 3.1, and 3.2 (on macOS via rbenv).

Fixes #1505 