### PR TITLE
Add json as an explicit dependency

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   # This way, we can release minor versions of the adapter with "breaking" changes for older versions of Faraday
   # and then bump the version requirement on the next compatible version of faraday.
   spec.add_dependency 'faraday-net_http', '>= 2.0', '< 3.4'
+  spec.add_dependency 'json'
   spec.add_dependency 'logger'
 
   # Includes `examples` and `spec` to allow external adapter gems to run Faraday unit and integration tests


### PR DESCRIPTION
## Description

This is similar to https://github.com/lostisland/faraday/pull/1573, but for `json`.

In this case, I'm not getting a warning about `json` but about `ostruct`, i.e., it's not `json` that's being removed as a default gem in Ruby 3.5, but `ostruct`:

> /home/deivid/.asdf/installs/ruby/3.3.5/lib/ruby/3.3.0/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
>
> You can add ostruct to your Gemfile or gemspec to silence this warning.

`ostruct` is getting loaded by `json` though, and `json` is getting loaded by `faraday`.

`json` has fixed the problem by autoloading the class that uses `ostruct` at https://github.com/flori/json/commit/b507f9e404f86df5447b3088eb5ddd57a98317a7. However, I can't really pick up the fix, since `json` is not a explicit dependency of `faraday`, so the default version of it always get loaded.

So the only thing remaining to fix the issue would be for `faraday` to declare its dependency on `json`. That way, Bundler will be aware of the dependency and a `bundle update json` can be used to pick up a `json` version that does not load `ostruct` and thus avoid the warning.