### PR TITLE
docs: update `body` param type for `run_request`

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -423,8 +423,8 @@ module Faraday
     #
     # @param method [Symbol] HTTP method.
     # @param url [String, URI, nil] String or URI to access.
-    # @param body [Object, nil] The request body that will eventually be converted to
-    #             a string.
+    # @param body [String, Hash, Array, nil] The request body that will eventually be converted to
+    #             a string; middlewares can be used to support more complex types.
     # @param headers [Hash, nil] unencoded HTTP header key/value pairs.
     #
     # @return [Faraday::Response]

--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -423,7 +423,7 @@ module Faraday
     #
     # @param method [Symbol] HTTP method.
     # @param url [String, URI, nil] String or URI to access.
-    # @param body [String, nil] The request body that will eventually be converted to
+    # @param body [Object, nil] The request body that will eventually be converted to
     #             a string.
     # @param headers [Hash, nil] unencoded HTTP header key/value pairs.
     #


### PR DESCRIPTION
## Description

It looks like this was already picked up in the past (via #601) but the docs have since been overhauled and this was lost in the transition.

I've used `Object` as my understanding is really `body` doesn't care what it's passed so long as it can be turned into a string or JSON, and then beyond supporting calling methods like `to_json`, that's up the object being passed in to handle.

## Todos
List any remaining work that needs to be done, i.e:
- [x] ~Tests~
- [x] ~Documentation~