### PR TITLE
Include `env[:headers]` in `Stubs::NotFound`

### DIFF
--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -275,7 +275,7 @@ module Faraday
 
         unless stub
           raise Stubs::NotFound, "no stubbed request for #{env[:method]} " \
-                                 "#{env[:url]} #{env[:body]}"
+                                 "#{env[:url]} #{env[:body]} #{env[:headers]}"
         end
 
         block_arity = stub.block.arity


### PR DESCRIPTION
When using `strict_mode`, I often get an error with `Stubs::NotFound` and can't figure out why such an error happens at a glance. After looking into the problem carefully, I finally find out some headers are missing. This is not a good developer experience.

I think the error message of `Stubs::NotFound` should include headers to let developers know the difference between the expected and actual requests.

That's why this patch appends `env[:headers]` to the error message.
