### PR TITLE
add bundler config to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description
I was working on config for faraday-excon and when updating it's dependabot stuff I saw you all didn't have bundler configured here either, so I thought I would offer the setup in case you want it.
