### PR TITLE
Add `TooManyRequestsError` (429) to error docs

### DIFF
--- a/docs/middleware/included/raising-errors.md
+++ b/docs/middleware/included/raising-errors.md
@@ -39,6 +39,7 @@ by the client. They raise error classes inheriting from `Faraday::ClientError`.
 | [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) | `Faraday::RequestTimeoutError`      |
 | [409](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) | `Faraday::ConflictError`            |
 | [422](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) | `Faraday::UnprocessableEntityError` |
+| [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) | `Faraday::TooManyRequestsError` |
 | 4xx (any other)                                                     | `Faraday::ClientError`              |
 
 ## 5xx Errors


### PR DESCRIPTION
## Description

`TooManyRequestsError` for HTTP 429 was added in https://github.com/lostisland/faraday/pull/1530. This updates the docs. I've checked the other exceptions as well, this one was the only one missing.
