### PR TITLE
Lint fix: get to green

### DIFF
--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -169,7 +169,7 @@ module Faraday
     def stream_response(&block)
       size = 0
       yielded = false
-      block_result = block.call do |chunk| # rubocop:disable Performance/RedundantBlockCall
+      block_result = block.call do |chunk|
         if chunk.bytesize.positive? || size.positive?
           yielded = true
           size += chunk.bytesize


### PR DESCRIPTION

## Description

Seen in build for #1557 - and this is unrelated to that.

```
Lint/RedundantCopDisableDirective: Unnecessary disabling of Performance/RedundantBlockCall
```

This change was created using `bundle exec rubocop -A`.