### PR TITLE
Remove unnecessary rubocop disable comments.

### DIFF
--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -99,32 +99,32 @@ module Faraday
           matches?(consumed, env)
         end
 
-        def get(path, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
-          new_stub(:get, path, headers, &block) # rubocop:disable Style/ArgumentsForwarding
+        def get(path, headers = {}, &block)
+          new_stub(:get, path, headers, &block)
         end
 
-        def head(path, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
-          new_stub(:head, path, headers, &block) # rubocop:disable Style/ArgumentsForwarding
+        def head(path, headers = {}, &block)
+          new_stub(:head, path, headers, &block)
         end
 
-        def post(path, body = nil, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
-          new_stub(:post, path, headers, body, &block) # rubocop:disable Style/ArgumentsForwarding
+        def post(path, body = nil, headers = {}, &block)
+          new_stub(:post, path, headers, body, &block)
         end
 
-        def put(path, body = nil, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
-          new_stub(:put, path, headers, body, &block) # rubocop:disable Style/ArgumentsForwarding
+        def put(path, body = nil, headers = {}, &block)
+          new_stub(:put, path, headers, body, &block)
         end
 
-        def patch(path, body = nil, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
-          new_stub(:patch, path, headers, body, &block) # rubocop:disable Style/ArgumentsForwarding
+        def patch(path, body = nil, headers = {}, &block)
+          new_stub(:patch, path, headers, body, &block)
         end
 
-        def delete(path, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
-          new_stub(:delete, path, headers, &block) # rubocop:disable Style/ArgumentsForwarding
+        def delete(path, headers = {}, &block)
+          new_stub(:delete, path, headers, &block)
         end
 
-        def options(path, headers = {}, &block) # rubocop:disable Style/ArgumentsForwarding
-          new_stub(:options, path, headers, &block) # rubocop:disable Style/ArgumentsForwarding
+        def options(path, headers = {}, &block)
+          new_stub(:options, path, headers, &block)
         end
 
         # Raises an error if any of the stubbed calls have not been made.

--- a/lib/faraday/middleware_registry.rb
+++ b/lib/faraday/middleware_registry.rb
@@ -59,9 +59,9 @@ module Faraday
 
     private
 
-    def middleware_mutex(&block) # rubocop:disable Style/ArgumentsForwarding
+    def middleware_mutex(&block)
       @middleware_mutex ||= Monitor.new
-      @middleware_mutex.synchronize(&block) # rubocop:disable Style/ArgumentsForwarding
+      @middleware_mutex.synchronize(&block)
     end
 
     def load_middleware(key)


### PR DESCRIPTION
## Description
These were added in #1550 because of an unsafe autocorrect, but have since been addressed in https://github.com/rubocop/rubocop/pull/12628