### PR TITLE
CI: Drop EOL Ruby 3.0 from build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', '3.1', '3.2', '3.3' ]
+        ruby: [ '3.1', '3.2', '3.3' ]
         experimental: [false]
         include:
           - ruby: head


### PR DESCRIPTION
## Description

Ruby versions go out of support after a few years.

This change stops using Ruby 3.0 to run our test suite.

