### PR TITLE
Lint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
 end
 
 group :development, :lint do
+  gem 'racc', '~> 1.7' # for RuboCop, on Ruby 3.3
   gem 'rubocop'
   gem 'rubocop-packaging', '~> 0.5'
   gem 'rubocop-performance', '~> 1.0'

--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -146,7 +146,7 @@ module Faraday
         # which means that all of a path, parameters, and headers must be the same as an actual request.
         def strict_mode=(value)
           @strict_mode = value
-          @stack.each do |_method, stubs|
+          @stack.each_value do |stubs|
             stubs.each do |stub|
               stub.strict_mode = value
             end

--- a/lib/faraday/logging/formatter.rb
+++ b/lib/faraday/logging/formatter.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'pp'
-
 module Faraday
   module Logging
     # Serves as an integration point to customize logging


### PR DESCRIPTION
## Description

Rubocop had found new things to lint warn about.

This fixes it.

Also, when using rc1 of ruby 3.3, racc wasn't automatically included. So, I added that to the Gemfile.

