### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -517,7 +517,7 @@ Breaking changes:
 - Drop support for Ruby 1.8
 
 Features:
-- Include wrapped exception/reponse in ClientErrors
+- Include wrapped exception/response in ClientErrors
 - Add `response.reason_phrase`
 - Provide option to selectively skip logging request/response headers
 - Add regex support for pattern matching in `test` adapter

--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -147,7 +147,7 @@ In the case where it is desirable to change the default option for all instances
 Faraday::Response::RaiseError.default_options = { include_request: false }
 ```
 
-After app initialization, all instances of the middleware will have the newly configured option(s). They can still be overriden on a per-instance bases (if handled in the middleware), like this:
+After app initialization, all instances of the middleware will have the newly configured option(s). They can still be overridden on a per-instance bases (if handled in the middleware), like this:
 
 ```ruby
   Faraday.new do |f|


### PR DESCRIPTION
Found via `codespell`

[ci skip]