### PR TITLE
Add `base64` to runtime dependency

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6'
 
+  spec.add_dependency 'base64'
   # faraday-net_http is the "default adapter", but being a Faraday dependency it can't
   # control which version of faraday it will be pulled from.
   # To avoid releasing a major version every time there's a new Faraday API, we should


### PR DESCRIPTION
## Description

This PR adds `base64` to runtime dependency to suppress the following Ruby 3.3's warning:

```console
$ ruby -ve 'require "faraday"'
ruby 3.3.0dev (2023-08-14T15:48:39Z master 52837fcec2) [x86_64-darwin22]
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/faraday-2.7.10/lib/faraday/utils.rb:3:
warning: base64 which will be not part of the default gems since Ruby 3.4.0
```

cf: https://github.com/rails/rails/pull/48907

## Todos

List any remaining work that needs to be done, i.e:

- [x] Tests
- [x] Documentation

## Additional Notes

N/A