### PR TITLE
Add ciphers attribute to SSLOptions

### DIFF
--- a/docs/customization/ssl-options.md
+++ b/docs/customization/ssl-options.md
@@ -2,22 +2,23 @@
 
 Faraday supports a number of SSL options, which can be provided while initializing the connection.
 
-| Option             | Type                                   | Default | Description                                                                                                                                      |
-|--------------------|----------------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| `:verify`          | Boolean                                | true    | Verify SSL certificate. Defaults to `true`.                                                                                                      |
-| `:verify_hostname` | Boolean                                | true    | Verify SSL certificate hostname. Defaults to `true`.                                                                                             |
-| `:ca_file`         | String                                 | nil     | Path to a CA file in PEM format.                                                                                                                 |
-| `:ca_path`         | String                                 | nil     | Path to a CA directory.                                                                                                                          |
+| Option             | Type                                   | Default | Description                                                                                                                        |
+|--------------------|----------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------|
+| `:verify`          | Boolean                                | true    | Verify SSL certificate. Defaults to `true`.                                                                                        |
+| `:verify_hostname` | Boolean                                | true    | Verify SSL certificate hostname. Defaults to `true`.                                                                               |
+| `:ca_file`         | String                                 | nil     | Path to a CA file in PEM format.                                                                                                   |
+| `:ca_path`         | String                                 | nil     | Path to a CA directory.                                                                                                            |
 | `:verify_mode`     | Integer                                | nil     | Any `OpenSSL::SSL::` constant (see [SSL docs](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/SSL.html)).                          |
-| `:cert_store`      | OpenSSL::X509::Store                   | nil     | OpenSSL certificate store.                                                                                                                       |
-| `:client_cert`     | OpenSSL::X509::Certificate             | nil     | Client certificate.                                                                                                                              |
-| `:client_key`      | OpenSSL::PKey::RSA, OpenSSL::PKey::DSA | nil     | Client private key.                                                                                                                              |
-| `:certificate`     | OpenSSL::X509::Certificate             | nil     | Certificate (Excon only).                                                                                                                        |
-| `:private_key`     | OpenSSL::PKey::RSA                     | nil     | Private key (Excon only).                                                                                                                        |
-| `:verify_depth`    | Integer                                | nil     | Maximum depth for the certificate chain verification.                                                                                            |
+| `:cert_store`      | OpenSSL::X509::Store                   | nil     | OpenSSL certificate store.                                                                                                         |
+| `:client_cert`     | OpenSSL::X509::Certificate             | nil     | Client certificate.                                                                                                                |
+| `:client_key`      | OpenSSL::PKey::RSA, OpenSSL::PKey::DSA | nil     | Client private key.                                                                                                                |
+| `:certificate`     | OpenSSL::X509::Certificate             | nil     | Certificate (Excon only).                                                                                                          |
+| `:private_key`     | OpenSSL::PKey::RSA                     | nil     | Private key (Excon only).                                                                                                          |
+| `:verify_depth`    | Integer                                | nil     | Maximum depth for the certificate chain verification.                                                                              |
 | `:version`         | Integer                                | nil     | SSL version (see [SSL docs](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/SSL/SSLContext.html#method-i-ssl_version-3D)).         |
 | `:min_version`     | Integer                                | nil     | Minimum SSL version (see [SSL docs](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/SSL/SSLContext.html#method-i-min_version-3D)). |
 | `:max_version`     | Integer                                | nil     | Maximum SSL version (see [SSL docs](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/SSL/SSLContext.html#method-i-max_version-3D)). |
+| `:ciphers`         | String                                 | nil     | Ciphers supported (see [SSL docs](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/SSL/SSLContext.html#method-i-ciphers-3D)).       |
 
 ## Example
 

--- a/lib/faraday/options/ssl_options.rb
+++ b/lib/faraday/options/ssl_options.rb
@@ -46,12 +46,15 @@ module Faraday
   #   #
   #   # @!attribute max_version
   #   #   @return [String, Symbol] maximum SSL version (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-max_version-3D)
+  #   #
+  #   # @!attribute ciphers
+  #   #   @return [String] cipher list in OpenSSL format (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-ciphers-3D)
   #   class SSLOptions < Options; end
   SSLOptions = Options.new(:verify, :verify_hostname,
                            :ca_file, :ca_path, :verify_mode,
                            :cert_store, :client_cert, :client_key,
                            :certificate, :private_key, :verify_depth,
-                           :version, :min_version, :max_version) do
+                           :version, :min_version, :max_version, :ciphers) do
     # @return [Boolean] true if should verify
     def verify?
       verify != false

--- a/spec/faraday/utils_spec.rb
+++ b/spec/faraday/utils_spec.rb
@@ -103,7 +103,8 @@ RSpec.describe Faraday::Utils do
           version: '2',
           min_version: nil,
           max_version: nil,
-          verify_hostname: nil
+          verify_hostname: nil,
+          ciphers: nil
         }
       end
 


### PR DESCRIPTION
Fixes issue #1581 
Allows a ciphers attribute to be used to pass a cipher string in OpenSSL format to adapters
This controls which ciphers are chosen to connect to the server.