### PR TITLE
Make RaiseError middleware configurable to not raise error on certain status codes (e.g. 404)

### DIFF
--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -10,9 +10,11 @@ module Faraday
       ServerErrorStatuses = (500...600)
       # rubocop:enable Naming/ConstantName
 
-      DEFAULT_OPTIONS = { include_request: true }.freeze
+      DEFAULT_OPTIONS = { include_request: true, allowed_statuses: [] }.freeze
 
       def on_complete(env)
+        return if Array(options[:allowed_statuses]).include?(env[:status])
+
         case env[:status]
         when 400
           raise Faraday::BadRequestError, response_values(env)


### PR DESCRIPTION
## Description

This adds the possibility to use the `RaiseError` middleware while preventing certain status from raising errors.

A common example are cases where raising errors on 4xx/5xx status codes is generally desirable and consequently we want to use the `RaiseError` middleware and then having to work around a missing upsert (`PUT`) behavior by first trying to fetch a resource and depending on whether or not the resource is found, we subsequently `POST` to create or `PATCH` to update.

Before:

``` ruby
client = Faraday.new('https://example.com') do |b|
  b.response :raise_error
end

existing_object = begin
  client.get('/foo/1').body
rescue Faraday::ResourceNotFound
  # We expect this resource to potentially be missing, but still have to
  # rescue from it when using the RaiseError middleware
end

if existing_object
  client.patch('/foo', data)
else
  client.post('/foo', data)
end
```

After:

``` ruby
client = Faraday.new('https://example.com') do |b|
  b.response :raise_error, allowed_statuses: [404]
end

existing_object = client.get('/foo/1').body

if existing_object
  client.patch('/foo', data)
else
  client.post('/foo', data)
end
```

Closes #1587.

## Todos

None.

## Additional Notes

In addition to adding the feature, I've refactored the repetitive `case`/`when` statement. I'm happy to take it out if that change is undesirable.