### PR TITLE
Fix: Add back support for Hash#pretty_inspect

### DIFF
--- a/lib/faraday/logging/formatter.rb
+++ b/lib/faraday/logging/formatter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pp'
+
 module Faraday
   module Logging
     # Serves as an integration point to customize logging

--- a/lib/faraday/logging/formatter.rb
+++ b/lib/faraday/logging/formatter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pp'
+require 'pp' # This require is necessary for Hash#pretty_inspect to work, do not remove it, people rely on it.
 
 module Faraday
   module Logging


### PR DESCRIPTION
## Description

This PR reverts commit 53c7b499db87894c56d9a556ff9bddf5852b002d.

This require is necessary, in order to have access to the method Hash#pretty_inspect. Thanks @segiddins for sharp eyes!
