### PR TITLE
Introduce Middleware DEFAULT_OPTIONS with Application and Instance Configurability

### DIFF
--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -139,7 +139,7 @@ If the default value provides the desired functionality, no further consideratio
 
 #### Setting Alternative Options per Application
 
-In the case where it is desirable to change the default option for all instances within an applcation, it can be done by configuring the options in a `/config/initializers` file. For example:
+In the case where it is desirable to change the default option for all instances within an application, it can be done by configuring the options in a `/config/initializers` file. For example:
 
 ```ruby
 # config/initializers/faraday_config.rb

--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -114,6 +114,47 @@ conn = Faraday.new do |f|
 end
 ```
 
+### DEFAULT_OPTIONS
+
+`DEFAULT_OPTIONS` improve the flexibility and customizability of new and existing middleware. Class-level `DEFAULT_OPTIONS` and the ability to set these defaults at the application level compliment existing functionality in which options can be passed into middleware on a per-instance basis.
+
+#### Using DEFAULT_OPTIONS
+
+Using `RaiseError` as an example, you can see that `DEFAULT_OPTIONS` have been defined at the top of the class:
+
+```ruby
+  DEFAULT_OPTIONS = { include_request: true }.freeze
+```
+
+These options will be set at the class level upon instantiation and referenced as needed within the class. Using our same example:
+
+```ruby
+  ...
+  return response unless options[:include_request]
+```
+
+If the default value provides the desired functionality, no further consideration is needed.
+
+#### Setting Alternative Options per Application
+
+In the case where it is desirable to change the default option for all instances within an applcation, it can be done by configuring the options in a `/config/initializers` file. For example:
+
+```ruby
+# config/initializers/faraday_config.rb
+
+Faraday::Response::RaiseError.default_options = { include_request: false }
+```
+
+After app initialization, all instances of the middleware will have the newly configured option(s). They can still be overriden on a per-instance bases (if handled in the middleware), like this:
+
+```ruby
+  Faraday.new do |f|
+    ...
+    f.response :raise_error, include_request: true 
+    ...
+  end
+```
+
 ### Available Middleware
 
 The following pages provide detailed configuration for the middleware that ships with Faraday:

--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -126,11 +126,13 @@ Using `RaiseError` as an example, you can see that `DEFAULT_OPTIONS` have been d
   DEFAULT_OPTIONS = { include_request: true }.freeze
 ```
 
-These options will be set at the class level upon instantiation and referenced as needed within the class. Using our same example:
+These options will be set at the class level upon instantiation and referenced as needed within the class. From our same example:
 
 ```ruby
+  def response_values(env)
   ...
