### PR TITLE
fix: Avoid lazy-initialized lock

### DIFF
--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -10,7 +10,7 @@ module Faraday
     attr_reader :app, :options
 
     DEFAULT_OPTIONS = {}.freeze
-    LOCK = Monitor.new
+    LOCK = Mutex.new
 
     def initialize(app = nil, options = {})
       @app = app

--- a/lib/faraday/middleware.rb
+++ b/lib/faraday/middleware.rb
@@ -10,6 +10,7 @@ module Faraday
     attr_reader :app, :options
 
     DEFAULT_OPTIONS = {}.freeze
+    LOCK = Monitor.new
 
     def initialize(app = nil, options = {})
       @app = app
@@ -27,7 +28,7 @@ module Faraday
       #
       def default_options=(options = {})
         validate_default_options(options)
-        lock.synchronize do
+        LOCK.synchronize do
           @default_options = default_options.merge(options)
         end
       end
@@ -40,10 +41,6 @@ module Faraday
       end
 
       private
-
-      def lock
-        @lock ||= Monitor.new
-      end
 
       def validate_default_options(options)
         invalid_keys = options.keys.reject { |opt| self::DEFAULT_OPTIONS.key?(opt) }


### PR DESCRIPTION
## Description

2.10.0 introduced a [lock](https://rubyapi.org/3.3/o/monitor), to synchronize changes to default options.

## Issue

The mechanism to obtain the lock tried to wait as long as possible, with a lazy-initialized assignment.

This becomes a race between clients: "Who locks the lock?".

## Solution

We avoid this by creating the lock beforehand.

In addition: this changes the lock to be a Mutex, not a Monitor.

> A mutex should be fine, the only reason to use a monitor is if you are going to re-enter the same block on the same thread, e.g.
>
> 
> ```ruby
> def do_something
>  MONITOR.synchronize do
>    ...
>    yield
>    ...
>   end
> end
>
> def do_something_else
>  MONITOR.synchronize do ...
> ```
>
> In the above example, the user-supplied block might call another method with the lock.
>
> Generally, "Recursive locks are bad": https://blog.stephencleary.com/2013/04/recursive-re-entrant-locks.html
