### PR TITLE
Remove runtime dependency on base64

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_dependency 'base64'
   # faraday-net_http is the "default adapter", but being a Faraday dependency it can't
   # control which version of faraday it will be pulled from.
   # To avoid releasing a major version every time there's a new Faraday API, we should

--- a/lib/faraday/utils.rb
+++ b/lib/faraday/utils.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'base64'
 require 'uri'
 require 'faraday/utils/headers'
 require 'faraday/utils/params_hash'
@@ -54,7 +53,7 @@ module Faraday
     end
 
     def basic_header_from(login, pass)
-      value = Base64.encode64("#{login}:#{pass}")
+      value = ["#{login}:#{pass}"].pack('m') # Base64 encoding
       value.delete!("\n")
       "Basic #{value}"
     end


### PR DESCRIPTION
## Description
#1525 removed a warning in ruby 3.3 because of the base64 dependency. Only a single method in one place is used so there's no need to pull it in. Since it's just a wrapper around the `pack` method it's trivial to replace.

Same approach by other gems:
* https://github.com/rack/rack/pull/2110
* https://github.com/rubocop/rubocop/pull/12313