### PR TITLE
Raise Error: Add Faraday::RequestTimeoutError

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,4 +18,12 @@ $ bundle exec jekyll serve
 # The site will now be reachable at http://127.0.0.1:4000/faraday/
 ```
 
+On newer Ruby versions (>= 3.0) `eventmachine` needs a little help to find OpenSSL 1.1 to get compiled (see <https://github.com/eventmachine/eventmachine/issues/936>). If you're using homebrew on macOS, you can do this:
+
+```bash
+brew install openssl@1.1
+bundle config build.eventmachine --with-openssl-dir=$(brew --prefix openssl@1.1)
+bundle install
+```
+
 [website]: https://lostisland.github.io/faraday

--- a/docs/middleware/response/raise_error.md
+++ b/docs/middleware/response/raise_error.md
@@ -32,13 +32,14 @@ Specific exceptions are raised based on the HTTP Status code, according to the l
 An HTTP status in the 400-499 range typically represents an error
 by the client. They raise error classes inheriting from `Faraday::ClientError`.
 
-* 400 => `Faraday::BadRequestError`
-* 401 => `Faraday::UnauthorizedError`
-* 403 => `Faraday::ForbiddenError`
-* 404 => `Faraday::ResourceNotFound`
-* 407 => `Faraday::ProxyAuthError`
-* 409 => `Faraday::ConflictError`
-* 422 => `Faraday::UnprocessableEntityError`
+* [400](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) => `Faraday::BadRequestError`
+* [401](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) => `Faraday::UnauthorizedError`
+* [403](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) => `Faraday::ForbiddenError`
+* [404](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404) => `Faraday::ResourceNotFound`
+* [407](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/407) => `Faraday::ProxyAuthError`
+* [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) => `Faraday::RequestTimeoutError`
+* [409](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) => `Faraday::ConflictError`
+* [422](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) => `Faraday::UnprocessableEntityError`
 * 4xx => `Faraday::ClientError`
 
 An HTTP status in the 500-599 range represents a server error, and raises a

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -112,6 +112,10 @@ module Faraday
   class ProxyAuthError < ClientError
   end
 
+  # Raised by Faraday::Response::RaiseError in case of a 408 response.
+  class RequestTimeoutError < ClientError
+  end
+
   # Raised by Faraday::Response::RaiseError in case of a 409 response.
   class ConflictError < ClientError
   end

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -24,6 +24,8 @@ module Faraday
           # mimic the behavior that we get with proxy requests with HTTPS
           msg = %(407 "Proxy Authentication Required")
           raise Faraday::ProxyAuthError.new(msg, response_values(env))
+        when 408
+          raise Faraday::RequestTimeoutError, response_values(env)
         when 409
           raise Faraday::ConflictError, response_values(env)
         when 422

--- a/spec/faraday/response/raise_error_spec.rb
+++ b/spec/faraday/response/raise_error_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Faraday::Response::RaiseError do
         stub.get('forbidden') { [403, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('not-found') { [404, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('proxy-error') { [407, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('request-timeout') { [408, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('conflict') { [409, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('unprocessable-entity') { [422, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('4xx') { [499, { 'X-Reason' => 'because' }, 'keep looking'] }
@@ -74,6 +75,17 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(407)
       expect(ex.response_status).to eq(407)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::RequestTimeoutError for 408 responses' do
+    expect { conn.get('request-timeout') }.to raise_error(Faraday::RequestTimeoutError) do |ex|
+      expect(ex.message).to eq('the server responded with status 408')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+      expect(ex.response[:status]).to eq(408)
+      expect(ex.response_status).to eq(408)
       expect(ex.response_body).to eq('keep looking')
       expect(ex.response_headers['X-Reason']).to eq('because')
     end


### PR DESCRIPTION
Fixes #1511

This PR adds `Faraday::RequestTimeoutError` and raises it on HTTP 408 responses when the [Raise Error Middleware](https://lostisland.github.io/faraday/middleware/raise-error) is used.

I also took the liberty to hint out how to get `eventmachine` installed with Ruby >= 3.0 to work on `docs/`.

Let me know if this works for you or if you expect something in addition. I basically just copy-pasted the new error looking at the surrounding code 😀 