### PR TITLE
Configurable JSON encoders and decoders

### DIFF
--- a/docs/middleware/included/json.md
+++ b/docs/middleware/included/json.md
@@ -26,7 +26,7 @@ conn.post('/', { a: 1, b: 2 })
 By default, middleware utilizes Ruby's `json` to generate JSON strings.
 
 Other encoders can be used by specifying `encoder` option for the middleware:
-* a module/class which implements `encode`
+* a module/class which implements `dump`
 * a module/class-method pair to be used 
 
 ```ruby
@@ -37,7 +37,7 @@ Faraday.new(...) do |f|
 end
 
 Faraday.new(...) do |f|
-  f.request :json, encoder: [Oj, :encode]
+  f.request :json, encoder: [Oj, :dump]
 end
 ```
 
@@ -65,7 +65,7 @@ conn.get('json').body
 By default, middleware utilizes Ruby's `json` to parse JSON strings.
 
 Other decoders can be used by specifying `decoder` parser option for the middleware:
-* a module/class which implements `decode`
+* a module/class which implements `load`
 * a module/class-method pair to be used 
 
 ```ruby
@@ -76,6 +76,6 @@ Faraday.new(...) do |f|
 end
 
 Faraday.new(...) do |f|
-  f.response :json, parser_options: { decoder: [Oj, :decode] }
+  f.response :json, parser_options: { decoder: [Oj, :load] }
 end
 ```

--- a/docs/middleware/included/json.md
+++ b/docs/middleware/included/json.md
@@ -21,6 +21,26 @@ conn.post('/', { a: 1, b: 2 })
 # Body: {"a":1,"b":2}
 ```
 
+### Using custom JSON encoders
+
+By default, middleware utilizes Ruby's `json` to generate JSON strings.
+
+Other encoders can be used by specifying `encoder` option for the middleware:
+* a module/class which implements `encode`
+* a module/class-method pair to be used 
+
+```ruby
+require 'oj'
+
+Faraday.new(...) do |f|
+  f.request :json, encoder: Oj
+end
+
+Faraday.new(...) do |f|
+  f.request :json, encoder: [Oj, :encode]
+end
+```
+
 ## JSON Responses
 
 The `JSON` response middleware parses response body into a hash of key/value pairs.

--- a/docs/middleware/included/json.md
+++ b/docs/middleware/included/json.md
@@ -59,3 +59,23 @@ end
 conn.get('json').body
 # => {"slideshow"=>{"author"=>"Yours Truly", "date"=>"date of publication", "slides"=>[{"title"=>"Wake up to WonderWidgets!", "type"=>"all"}, {"items"=>["Why <em>WonderWidgets</em> are great", "Who <em>buys</em> WonderWidgets"], "title"=>"Overview", "type"=>"all"}], "title"=>"Sample Slide Show"}}
 ```
+
+### Using custom JSON decoders
+
+By default, middleware utilizes Ruby's `json` to parse JSON strings.
+
+Other decoders can be used by specifying `decoder` parser option for the middleware:
+* a module/class which implements `decode`
+* a module/class-method pair to be used 
+
+```ruby
+require 'oj'
+
+Faraday.new(...) do |f|
+  f.response :json, parser_options: { decoder: Oj }
+end
+
+Faraday.new(...) do |f|
+  f.response :json, parser_options: { decoder: [Oj, :encode] }
+end
+```

--- a/docs/middleware/included/json.md
+++ b/docs/middleware/included/json.md
@@ -76,6 +76,6 @@ Faraday.new(...) do |f|
 end
 
 Faraday.new(...) do |f|
