### PR TITLE
Use Rubygems Trusted Publishers to publish.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,14 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read  # to checkout the code (actions/checkout)
 jobs:
   build:
     name: Publish to Rubygems
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +22,4 @@ jobs:
           ruby-version: 3
 
       - name: Publish to RubyGems
-        uses: dawidd6/action-publish-gem@v1
-        with:
-          api_key: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
+        uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Description
This new method doesn't need to store any token in GitHub.
For more details: https://guides.rubygems.org/trusted-publishing/