### PR TITLE
Add option for omitting request data from Faraday exceptions

### DIFF
--- a/docs/middleware/included/raising-errors.md
+++ b/docs/middleware/included/raising-errors.md
@@ -6,7 +6,7 @@ This greatly increases the ease of use of Faraday, as you don't have to check
 the response status code manually.
 These errors add to the list of default errors [raised by Faraday](getting-started/errors.md).
 
-All exceptions are initialized providing the response `status`, `headers`, and `body`.
+All exceptions are initialized with a hash containing the response `status`, `headers`, and `body`.
 
 ```ruby
 conn = Faraday.new(url: 'http://httpbingo.org') do |faraday|
@@ -57,3 +57,28 @@ See [Faraday Errors](getting-started/errors.md) for more information on these.
 The HTTP response status may be nil due to a malformed HTTP response from the
 server, or a bug in the underlying HTTP library. This is considered a server error
 and raised as `Faraday::NilStatusError`, which inherits from `Faraday::ServerError`.
+
+## Middleware Options
+
+The behavior of this middleware can be customized with the following options:
+
+| Option              | Default | Description |
+|---------------------|---------|-------------|
+| **include_request** | true    | When true, exceptions are initialized with request information including `method`, `url`, `url_path`, `params`, `headers`, and `body`. |
+
+### Example Usage
+
+```ruby
+conn = Faraday.new(url: 'http://httpbingo.org') do |faraday|
+  faraday.response :raise_error, include_request: true
+end
+
+begin
+  conn.get('/wrong-url') # => Assume this raises a 404 response
+rescue Faraday::ResourceNotFound => e
+  e.response[:status]              #=> 404
+  e.response[:headers]             #=> { ... }
+  e.response[:body]                #=> "..."
+  e.response[:request][:url_path]  #=> "/wrong-url"
+end
+```

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -39,11 +39,26 @@ module Faraday
         end
       end
 
+      # Returns a hash of response data with the following keys:
+      #   - status
+      #   - headers
+      #   - body
+      #   - request
+      #
+      # The `request` key is omitted when the middleware is explicitly
+      # configured with the option `include_request: false`.
       def response_values(env)
-        {
+        response = {
           status: env.status,
           headers: env.response_headers,
-          body: env.body,
+          body: env.body
+        }
+
+        # Include the request data by default. If the middleware was explicitly
+        # configured to _not_ include request data, then omit it.
+        return response unless options.fetch(:include_request, true)
+
+        response.merge(
           request: {
             method: env.method,
             url: env.url,
@@ -52,7 +67,7 @@ module Faraday
             headers: env.request_headers,
             body: env.request_body
           }
-        }
+        )
       end
 
       def query_params(env)


### PR DESCRIPTION
## Description

Adds an option to the `:raise_error` middleware that prevents request data from being included in the generated Faraday exception.

Request data can include sensitive headers (e.g. `Authorization`) or other request parameters. Uncaught exceptions tend to make their way into bug trackers, which is not a place where you want sensitive information to go!

In order to prevent request data from being included in Faraday exceptions, you can now configure the `:raise_error` middleware so that it is omitted:

```ruby
Faraday.new do |faraday|
  faraday.raise_error, include_request: false
end
```

## Todos

- [ ] Documentation

## Additional Notes

Request data started being bundled in Faraday exceptions in #1181.

To prevent this from becoming a breaking change, I preserved the existing behaviour - request data is included by default.

That said, I would love to see request data omitted by default in a future major version. As a user of this gem, I don't expect "response" data to include "request" data.