-  return response unless options[:include_request]
+    return response unless options[:include_request]
+  ...
 ```
 
 If the default value provides the desired functionality, no further consideration is needed.

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -158,4 +158,8 @@ module Faraday
   # Raised by middlewares that parse the response, like the JSON response middleware.
   class ParsingError < Error
   end
+
+  # Raised by Faraday::Middleware and subclasses when invalid default_options are used
+  class InitializationError < Error
+  end
 end

--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -41,7 +41,7 @@ module Faraday
         invalid_keys = options.keys.reject { |opt| self::DEFAULT_OPTIONS.key?(opt) }
         return unless invalid_keys.any?
 
-        raise(Faraday::Error,
+        raise(Faraday::InitializationError,
               "Invalid options provided. Keys not found in #{self}::DEFAULT_OPTIONS: #{invalid_keys.join(', ')}")
       end
     end

--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -38,10 +38,11 @@ module Faraday
       private
 
       def validate_default_options(options)
-        options.each_key do |opt|
-          self::DEFAULT_OPTIONS.key?(opt) ||
-            raise(Faraday::Error, "#{opt} is not a DEFAULT_OPTION for #{self}")
-        end
+        invalid_keys = options.keys.reject { |opt| self::DEFAULT_OPTIONS.key?(opt) }
+        return unless invalid_keys.any?
+
+        raise(Faraday::Error,
+              "Invalid options provided. Keys not found in #{self}::DEFAULT_OPTIONS: #{invalid_keys.join(', ')}")
       end
     end
 

--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -25,15 +25,14 @@ module Faraday
       #
       def default_options=(options = {})
         validate_default_options(options)
-        @default_options = default_options.merge!(options)
+        @default_options = default_options.merge(options)
       end
 
       # default_options attr_reader that initializes class instance variable
       # with the values of any Faraday::Middleware defaults, and merges with
       # subclass defaults
       def default_options
-        @default_options ||= {}.merge!(DEFAULT_OPTIONS)
-                               .merge!(self::DEFAULT_OPTIONS)
+        @default_options ||= DEFAULT_OPTIONS.merge(self::DEFAULT_OPTIONS)
       end
 
       private

--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'monitor'
+
 module Faraday
   # Middleware is the basic base class of any Faraday middleware.
   class Middleware
@@ -25,7 +27,9 @@ module Faraday
       #
       def default_options=(options = {})
         validate_default_options(options)
-        @default_options = default_options.merge(options)
+        lock.synchronize do
+          @default_options = default_options.merge(options)
+        end
       end
 
       # default_options attr_reader that initializes class instance variable
@@ -36,6 +40,10 @@ module Faraday
       end
 
       private
+
+      def lock
+        @lock ||= Monitor.new
+      end
 
       def validate_default_options(options)
         invalid_keys = options.keys.reject { |opt| self::DEFAULT_OPTIONS.key?(opt) }

--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -9,7 +9,20 @@ module Faraday
 
     def initialize(app = nil, options = {})
       @app = app
-      @options = options
+      @options = @@default_options.merge(options)
+    end
+
+    # Faraday::Middleware::default_options= allows user to set default options at the Faraday::Middleware
+    # class level.
+    #
+    # @example Set the Faraday::Response::RaiseError option, `include_request` to `false`
+    # my_app/config/initializers/my_faraday_middleware.rb
+    #
+    # Faraday::Response::RaiseError.default_options = { include_request: false }
+    #
+    def self.default_options=(options = {}) 
+      @@default_options ||= {}
+      @@default_options.merge!(options)
     end
 
     def call(env)

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -10,6 +10,8 @@ module Faraday
       ServerErrorStatuses = (500...600)
       # rubocop:enable Naming/ConstantName
 
+      DEFAULT_OPTIONS = { include_request: true }.freeze
+
       def on_complete(env)
         case env[:status]
         when 400
@@ -58,7 +60,7 @@ module Faraday
 
         # Include the request data by default. If the middleware was explicitly
         # configured to _not_ include request data, then omit it.
-        return response unless options.fetch(:include_request, true)
+        return response unless options[:include_request]
 
         response.merge(
           request: {

--- a/spec/faraday/middleware_spec.rb
+++ b/spec/faraday/middleware_spec.rb
@@ -91,6 +91,13 @@ RSpec.describe Faraday::Middleware do
       end
     end
 
+    after(:all) do
+      FaradayMiddlewareSubclasses::SubclassNoOptions.instance_variable_set(:@default_options, nil)
+      FaradayMiddlewareSubclasses::SubclassOneOption.instance_variable_set(:@default_options, nil)
+      FaradayMiddlewareSubclasses::SubclassTwoOptions.instance_variable_set(:@default_options, nil)
+      Faraday::Middleware.instance_variable_set(:@default_options, nil)
+    end
+
     context 'with subclass DEFAULT_OPTIONS defined' do
       include_context 'reset @default_options'
 

--- a/spec/faraday/middleware_spec.rb
+++ b/spec/faraday/middleware_spec.rb
@@ -193,5 +193,21 @@ RSpec.describe Faraday::Middleware do
         it { expect(resp2.body).to eq('ok') }
       end
     end
+
+    describe 'default_options input validation' do
+      include_context 'reset @default_options'
+
+      it 'raises error if Faraday::Middleware option does not exist' do
+        expect { Faraday::Middleware.default_options = { something_special: true } }.to raise_error(Faraday::InitializationError) do |e|
+          expect(e.message).to eq('Invalid options provided. Keys not found in Faraday::Middleware::DEFAULT_OPTIONS: something_special')
+        end
+      end
+
+      it 'raises error if subclass option does not exist' do
+        expect { subclass_one_option.default_options = { this_is_a_typo: true } }.to raise_error(Faraday::InitializationError) do |e|
+          expect(e.message).to eq('Invalid options provided. Keys not found in FaradayMiddlewareSubclasses::SubclassOneOption::DEFAULT_OPTIONS: this_is_a_typo')
+        end
+      end
+    end
   end
 end

--- a/spec/faraday/middleware_spec.rb
+++ b/spec/faraday/middleware_spec.rb
@@ -69,6 +69,127 @@ RSpec.describe Faraday::Middleware do
   end
 
   describe '::default_options' do
-    # TODO
+    let(:subclass_no_options) { FaradayMiddlewareSubclasses::SubclassNoOptions }
+    let(:subclass_one_option) { FaradayMiddlewareSubclasses::SubclassOneOption }
+    let(:subclass_two_options) { FaradayMiddlewareSubclasses::SubclassTwoOptions }
+
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('/success') do
+          [200, {}, 'ok']
+        end
+      end
+    end
+
+    def build_conn(resp_middleware)
+      Faraday.new do |c|
+        c.adapter :test, stubs
+        c.response resp_middleware
+      end
+    end
+
+    RSpec.shared_context 'reset @default_options' do
+      before(:each) do
+        FaradayMiddlewareSubclasses::SubclassNoOptions.instance_variable_set(:@default_options, nil)
+        FaradayMiddlewareSubclasses::SubclassOneOption.instance_variable_set(:@default_options, nil)
+        FaradayMiddlewareSubclasses::SubclassTwoOptions.instance_variable_set(:@default_options, nil)
+        Faraday::Middleware.instance_variable_set(:@default_options, nil)
+      end
+    end
+
+    context 'with subclass DEFAULT_OPTIONS defined' do
+      include_context 'reset @default_options'
+
+      context 'and without application options configured' do
+        let(:resp1) { build_conn(:one_option).get('/success') }
+
+        it 'has only subclass defaults' do
+          expect(subclass_no_options.default_options).to eq(subclass_no_options::DEFAULT_OPTIONS)
+          expect(subclass_one_option.default_options).to eq(subclass_one_option::DEFAULT_OPTIONS)
+          expect(subclass_two_options.default_options).to eq(subclass_two_options::DEFAULT_OPTIONS)
+        end
+
+        it { expect(resp1.body).to eq('ok') }
+      end
+
+      context "and with one application's options changed" do
+        let(:resp2) { build_conn(:two_options).get('/success') }
+
+        before(:each) do
+          FaradayMiddlewareSubclasses::SubclassTwoOptions.default_options = { some_option: false }
+        end
+
+        it 'only updates default options of target subclass' do
+          expect(subclass_no_options.default_options).to eq(subclass_no_options::DEFAULT_OPTIONS)
+          expect(subclass_one_option.default_options).to eq(subclass_one_option::DEFAULT_OPTIONS)
+          expect(subclass_two_options.default_options).to eq({ some_option: false, some_other_option: false })
+          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
+        end
+
+        it { expect(resp2.body).to eq('ok') }
+      end
+
+      context "and with two applications' options changed" do
+        let(:resp1) { build_conn(:one_option).get('/success') }
+        let(:resp2) { build_conn(:two_options).get('/success') }
+
+        before(:each) do
+          FaradayMiddlewareSubclasses::SubclassOneOption.default_options = { some_other_option: true }
+          FaradayMiddlewareSubclasses::SubclassTwoOptions.default_options = { some_option: false }
+        end
+
+        it 'updates subclasses and parent independent of each other' do
+          expect(subclass_no_options.default_options).to eq(subclass_no_options::DEFAULT_OPTIONS)
+          expect(subclass_one_option.default_options).to eq({ some_other_option: true })
+          expect(subclass_two_options.default_options).to eq({ some_option: false, some_other_option: false })
+          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
+        end
+
+        it { expect(resp1.body).to eq('ok') }
+        it { expect(resp2.body).to eq('ok') }
+      end
+    end
+
+    context 'with FARADAY::MIDDLEWARE DEFAULT_OPTIONS and with Subclass DEFAULT_OPTIONS' do
+      before(:each) do
+        stub_const('Faraday::Middleware::DEFAULT_OPTIONS', { its_magic: false })
+      end
+
+      # Must stub Faraday::Middleware::DEFAULT_OPTIONS before resetting default options
+      include_context 'reset @default_options'
+
+      context 'and without application options configured' do
+        let(:resp1) { build_conn(:one_option).get('/success') }
+
+        it 'has only subclass defaults' do
+          expect(FaradayMiddlewareSubclasses::SubclassNoOptions.default_options).to eq({ its_magic: false })
+          expect(FaradayMiddlewareSubclasses::SubclassOneOption.default_options).to eq({ its_magic: false, some_other_option: false })
+          expect(FaradayMiddlewareSubclasses::SubclassTwoOptions.default_options).to eq({ its_magic: false, some_option: true, some_other_option: false })
+          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
+        end
+
+        it { expect(resp1.body).to eq('ok') }
+      end
+
+      context "and with two applications' options changed" do
+        let(:resp1) { build_conn(:one_option).get('/success') }
+        let(:resp2) { build_conn(:two_options).get('/success') }
+
+        before(:each) do
+          FaradayMiddlewareSubclasses::SubclassOneOption.default_options = { some_other_option: true }
+          FaradayMiddlewareSubclasses::SubclassTwoOptions.default_options = { some_option: false }
+        end
+
+        it 'updates subclasses and parent independent of each other' do
+          expect(FaradayMiddlewareSubclasses::SubclassNoOptions.default_options).to eq({ its_magic: false })
+          expect(FaradayMiddlewareSubclasses::SubclassOneOption.default_options).to eq({ its_magic: false, some_other_option: true })
+          expect(FaradayMiddlewareSubclasses::SubclassTwoOptions.default_options).to eq({ its_magic: false, some_option: false, some_other_option: false })
+          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
+        end
+
+        it { expect(resp1.body).to eq('ok') }
+        it { expect(resp2.body).to eq('ok') }
+      end
+    end
   end
 end

--- a/spec/faraday/middleware_spec.rb
+++ b/spec/faraday/middleware_spec.rb
@@ -67,4 +67,8 @@ RSpec.describe Faraday::Middleware do
       end
     end
   end
+
+  describe '::default_options' do
+    # TODO
+  end
 end

--- a/spec/faraday/middleware_spec.rb
+++ b/spec/faraday/middleware_spec.rb
@@ -73,17 +73,11 @@ RSpec.describe Faraday::Middleware do
     let(:subclass_one_option) { FaradayMiddlewareSubclasses::SubclassOneOption }
     let(:subclass_two_options) { FaradayMiddlewareSubclasses::SubclassTwoOptions }
 
-    let(:stubs) do
-      Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.get('/success') do
-          [200, {}, 'ok']
-        end
-      end
-    end
-
     def build_conn(resp_middleware)
       Faraday.new do |c|
-        c.adapter :test, stubs
+        c.adapter :test do |stub|
+          stub.get('/success') { [200, {}, 'ok'] }
+        end
         c.response resp_middleware
       end
     end
@@ -104,6 +98,7 @@ RSpec.describe Faraday::Middleware do
         let(:resp1) { build_conn(:one_option).get('/success') }
 
         it 'has only subclass defaults' do
+          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
           expect(subclass_no_options.default_options).to eq(subclass_no_options::DEFAULT_OPTIONS)
           expect(subclass_one_option.default_options).to eq(subclass_one_option::DEFAULT_OPTIONS)
           expect(subclass_two_options.default_options).to eq(subclass_two_options::DEFAULT_OPTIONS)
@@ -120,10 +115,10 @@ RSpec.describe Faraday::Middleware do
         end
 
         it 'only updates default options of target subclass' do
+          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
           expect(subclass_no_options.default_options).to eq(subclass_no_options::DEFAULT_OPTIONS)
           expect(subclass_one_option.default_options).to eq(subclass_one_option::DEFAULT_OPTIONS)
           expect(subclass_two_options.default_options).to eq({ some_option: false, some_other_option: false })
-          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
         end
 
         it { expect(resp2.body).to eq('ok') }
@@ -139,10 +134,10 @@ RSpec.describe Faraday::Middleware do
         end
 
         it 'updates subclasses and parent independent of each other' do
+          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
           expect(subclass_no_options.default_options).to eq(subclass_no_options::DEFAULT_OPTIONS)
           expect(subclass_one_option.default_options).to eq({ some_other_option: true })
           expect(subclass_two_options.default_options).to eq({ some_option: false, some_other_option: false })
-          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
         end
 
         it { expect(resp1.body).to eq('ok') }
@@ -162,10 +157,10 @@ RSpec.describe Faraday::Middleware do
         let(:resp1) { build_conn(:one_option).get('/success') }
 
         it 'has only subclass defaults' do
+          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
           expect(FaradayMiddlewareSubclasses::SubclassNoOptions.default_options).to eq({ its_magic: false })
           expect(FaradayMiddlewareSubclasses::SubclassOneOption.default_options).to eq({ its_magic: false, some_other_option: false })
           expect(FaradayMiddlewareSubclasses::SubclassTwoOptions.default_options).to eq({ its_magic: false, some_option: true, some_other_option: false })
-          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
         end
 
         it { expect(resp1.body).to eq('ok') }
@@ -181,10 +176,10 @@ RSpec.describe Faraday::Middleware do
         end
 
         it 'updates subclasses and parent independent of each other' do
+          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
           expect(FaradayMiddlewareSubclasses::SubclassNoOptions.default_options).to eq({ its_magic: false })
           expect(FaradayMiddlewareSubclasses::SubclassOneOption.default_options).to eq({ its_magic: false, some_other_option: true })
           expect(FaradayMiddlewareSubclasses::SubclassTwoOptions.default_options).to eq({ its_magic: false, some_option: false, some_other_option: false })
-          expect(Faraday::Middleware.default_options).to eq(Faraday::Middleware::DEFAULT_OPTIONS)
         end
 
         it { expect(resp1.body).to eq('ok') }

--- a/spec/faraday/response/raise_error_spec.rb
+++ b/spec/faraday/response/raise_error_spec.rb
@@ -194,16 +194,60 @@ RSpec.describe Faraday::Response::RaiseError do
       end
     end
 
-    context 'when the include_request option is set to false' do
-      let(:middleware_options) { { include_request: false } }
+    describe 'DEFAULT_OPTION: include_request' do
+      before(:each) do
+        Faraday::Response::RaiseError.instance_variable_set(:@default_options, nil)
+        Faraday::Middleware.instance_variable_set(:@default_options, nil)
+      end
 
-      it 'does not include request info in the exception' do
-        expect { perform_request }.to raise_error(Faraday::BadRequestError) do |ex|
-          expect(ex.response.keys).to contain_exactly(
-            :status,
-            :headers,
-            :body
-          )
+      after(:all) do
+        Faraday::Response::RaiseError.instance_variable_set(:@default_options, nil)
+        Faraday::Middleware.instance_variable_set(:@default_options, nil)
+      end
+
+      context 'when RaiseError DEFAULT_OPTION (include_request: true) is used' do
+        it 'includes request info in the exception' do
+          expect { perform_request }.to raise_error(Faraday::BadRequestError) do |ex|
+            expect(ex.response.keys).to contain_exactly(
+              :status,
+              :headers,
+              :body,
+              :request
+            )
+          end
+        end
+      end
+
+      context 'when application sets default_options `include_request: false`' do
+        before(:each) do
+          Faraday::Response::RaiseError.default_options = { include_request: false }
+        end
+
+        context 'and when include_request option is omitted' do
+          it 'does not include request info in the exception' do
+            expect { perform_request }.to raise_error(Faraday::BadRequestError) do |ex|
+              expect(ex.response.keys).to contain_exactly(
+                :status,
+                :headers,
+                :body
+              )
+            end
+          end
+        end
+
+        context 'and when include_request option is explicitly set for instance' do
+          let(:middleware_options) { { include_request: true } }
+
+          it 'includes request info in the exception' do
+            expect { perform_request }.to raise_error(Faraday::BadRequestError) do |ex|
+              expect(ex.response.keys).to contain_exactly(
+                :status,
+                :headers,
+                :body,
+                :request
+              )
+            end
+          end
         end
       end
     end

--- a/spec/support/faraday_middleware_subclasses.rb
+++ b/spec/support/faraday_middleware_subclasses.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module FaradayMiddlewareSubclasses
+  class SubclassNoOptions < Faraday::Middleware
+  end
+
+  class SubclassOneOption < Faraday::Middleware
+    DEFAULT_OPTIONS = { some_other_option: false }.freeze
+  end
+
+  class SubclassTwoOptions < Faraday::Middleware
+    DEFAULT_OPTIONS = { some_option: true, some_other_option: false }.freeze
+  end
+end
+
+Faraday::Response.register_middleware(no_options: FaradayMiddlewareSubclasses::SubclassNoOptions)
+Faraday::Response.register_middleware(one_option: FaradayMiddlewareSubclasses::SubclassOneOption)
+Faraday::Response.register_middleware(two_options: FaradayMiddlewareSubclasses::SubclassTwoOptions)


### PR DESCRIPTION
## Description

This PR introduces a new feature to Faraday::Middleware: Default Options. While the concept of `DEFAULT_OPTIONS` isn't fundamentally new to Faraday, this PR provides some building blocks to introduce Default Options, and the ability to override them at the application level. While it has only been implemented in the RaiseError class, it can easily be added to other Faraday::Middleware classes for which there's a need.

The suggestion was first mentioned [here](https://github.com/lostisland/faraday/pull/1526#issuecomment-2093164772) with some conversation and ideation afterwards. As our team _did_ have a need for this functionality (i.e. setting a different default for `:include_request`), I created a little monkeypatch in our repo, and figured I'd submit a [much more thought out] addition to Faraday itself.

My addition to the documentation (please let me know if you would like this elsewhere!) mostly sums up the general idea and how a user would implement it.

Addresses comment [here](https://github.com/lostisland/faraday/pull/1526#issuecomment-2093348768)

## Additional Notes

The additional "feature" that I did not include in the documentation is that this implementation allows for `DEFAULT_OPTIONS` to be set at the `FARADAY::MIDDLEWARE` level, that would be propagated to child classes. Leaving it blank for now allows for the feature to work as intended, but could open it up for additional configuration in future iterations of the gem. I'd love to hear your thoughts here.

This is my first time contributing to a widely used gem, so be gentle 😆 
