### PR TITLE
Add support for a new `ParallelManager#execute` method.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,7 +31,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 225
+  Max: 230
 
 # Offense count: 9
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/docs/adapters/custom/parallel-requests.md
+++ b/docs/adapters/custom/parallel-requests.md
@@ -65,7 +65,7 @@ end
 Prior to the introduction of the `execute` method, the `ParallelManager` was expected to implement a `run` method
 and the execution of the block was done by the Faraday connection BEFORE calling that method.
 
-This approach made the `ParallelManager` implementation harder and keeping the state required.
+This approach made the `ParallelManager` implementation harder and forced you to keep state around.
 The new `execute` implementation allows to avoid this shortfall and support different flows.
 
 As of Faraday 2.0, `run` is still supported in case `execute` is not implemented by the `ParallelManager`,


### PR DESCRIPTION
## Description
The new interface passes the parallel block with all the requests to the ParallelManager, instead of running it beforehand.

This allows for better, stateless ParallelManager implementations.

Fixes https://github.com/lostisland/faraday/issues/1583

## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests: probably not adding any since the implementation depends on the adapter
- [x] Documentation
