### PR TITLE
Fix Rubocop errors

### DIFF
--- a/lib/faraday/adapter.rb
+++ b/lib/faraday/adapter.rb
@@ -26,7 +26,7 @@ module Faraday
     self.supports_parallel = false
 
     def initialize(_app = nil, opts = {}, &block)
-      @app = ->(env) { env.response }
+      @app = lambda(&:response)
       @connection_options = opts
       @config_block = block
     end

--- a/lib/faraday/utils/headers.rb
+++ b/lib/faraday/utils/headers.rb
@@ -62,10 +62,10 @@ module Faraday
         super(key, val)
       end
 
-      def fetch(key, *args, &block)
+      def fetch(key, ...)
         key = KeyMap[key]
         key = @names.fetch(key.downcase, key)
-        super(key, *args, &block)
+        super(key, ...)
       end
 
       def delete(key)


### PR DESCRIPTION
## Description
Latest `rubocop` (1.64.0) is raising new errors for some reason, this is blocking PRs.