### PR TITLE
Allow `faraday-net_http` 3.4.x

### DIFF
--- a/faraday.gemspec
+++ b/faraday.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # always fix its required version to the next MINOR version.
   # This way, we can release minor versions of the adapter with "breaking" changes for older versions of Faraday
   # and then bump the version requirement on the next compatible version of faraday.
-  spec.add_dependency 'faraday-net_http', '>= 2.0', '< 3.4'
+  spec.add_dependency 'faraday-net_http', '>= 2.0', '< 3.5'
   spec.add_dependency 'json'
   spec.add_dependency 'logger'
 


### PR DESCRIPTION
## Description

Due to a minor version requirement, it's currently not possible to use the latest version of Faraday with the latest version of the [`faraday-net_http` adapter](https://github.com/lostisland/faraday-net_http/releases/tag/v3.4.0).  

This change bumps the minor version to allow usage.
