### PR TITLE
Opt-in for MFA requirement explicitly

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
     'changelog_uri' =>
       "https://github.com/lostisland/faraday/releases/tag/v#{spec.version}",
     'source_code_uri' => 'https://github.com/lostisland/faraday',
-    'bug_tracker_uri' => 'https://github.com/lostisland/faraday/issues'
+    'bug_tracker_uri' => 'https://github.com/lostisland/faraday/issues',
+    'rubygems_mfa_required' => 'true'
   }
 end


### PR DESCRIPTION
As a popular gem, `faraday` implicitly requires that all privileged operations by any of the owners require OTP.

However, by explicitly setting `rubygems_mfa_required` metadata, the gem will show "NEW VERSIONS REQUIRE MFA" and
"VERSION PUBLISHED WITH MFA" in the sidebar at
https://rubygems.org/gems/faraday

Ref:
- https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html
- https://guides.rubygems.org/mfa-requirement-opt-in/

---

![image](https://github.com/user-attachments/assets/49d1bf55-195e-4bcf-ae29-59ca185f88a3)
