### PR TITLE
feat(ssl options): support SNI hostname

### DIFF
--- a/docs/customization/ssl-options.md
+++ b/docs/customization/ssl-options.md
@@ -6,6 +6,7 @@ Faraday supports a number of SSL options, which can be provided while initializi
 |--------------------|----------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------|
 | `:verify`          | Boolean                                | true    | Verify SSL certificate. Defaults to `true`.                                                                                        |
 | `:verify_hostname` | Boolean                                | true    | Verify SSL certificate hostname. Defaults to `true`.                                                                               |
+| `:hostname`        | String                                 | nil     | Server hostname for SNI (see [SSL docs](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/SSL/SSLSocket.html#method-i-hostname-3D)). |
 | `:ca_file`         | String                                 | nil     | Path to a CA file in PEM format.                                                                                                   |
 | `:ca_path`         | String                                 | nil     | Path to a CA directory.                                                                                                            |
 | `:verify_mode`     | Integer                                | nil     | Any `OpenSSL::SSL::` constant (see [SSL docs](https://ruby-doc.org/3.2.2/exts/openssl/OpenSSL/SSL.html)).                          |

--- a/lib/faraday/options/ssl_options.rb
+++ b/lib/faraday/options/ssl_options.rb
@@ -12,7 +12,7 @@ module Faraday
   #   #           during the handshake or not (see https://github.com/ruby/openssl/pull/60)
   #   #
   #   # @!attribute hostname
-  #   #   @return [String] SNI hostname (see https://ruby.github.io/openssl/OpenSSL/SSL/SSLSocket.html#method-i-hostname-3D)
+  #   #   @return [String] Server hostname used for SNI (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLSocket.html#method-i-hostname-3D)
   #   #
   #   # @!attribute ca_file
   #   #   @return [String] CA file

--- a/lib/faraday/options/ssl_options.rb
+++ b/lib/faraday/options/ssl_options.rb
@@ -11,6 +11,9 @@ module Faraday
   #   #   @return [Boolean] whether to enable hostname verification on server certificates
   #   #           during the handshake or not (see https://github.com/ruby/openssl/pull/60)
   #   #
+  #   # @!attribute hostname
+  #   #   @return [String] SNI hostname (see https://ruby.github.io/openssl/OpenSSL/SSL/SSLSocket.html#method-i-hostname-3D)
+  #   #
   #   # @!attribute ca_file
   #   #   @return [String] CA file
   #   #
@@ -50,7 +53,7 @@ module Faraday
   #   # @!attribute ciphers
   #   #   @return [String] cipher list in OpenSSL format (see https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-ciphers-3D)
   #   class SSLOptions < Options; end
-  SSLOptions = Options.new(:verify, :verify_hostname,
+  SSLOptions = Options.new(:verify, :verify_hostname, :hostname,
                            :ca_file, :ca_path, :verify_mode,
                            :cert_store, :client_cert, :client_key,
                            :certificate, :private_key, :verify_depth,

--- a/spec/faraday/utils_spec.rb
+++ b/spec/faraday/utils_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe Faraday::Utils do
           min_version: nil,
           max_version: nil,
           verify_hostname: nil,
+          hostname: nil,
           ciphers: nil
         }
       end


### PR DESCRIPTION
The HTTPX gem supports this OpenSSL::SSL::SSLSocket#hostname= option

## Description

The [HTTPX gem](https://github.com/HoneyryderChuck/httpx/blob/7811cbf3a7b81d75c5a9865b14f5d02ed63a8e44/lib/httpx/io/ssl.rb#L94-L114
) supports the `ssl` option `hostname=` but, when using the Faraday adapter, it raises an error

```ruby
NameError: no member 'hostname' in struct (NameError)

        target[key] = if value.is_a?(Hash) && (target[key].is_a?(Hash) || target[key].is_a?(Options))
              ^^^^^^^
```

This option is defined as `OpenSSL::SSL::SSLSocket#hostname` and looks like it has been around a long time https://github.com/ruby/openssl/issues/81

I've found it helpful when using a SOCKS5 proxy and I want to set the hostname for use in verifying the certificate. Without this change, I need to set OpenSSL::SSL::VERIFY_NONE


## Todos

Not sure if tests or documentation are needed

## Additional Notes

Happy to make any changes needed.
