### PR TITLE
Only load what is required from `cgi`

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'cgi'
+require 'cgi/escape'
+require 'cgi/util' if RUBY_VERSION < '3.5'
 require 'date'
 require 'set'
 require 'forwardable'


### PR DESCRIPTION
## Description

In Ruby 3.5 most of the `cgi` gem will be removed. Only the various escape/unescape methods will be retained by default.

On older versions, `require "cgi/util"` is needed because the unescape* methods don't work otherwise.

## Additional Notes

https://bugs.ruby-lang.org/issues/21258
