### PR TITLE
Configure "npm" package-ecosystem for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: /
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Description

I propose adding a new `package-ecosystem` to `dependabot.yml` to maintain the npm dependencies up to date.

After migrating to the new docs, this repository has included `package.json` and its lock file. Maybe, using Dependabot for them can be beneficial.
