### PR TITLE
Remove ruby2_keywords

### DIFF
--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -27,10 +27,11 @@ module Faraday
 
       attr_reader :name
 
-      ruby2_keywords def initialize(klass, *args, &block)
+      def initialize(klass, *args, **kwargs, &block)
         @name = klass.to_s
         REGISTRY.set(klass) if klass.respond_to?(:name)
         @args = args
+        @kwargs = kwargs
         @block = block
       end
 
@@ -53,7 +54,7 @@ module Faraday
       end
 
       def build(app = nil)
-        klass.new(app, *@args, &@block)
+        klass.new(app, *@args, **@kwargs, &@block)
       end
     end
 
@@ -106,11 +107,11 @@ module Faraday
       use_symbol(Faraday::Response, ...)
     end
 
-    ruby2_keywords def adapter(klass = NO_ARGUMENT, *args, &block)
+    def adapter(klass = NO_ARGUMENT, *args, **kwargs, &block)
       return @adapter if klass == NO_ARGUMENT || klass.nil?
 
       klass = Faraday::Adapter.lookup_middleware(klass) if klass.is_a?(Symbol)
-      @adapter = self.class::Handler.new(klass, *args, &block)
+      @adapter = self.class::Handler.new(klass, *args, **kwargs, &block)
     end
 
     ## methods to push onto the various positions in the stack:


### PR DESCRIPTION
## Description

I was wondering what Ruby version faraday supports to see if https://github.com/tisba/faraday-follow-redirects is in alignment. While doing this, I kind of stumbled across https://github.com/lostisland/faraday/pull/1601. And I was wondering, since `faraday` [only supports Ruby >= 3.0](https://github.com/lostisland/faraday/blob/v2.12.2/faraday.gemspec#L16), why we should need `ruby2_keywords` at all, because this is [meant to be to create backward compatibility to Ruby versions before 3.0](https://ruby-doc.org/3.4.1/Module.html#method-i-ruby2_keywords).

Long story short: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#delegation-ruby-3 explains how we are supposed to handle argument delegation for Ruby >= 3.0. And since `...` does not support default values for positional arguments (can't find a reference, but it's a `SyntaxError`), we are supposed to use `*args, **kwargs`.

## Todos
List any remaining work that needs to be done, i.e:
- [X] Tests (no changes required)
- [x] Documentation

Technically `UPGRADING.md` would need some updating, as this mentions `ruby2_keywords` as a dependency. I'm not sure if I'm supposed to update this.