### PR TITLE
Fix relative path on middleware doc

### DIFF
--- a/docs/middleware/index.md
+++ b/docs/middleware/index.md
@@ -160,12 +160,12 @@ After app initialization, all instances of the middleware will have the newly co
 ### Available Middleware
 
 The following pages provide detailed configuration for the middleware that ships with Faraday:
-* [Authentication](middleware/included/authentication.md)
-* [URL Encoding](middleware/included/url-encoding.md)
-* [JSON Encoding/Decoding](middleware/included/json.md)
-* [Instrumentation](middleware/included/instrumentation.md)
-* [Logging](middleware/included/logging.md)
-* [Raising Errors](middleware/included/raising-errors.md)
+* [Authentication](included/authentication.md)
+* [URL Encoding](included/url-encoding.md)
+* [JSON Encoding/Decoding](included/json.md)
+* [Instrumentation](included/instrumentation.md)
+* [Logging](included/logging.md)
+* [Raising Errors](included/raising-errors.md)
 
 The [Awesome Faraday](https://github.com/lostisland/awesome-faraday/) project
 has a complete list of useful, well-maintained Faraday middleware. Middleware is


### PR DESCRIPTION
## Description
I found the link to each included middleware from middleware/index.md was broken, it's defined as a relative path so we don't need `middleware` directory.

https://github.com/lostisland/faraday/blob/93ef9e0ea905675358e2ae3edadebe1e13df95ef/docs/middleware/index.md?plain=1#L162-L168

## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests
- [ ] Documentation

This PR contains only the change of document, I think we can skip this todos but please let me know if I should take action for them.

## Additional Notes
nothing special
