### PR TITLE
Fix included middleware links

### DIFF
--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -117,12 +117,12 @@ end
 ### Available Middleware
 
 The following pages provide detailed configuration for the middleware that ships with Faraday:
-* [Authentication](middleware/authentication.md)
-* [URL Encoding](middleware/url-encoding.md)
-* [JSON Encoding/Decoding](middleware/json.md)
-* [Instrumentation](middleware/instrumentation.md)
-* [Logging](middleware/logging.md)
-* [Raising Errors](middleware/raising-errors.md)
+* [Authentication](middleware/included/authentication.md)
+* [URL Encoding](middleware/included/url-encoding.md)
+* [JSON Encoding/Decoding](middleware/included/json.md)
+* [Instrumentation](middleware/included/instrumentation.md)
+* [Logging](middleware/included/logging.md)
+* [Raising Errors](middleware/included/raising-errors.md)
 
 The [Awesome Faraday](https://github.com/lostisland/awesome-faraday/) project
 has a complete list of useful, well-maintained Faraday middleware. Middleware is


### PR DESCRIPTION
## Description

Hi 👋🏻 Thanks for maintaining Faraday.

The "Available Middleware" links on the [Middleware Overview](https://lostisland.github.io/faraday/#/middleware/index) page were pointing to `/middleware/___` instead of `/middleware/included/___`. I updated them to point to the correct place.

## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests (N/A I think)
- [x] Documentation
