### PR TITLE
Fix Style/RedundantParentheses in options/env.rb

### DIFF
--- a/lib/faraday/options/env.rb
+++ b/lib/faraday/options/env.rb
@@ -60,7 +60,7 @@ module Faraday
                     :reason_phrase, :response_body) do
     const_set(:ContentLength, 'Content-Length')
     const_set(:StatusesWithoutBody, Set.new([204, 304]))
-    const_set(:SuccessfulStatuses, (200..299))
+    const_set(:SuccessfulStatuses, 200..299)
 
     # A Set of HTTP verbs that typically send a body.  If no body is set for
     # these requests, the Content-Length header is set to 0.


### PR DESCRIPTION
## Description
Fixes a [Rubocop error](https://github.com/lostisland/faraday/actions/runs/14665609882/job/41159545174) causing Master CI to fail