### PR TITLE
Add logger as dependency

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   # This way, we can release minor versions of the adapter with "breaking" changes for older versions of Faraday
   # and then bump the version requirement on the next compatible version of faraday.
   spec.add_dependency 'faraday-net_http', '>= 2.0', '< 3.2'
+  spec.add_dependency 'logger'
 
   # Includes `examples` and `spec` to allow external adapter gems to run Faraday unit and integration tests
   spec.files = Dir['CHANGELOG.md', '{examples,lib,spec}/**/*', 'LICENSE.md', 'Rakefile', 'README.md']


### PR DESCRIPTION
To ensure compatibility with Ruby 3.4 logger needs to be added as an explicit dependency.
A deprecation warning is already shown. See the output of the RSpec step for example: 
https://github.com/lostisland/faraday/actions/runs/9661172692/job/26648356492