### PR TITLE
Logger middleware default options

### DIFF
--- a/lib/faraday/response/logger.rb
+++ b/lib/faraday/response/logger.rb
@@ -10,11 +10,13 @@ module Faraday
     # lifecycle to a given Logger object. By default, this logs to STDOUT. See
     # Faraday::Logging::Formatter to see specifically what is logged.
     class Logger < Middleware
+      DEFAULT_OPTIONS = { formatter: Logging::Formatter }.merge(Logging::Formatter::DEFAULT_OPTIONS).freeze
+
       def initialize(app, logger = nil, options = {})
-        super(app)
+        super(app, options)
         logger ||= ::Logger.new($stdout)
-        formatter_class = options.delete(:formatter) || Logging::Formatter
-        @formatter = formatter_class.new(logger: logger, options: options)
+        formatter_class = @options.delete(:formatter)
+        @formatter = formatter_class.new(logger: logger, options: @options)
         yield @formatter if block_given?
       end
 

--- a/spec/faraday/response/logger_spec.rb
+++ b/spec/faraday/response/logger_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Faraday::Response::Logger do
   context 'when logging request body' do
     let(:logger_options) { { bodies: { request: true } } }
 
-    it 'log only request body' do
+    it 'logs only request body' do
       conn.post '/ohyes', 'name=Tamago', accept: 'text/html'
       expect(string_io.string).to match(%(name=Tamago))
       expect(string_io.string).not_to match(%(pebbles))
@@ -199,7 +199,7 @@ RSpec.describe Faraday::Response::Logger do
   context 'when logging response body' do
     let(:logger_options) { { bodies: { response: true } } }
 
-    it 'log only response body' do
+    it 'logs only response body' do
       conn.post '/ohyes', 'name=Hamachi', accept: 'text/html'
       expect(string_io.string).to match(%(pebbles))
       expect(string_io.string).not_to match(%(name=Hamachi))
@@ -209,13 +209,13 @@ RSpec.describe Faraday::Response::Logger do
   context 'when logging request and response bodies' do
     let(:logger_options) { { bodies: true } }
 
-    it 'log request and response body' do
+    it 'logs request and response body' do
       conn.post '/ohyes', 'name=Ebi', accept: 'text/html'
       expect(string_io.string).to match(%(name=Ebi))
       expect(string_io.string).to match(%(pebbles))
     end
 
-    it 'log response body object' do
+    it 'logs response body object' do
       conn.get '/rubbles', nil, accept: 'text/html'
       expect(string_io.string).to match(%([\"Barney\", \"Betty\", \"Bam Bam\"]\n))
     end
@@ -225,6 +225,21 @@ RSpec.describe Faraday::Response::Logger do
       expect(string_io.string).to match(%(soylent green is))
       expect(string_io.string).to match(%(tasty))
       expect(string_io.string).not_to match(%(people))
+    end
+  end
+
+  context 'when bodies are logged by default' do
+    before do
+      described_class.default_options = { bodies: true }
+    end
+
+    it 'logs response body' do
+      conn.post '/ohai'
+      expect(string_io.string).to match(%(fred))
+    end
+
+    after do
+      described_class.default_options = { bodies: false }
     end
   end
 


### PR DESCRIPTION
## Description
Currently, it isn't possible to set the default options with of the Logger middleware with `Faraday::Response::Logger.default_options=` because `DEFAULT_OPTIONS` isn't defined and `options` isn't passed to `super`.