### PR TITLE
Support default json decoder even when nil responds to `:load`

### DIFF
--- a/lib/faraday/response/json.rb
+++ b/lib/faraday/response/json.rb
@@ -60,7 +60,7 @@ module Faraday
         @decoder_options =
           if @decoder_options.is_a?(Array) && @decoder_options.size >= 2
             @decoder_options.slice(0, 2)
-          elsif @decoder_options.respond_to?(:load)
+          elsif @decoder_options&.respond_to?(:load)
             [@decoder_options, :load]
           else
             [::JSON, :parse]

--- a/spec/faraday/response/json_spec.rb
+++ b/spec/faraday/response/json_spec.rb
@@ -184,6 +184,23 @@ RSpec.describe Faraday::Response::Json, type: :response do
         response = process(body)
         expect(response.body).to eq(result)
       end
+
+      it 'passes relevant options to JSON parse even when nil responds to :load' do
+        original_allow_message_expectations_on_nil = RSpec::Mocks.configuration.allow_message_expectations_on_nil
+        RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+        allow(nil).to receive(:respond_to?)
+          .with(:load)
+          .and_return(true)
+
+        expect(JSON).to receive(:parse)
+          .with(body, { symbolize_names: true })
+          .and_return(result)
+
+        response = process(body)
+        expect(response.body).to eq(result)
+      ensure 
+        RSpec::Mocks.configuration.allow_message_expectations_on_nil = original_allow_message_expectations_on_nil
+      end
     end
   end
 end


### PR DESCRIPTION
## Description
In Rails (some versions at least), nil responds to `:load` (via ActiveSupport::Dependencies::Loadable mixin). Default json decoder should still work to work in this case