-  f.response :json, parser_options: { decoder: [Oj, :encode] }
+  f.response :json, parser_options: { decoder: [Oj, :decode] }
 end
 ```

--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -30,7 +30,7 @@ module Faraday
           new_value = value
         end
 
-        send("#{key}=", new_value) unless new_value.nil?
+        send(:"#{key}=", new_value) unless new_value.nil?
       end
       self
     end
@@ -38,7 +38,7 @@ module Faraday
     # Public
     def delete(key)
       value = send(key)
-      send("#{key}=", nil)
+      send(:"#{key}=", nil)
       value
     end
 
@@ -57,7 +57,7 @@ module Faraday
                     else
                       other_value
                     end
-        send("#{key}=", new_value) unless new_value.nil?
+        send(:"#{key}=", new_value) unless new_value.nil?
       end
       self
     end

--- a/lib/faraday/request/json.rb
+++ b/lib/faraday/request/json.rb
@@ -26,8 +26,8 @@ module Faraday
       def encode(data)
         if options[:encoder].is_a?(Array) && options[:encoder].size >= 2
           options[:encoder][0].public_send(options[:encoder][1], data)
-        elsif options[:encoder].respond_to?(:encode)
-          options[:encoder].encode(data)
+        elsif options[:encoder].respond_to?(:dump)
+          options[:encoder].dump(data)
         else
           ::JSON.generate(data)
         end

--- a/lib/faraday/request/json.rb
+++ b/lib/faraday/request/json.rb
@@ -24,7 +24,13 @@ module Faraday
       private
 
       def encode(data)
-        ::JSON.generate(data)
+        if options[:encoder].is_a?(Array) && options[:encoder].size >= 2
+          options[:encoder][0].public_send(options[:encoder][1], data)
+        elsif options[:encoder].respond_to?(:encode)
+          options[:encoder].encode(data)
+        else
+          ::JSON.generate data
+        end
       end
 
       def match_content_type(env)

--- a/lib/faraday/request/json.rb
+++ b/lib/faraday/request/json.rb
@@ -29,7 +29,7 @@ module Faraday
         elsif options[:encoder].respond_to?(:encode)
           options[:encoder].encode(data)
         else
-          ::JSON.generate data
+          ::JSON.generate(data)
         end
       end
 

--- a/lib/faraday/response/json.rb
+++ b/lib/faraday/response/json.rb
@@ -60,8 +60,8 @@ module Faraday
         @decoder_options =
           if @decoder_options.is_a?(Array) && @decoder_options.size >= 2
             @decoder_options.slice(0, 2)
-          elsif @decoder_options.respond_to?(:decode)
-            [@decoder_options, :decode]
+          elsif @decoder_options.respond_to?(:load)
+            [@decoder_options, :load]
           else
             [::JSON, :parse]
           end

--- a/lib/faraday/response/json.rb
+++ b/lib/faraday/response/json.rb
@@ -33,7 +33,7 @@ module Faraday
 
         decoder, method_name = @decoder_options
 
-        decoder.public_send(method_name, body, @parser_options)
+        decoder.public_send(method_name, body, @parser_options || {})
       end
 
       def parse_response?(env)

--- a/spec/faraday/request/json_spec.rb
+++ b/spec/faraday/request/json_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Faraday::Request::Json do
   context 'with encoder' do
     let(:encoder) do
       double('Encoder').tap do |e|
-        allow(e).to receive(:encode) { |s, opts| JSON.generate(s, opts) }
+        allow(e).to receive(:dump) { |s, opts| JSON.generate(s, opts) }
       end
     end
 
@@ -145,8 +145,8 @@ RSpec.describe Faraday::Request::Json do
     context 'when encoder is passed as object' do
       let(:middleware) { described_class.new(->(env) { Faraday::Response.new(env) }, { encoder: encoder }) }
 
-      it 'calls specified JSON encoder' do
-        expect(encoder).to receive(:encode).with({ a: 1 })
+      it 'calls specified JSON encoder\'s dump method' do
+        expect(encoder).to receive(:dump).with({ a: 1 })
 
         result
       end
@@ -161,10 +161,10 @@ RSpec.describe Faraday::Request::Json do
     end
 
     context 'when encoder is passed as an object-method pair' do
-      let(:middleware) { described_class.new(->(env) { Faraday::Response.new(env) }, { encoder: [encoder, :encode] }) }
+      let(:middleware) { described_class.new(->(env) { Faraday::Response.new(env) }, { encoder: [encoder, :dump] }) }
 
       it 'calls specified JSON encoder' do
-        expect(encoder).to receive(:encode).with({ a: 1 })
+        expect(encoder).to receive(:dump).with({ a: 1 })
 
         result
       end

--- a/spec/faraday/request/json_spec.rb
+++ b/spec/faraday/request/json_spec.rb
@@ -132,4 +132,68 @@ RSpec.describe Faraday::Request::Json do
       expect(result_type).to eq('application/xml; charset=utf-8')
     end
   end
+
+  context 'with encoder' do
+    let(:encoder) do
+      double('Encoder').tap do |e|
+        allow(e).to receive(:encode) { |s, opts| JSON.generate(s, opts) }
+      end
+    end
+
+    let(:result) { process(a: 1) }
+
+    context 'when encoder is passed as object' do
+      let(:middleware) { described_class.new(->(env) { Faraday::Response.new(env) }, { encoder: encoder }) }
+
+      it 'calls specified JSON encoder' do
+        expect(encoder).to receive(:encode).with({ a: 1 })
+
+        result
+      end
+
+      it 'encodes body' do
+        expect(result_body).to eq('{"a":1}')
+      end
+
+      it 'adds content type' do
+        expect(result_type).to eq('application/json')
+      end
+    end
+
+    context 'when encoder is passed as an object-method pair' do
+      let(:middleware) { described_class.new(->(env) { Faraday::Response.new(env) }, { encoder: [encoder, :encode] }) }
+
+      it 'calls specified JSON encoder' do
+        expect(encoder).to receive(:encode).with({ a: 1 })
+
+        result
+      end
+
+      it 'encodes body' do
+        expect(result_body).to eq('{"a":1}')
+      end
+
+      it 'adds content type' do
+        expect(result_type).to eq('application/json')
+      end
+    end
+
+    context 'when encoder is not passed' do
+      let(:middleware) { described_class.new(->(env) { Faraday::Response.new(env) }) }
+
+      it 'calls JSON.generate' do
+        expect(JSON).to receive(:generate).with({ a: 1 })
+
+        result
+      end
+
+      it 'encodes body' do
+        expect(result_body).to eq('{"a":1}')
+      end
+
+      it 'adds content type' do
+        expect(result_type).to eq('application/json')
+      end
+    end
+  end
 end

--- a/spec/faraday/response/json_spec.rb
+++ b/spec/faraday/response/json_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Faraday::Response::Json, type: :response do
   context 'with decoder' do
     let(:decoder) do
       double('Decoder').tap do |e|
-        allow(e).to receive(:decode) { |s, opts| JSON.parse(s, opts) }
+        allow(e).to receive(:load) { |s, opts| JSON.parse(s, opts) }
       end
     end
 
@@ -136,8 +136,8 @@ RSpec.describe Faraday::Response::Json, type: :response do
         }
       end
 
-      it 'passes relevant options to specified decoder\'s decode method' do
-        expect(decoder).to receive(:decode)
+      it 'passes relevant options to specified decoder\'s load method' do
+        expect(decoder).to receive(:load)
           .with(body, { option: :option_value, symbolize_names: true })
           .and_return(result)
 
@@ -150,7 +150,7 @@ RSpec.describe Faraday::Response::Json, type: :response do
       let(:options) do
         {
           parser_options: {
-            decoder: [decoder, :decode],
+            decoder: [decoder, :load],
             option: :option_value,
             symbolize_names: true
           }
@@ -158,7 +158,7 @@ RSpec.describe Faraday::Response::Json, type: :response do
       end
 
       it 'passes relevant options to specified decoder\'s method' do
-        expect(decoder).to receive(:decode)
+        expect(decoder).to receive(:load)
           .with(body, { option: :option_value, symbolize_names: true })
           .and_return(result)
 


### PR DESCRIPTION
Moves [lostisland/faraday_middleware/#286](https://github.com/lostisland/faraday_middleware/pull/286)

By default `Faraday::Request::Json` and `Faraday::Response::Json` use `json` to encode/decode JSON data, although there are gems like `oj` which do the job faster than Ruby's built-in `json`.

This implementation allows to pass `encoder` option to `Faraday::Request::Json` and decoder option to pass in parser_options to `Faraday::Response::Json`

```ruby
require 'oj'

Faraday.new do |f|
  f.request :json, encoder: Oj
  f.response :json, parser_options: { decoder: Oj }
end
```