### PR TITLE
Fix compatibility with Ruby 3.4.0-preview1

### DIFF
--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe Faraday do
 
     it 'uses method_missing on Faraday if there is no proxyable method' do
       expected_message =
-        if RUBY_VERSION >= '3.3'
+        if RUBY_VERSION >= '3.4'
+          "undefined method 'this_method_does_not_exist' for module Faraday"
+        elsif RUBY_VERSION >= '3.3'
           "undefined method `this_method_does_not_exist' for module Faraday"
         else
           "undefined method `this_method_does_not_exist' for Faraday:Module"


### PR DESCRIPTION
## Description
This PR deals with Ruby 3.4's backtrace incompatibility introduced at https://github.com/ruby/ruby/pull/9608.
https://bugs.ruby-lang.org/issues/16495

```sh
❯ ruby -v
ruby 3.4.0preview1 (2024-05-16 master 9d69619623) [x86_64-darwin23]

  1) Faraday proxies to default_connection uses method_missing on Faraday if there is no proxyable method
     Failure/Error: expect { Faraday.this_method_does_not_exist }.to raise_error(NoMethodError, expected_message)

       expected NoMethodError with "undefined method `this_method_does_not_exist' for module Faraday", got #<NoMethodError: undefined method 'this_method_does_not_exist' for module Faraday> with backtrace:
         # ./lib/faraday.rb:147:in 'Faraday.method_missing'
         # ./spec/faraday_spec.rb:28:in 'block (4 levels) in <top (required)>'
         # ./spec/faraday_spec.rb:28:in 'block (3 levels) in <top (required)>'
     # ./spec/faraday_spec.rb:28:in 'block (3 levels) in <top (required)>'
```

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- [ ] Documentation

## Additional Notes
Optional section
