### PR TITLE
TooManyRequests error

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -124,6 +124,10 @@ module Faraday
   class UnprocessableEntityError < ClientError
   end
 
+  # Raised by Faraday::Response::RaiseError in case of a 429 response.
+  class TooManyRequestsError < ClientError
+  end
+
   # Faraday server error class. Represents 5xx status responses.
   class ServerError < Error
   end

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -30,6 +30,8 @@ module Faraday
           raise Faraday::ConflictError, response_values(env)
         when 422
           raise Faraday::UnprocessableEntityError, response_values(env)
+        when 429
+          raise Faraday::TooManyRequestsError, response_values(env)
         when ClientErrorStatuses
           raise Faraday::ClientError, response_values(env)
         when ServerErrorStatuses

--- a/spec/faraday/response/raise_error_spec.rb
+++ b/spec/faraday/response/raise_error_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Faraday::Response::RaiseError do
         stub.get('request-timeout') { [408, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('conflict') { [409, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('unprocessable-entity') { [422, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('too-many-requests') { [429, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('4xx') { [499, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('nil-status') { [nil, { 'X-Reason' => 'nil' }, 'fail'] }
         stub.get('server-error') { [500, { 'X-Error' => 'bailout' }, 'fail'] }
@@ -108,6 +109,17 @@ RSpec.describe Faraday::Response::RaiseError do
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(422)
       expect(ex.response_status).to eq(422)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::TooManyRequestsError for 429 responses' do
+    expect { conn.get('too-many-requests') }.to raise_error(Faraday::TooManyRequestsError) do |ex|
+      expect(ex.message).to eq('the server responded with status 429')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+      expect(ex.response[:status]).to eq(429)
+      expect(ex.response_status).to eq(429)
       expect(ex.response_body).to eq('keep looking')
       expect(ex.response_headers['X-Reason']).to eq('because')
     end


### PR DESCRIPTION
## Description
Faraday enumerates many common HTTP errors....could we please add [429 / TooManyRequests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) to the list?

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
