### PR TITLE
Add RuboCop disables for Style/ArgumentsForwarding

### DIFF
--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -99,32 +99,32 @@ module Faraday
           matches?(consumed, env)
         end
 
-        def get(path, headers = {}, &block)
-          new_stub(:get, path, headers, &block)
+        def get(path, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
+          new_stub(:get, path, headers, &block) # rubocop:disable Style/ArgumentsForwarding
         end
 
-        def head(path, headers = {}, &block)
-          new_stub(:head, path, headers, &block)
+        def head(path, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
+          new_stub(:head, path, headers, &block) # rubocop:disable Style/ArgumentsForwarding
         end
 
-        def post(path, body = nil, headers = {}, &block)
-          new_stub(:post, path, headers, body, &block)
+        def post(path, body = nil, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
+          new_stub(:post, path, headers, body, &block) # rubocop:disable Style/ArgumentsForwarding
         end
 
-        def put(path, body = nil, headers = {}, &block)
-          new_stub(:put, path, headers, body, &block)
+        def put(path, body = nil, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
+          new_stub(:put, path, headers, body, &block) # rubocop:disable Style/ArgumentsForwarding
         end
 
-        def patch(path, body = nil, headers = {}, &block)
-          new_stub(:patch, path, headers, body, &block)
+        def patch(path, body = nil, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
+          new_stub(:patch, path, headers, body, &block) # rubocop:disable Style/ArgumentsForwarding
         end
 
-        def delete(path, headers = {}, &block)
-          new_stub(:delete, path, headers, &block)
+        def delete(path, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
+          new_stub(:delete, path, headers, &block) # rubocop:disable Style/ArgumentsForwarding
         end
 
-        def options(path, headers = {}, &block)
-          new_stub(:options, path, headers, &block)
+        def options(path, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
+          new_stub(:options, path, headers, &block) # rubocop:disable Style/ArgumentsForwarding
         end
 
         # Raises an error if any of the stubbed calls have not been made.

--- a/lib/faraday/middleware_registry.rb
+++ b/lib/faraday/middleware_registry.rb
@@ -59,9 +59,9 @@ module Faraday
 
     private
 
-    def middleware_mutex(&block)
+    def middleware_mutex(&block) # rubocop:disable Style/ArgumentsForwarding
       @middleware_mutex ||= Monitor.new
-      @middleware_mutex.synchronize(&block)
+      @middleware_mutex.synchronize(&block) # rubocop:disable Style/ArgumentsForwarding
     end
 
     def load_middleware(key)


### PR DESCRIPTION
## Description

The `-a` autoformatting failed. Putting these in, to pass.

What it looked like:

![bild](https://github.com/lostisland/faraday/assets/211/f3c773f8-9db4-4a43-b415-cb65089e729f)


