### PR TITLE
Make Test adapter constructor able to receive stubs as a keyword argument

### DIFF
--- a/lib/faraday/adapter/test.rb
+++ b/lib/faraday/adapter/test.rb
@@ -255,8 +255,9 @@ module Faraday
         end
       end
 
-      def initialize(app, stubs = nil, &block)
+      def initialize(app, stubs_or_options = nil, &block)
         super(app)
+        stubs = stubs_or_options.is_a?(Hash) ? stubs_or_options[:stubs] : stubs_or_options
         @stubs = stubs || Stubs.new
         configure(&block) if block
       end

--- a/spec/faraday/adapter/test_spec.rb
+++ b/spec/faraday/adapter/test_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe Faraday::Adapter::Test do
 
   let(:response) { connection.get('/hello') }
 
+  it 'can receive stubs as a positional argument' do
+    expect(described_class.new(dummy_rack_app, stubs).stubs).to be stubs
+  end
+
+  it 'can receive stubs as a keyword argument' do
+    expect(described_class.new(dummy_rack_app, stubs: stubs).stubs).to be stubs
+  end
+
   context 'with simple path sets status' do
     subject { response.status }
 

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -92,5 +92,9 @@ module Faraday
       kb = 1024
       (32..126).map(&:chr).cycle.take(50 * kb).join
     end
+
+    def dummy_rack_app
+      ->(_env) { [200, { 'content-type' => 'text/plain' }, ['Hello World']] }
+    end
   end
 end


### PR DESCRIPTION
## Description
This PR makes Test adapter constructor able to receive `stubs` as a keyword argument. 

## Details
The Test adapter expects to receive the `stubs` as a positional argument. It is great because in the most of cases we want to use it like
```ruby
Faraday.new do |builder|
  builder.adapter :test, stubs
end
```

But it is not compatible with `Faraday.default_adapter_options` as it must to be a hash.
https://github.com/lostisland/faraday/blob/59c5003ceb350096ade65086f8c17efbb7e0e53c/lib/faraday/rack_builder.rb#L72-L76

So we can't do something like

```ruby
RSpec.configure do |config|
  config.before :context, :stub_api do
    Faraday.default_adapter = :test
    Faraday.default_adapter_options = # must be a hash
  end
end

```

I changed the Test adapter constructor to also accept positional argument instead of change `RackBuilder::Handler#builder` method because the way to pass options to adapters is using hash.