### PR TITLE
Fix thread safety issue by avoiding mutation of proxy options hash

### DIFF
--- a/lib/faraday/options/proxy_options.rb
+++ b/lib/faraday/options/proxy_options.rb
@@ -22,7 +22,7 @@ module Faraday
       when URI
         value = { uri: value }
       when Hash, Options
-        if (uri = value.delete(:uri))
+        if (uri = value[:uri])
           value[:uri] = Utils.URI(uri)
         end
       end

--- a/lib/faraday/options/proxy_options.rb
+++ b/lib/faraday/options/proxy_options.rb
@@ -22,8 +22,10 @@ module Faraday
       when URI
         value = { uri: value }
       when Hash, Options
-        if (uri = value[:uri])
-          value[:uri] = Utils.URI(uri)
+        if value[:uri]
+          value = value.dup.tap do |duped|
+            duped[:uri] = Utils.URI(duped[:uri])
+          end
         end
       end
 

--- a/spec/faraday/options/proxy_options_spec.rb
+++ b/spec/faraday/options/proxy_options_spec.rb
@@ -27,6 +27,33 @@ RSpec.describe Faraday::ProxyOptions do
       expect(options.inspect).to eq('#<Faraday::ProxyOptions (empty)>')
     end
 
+    it 'works with hash' do
+      hash = { user: 'user', password: 'pass', uri: 'http://@example.org' }
+      options = Faraday::ProxyOptions.from(hash)
+      expect(options.user).to eq('user')
+      expect(options.password).to eq('pass')
+      expect(options.uri).to be_a_kind_of(URI)
+      expect(options.path).to eq('')
+      expect(options.port).to eq(80)
+      expect(options.host).to eq('example.org')
+      expect(options.scheme).to eq('http')
+      expect(options.inspect).to match('#<Faraday::ProxyOptions uri=')
+    end
+
+    it 'works with option' do
+      opt_arg = { user: 'user', password: 'pass', uri: 'http://@example.org' }
+      option = Faraday::ConnectionOptions.from(proxy: opt_arg)
+      options = Faraday::ProxyOptions.from(option.proxy)
+      expect(options.user).to eq('user')
+      expect(options.password).to eq('pass')
+      expect(options.uri).to be_a_kind_of(URI)
+      expect(options.path).to eq('')
+      expect(options.port).to eq(80)
+      expect(options.host).to eq('example.org')
+      expect(options.scheme).to eq('http')
+      expect(options.inspect).to match('#<Faraday::ProxyOptions uri=')
+    end
+
     it 'works with no auth' do
       proxy = Faraday::ProxyOptions.from 'http://example.org'
       expect(proxy.user).to be_nil


### PR DESCRIPTION
Hi! Thank you for maintaining this great gem.
This pull request includes both a bug report and a fix.

## Description

Currently, the proxy option in Faraday mutates the provided hash by adding keys to it.
This causes issues in multi-threaded environments, potentially raising a RuntimeError.
Here is a minimal example to reproduce the issue (note: due to the nature of thread safety issues, this may not reproduce consistently):

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'faraday'
end

require 'faraday'

proxy_options = { uri: 'http://localhost:8080' }

t = Thread.new do
  loop do
    Faraday.new(proxy: proxy_options)
  end
end

sleep 1

loop do
  Faraday.new(proxy: proxy_options)
end

t.join

# => 
#<Thread:0x000000010295ddc0 faraday_proxy_multi.rb:14 run> terminated with exception (report_on_exception is true):
# ###/installs/ruby/3.4.1/lib/ruby/gems/3.4.0/gems/faraday-2.12.2/lib/faraday/options/proxy_options.rb:26:in 'Faraday::ProxyOptions.from': can't add a new key into hash during iteration (RuntimeError)
```

This PR avoids modifying the original hash and instead works with a duplicate one.
It also adds a test to ensure that the original proxy option remains unchanged.
