### PR TITLE
Failing test: Logging headers & errors fails when ConnectionFailed is raised

### DIFF
--- a/lib/faraday/logging/formatter.rb
+++ b/lib/faraday/logging/formatter.rb
@@ -56,6 +56,8 @@ module Faraday
       private
 
       def dump_headers(headers)
+        return if headers.nil?
+
         headers.map { |k, v| "#{k}: #{v.inspect}" }.join("\n")
       end
 

--- a/spec/faraday/response/logger_spec.rb
+++ b/spec/faraday/response/logger_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Faraday::Response::Logger do
         stubs.get('/filtered_headers') { [200, { 'Content-Type' => 'text/html' }, 'headers response'] }
         stubs.get('/filtered_params') { [200, { 'Content-Type' => 'text/html' }, 'params response'] }
         stubs.get('/filtered_url') { [200, { 'Content-Type' => 'text/html' }, 'url response'] }
+        stubs.get('/connection_failed') { raise Faraday::ConnectionFailed.new('Failed to open TCP connection') }
       end
     end
   end
@@ -213,6 +214,15 @@ RSpec.describe Faraday::Response::Logger do
     it 'logs error message' do
       expect { conn.get '/noroute' }.to raise_error(Faraday::Adapter::Test::Stubs::NotFound)
       expect(string_io.string).to match(%(no stubbed request for get http:/noroute))
+    end
+  end
+
+  context 'when logging headers and errors' do
+    let(:logger_options) { { headers: true, errors: true } }
+
+    it 'logs error message' do
+      expect { conn.get '/connection_failed' }.to raise_error(Faraday::ConnectionFailed)
+      expect(string_io.string).to match(%(Failed to open TCP connection))
     end
   end
 

--- a/spec/faraday/response/logger_spec.rb
+++ b/spec/faraday/response/logger_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Faraday::Response::Logger do
         stubs.get('/filtered_headers') { [200, { 'Content-Type' => 'text/html' }, 'headers response'] }
         stubs.get('/filtered_params') { [200, { 'Content-Type' => 'text/html' }, 'params response'] }
         stubs.get('/filtered_url') { [200, { 'Content-Type' => 'text/html' }, 'url response'] }
-        stubs.get('/connection_failed') { raise Faraday::ConnectionFailed.new('Failed to open TCP connection') }
+        stubs.get('/connection_failed') { raise Faraday::ConnectionFailed, 'Failed to open TCP connection' }
       end
     end
   end


### PR DESCRIPTION
## Description

I was not able to use faraday logging with the logging options `headers: true, errors: true` when the connection can not be estabilshed and a `Faraday::ConnectionFailed` error should be raised, because it raised a different error instead: `NoMethodError: undefined method `map' for nil:NilClass`

Here is the stacktrace:

```
         # ./lib/faraday/logging/formatter.rb:59:in `dump_headers'
         # ./lib/faraday/logging/formatter.rb:112:in `block in log_headers'
         # ./lib/faraday/logging/formatter.rb:113:in `public_send'
         # ./lib/faraday/logging/formatter.rb:113:in `log_headers'
         # ./lib/faraday/logging/formatter.rb:46:in `exception'
         # ./lib/faraday/response/logger.rb:31:in `on_error'
         # ./lib/faraday/middleware.rb:21:in `rescue in call'
         # ./lib/faraday/middleware.rb:15:in `call'
         # ./lib/faraday/response/logger.rb:23:in `call'
         # ./lib/faraday/rack_builder.rb:153:in `build_response'
         # ./lib/faraday/connection.rb:444:in `run_request'
         # ./lib/faraday/connection.rb:200:in `get'
```

The reason this happens is that the `Faraday::Logging::Formatter#exception` method tries to log the headers of the exception, but there aren't any. `#log_headers` is still called though, because `exc.respond_to?(:response_headers) && log_headers?(:error)` is true, as the `Faraday::Error` class implements the `#response_headers` method. Again, the `@response` of the `exc` instance is `nil`, so when the `dump_headers` method is finally called, it is called with `nil`. And there it fails because it can't call `map` on nil. 

There are various ways to solve this, but the simplest would be to check for nil in the `dump_headers` method:

```ruby
      def dump_headers(headers)
        return if headers.nil?
        # or:
        return unless headers.respond_to?(:map)
        headers.map { |k, v| "#{k}: #{v.inspect}" }.join("\n")
      end
```

You could also catch this in the exception method, but I think catching it in the dump_headers method is more robust:

```ruby
      def exception(exc)
       #...
        log_headers('error', exc.response_headers) if exc.respond_to?(:response_headers) && !exc.response_headers.nil? && log_headers?(:error)
       #...
      end
```