### PR TITLE
Convert strings to UTF-8

### DIFF
--- a/lib/faraday/logging/formatter.rb
+++ b/lib/faraday/logging/formatter.rb
@@ -63,7 +63,7 @@ module Faraday
 
       def dump_body(body)
         if body.respond_to?(:to_str)
-          body.to_str
+          body.to_str.encode(Encoding::UTF_8, undef: :replace, invalid: :replace)
         else
           pretty_inspect(body)
         end

--- a/spec/faraday/response/logger_spec.rb
+++ b/spec/faraday/response/logger_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Faraday::Response::Logger do
         stubs.post('/ohai') { [200, { 'Content-Type' => 'text/html' }, 'fred'] }
         stubs.post('/ohyes') { [200, { 'Content-Type' => 'text/html' }, 'pebbles'] }
         stubs.get('/rubbles') { [200, { 'Content-Type' => 'application/json' }, rubbles] }
+        stubs.get('/8bit') { [200, { 'Content-Type' => 'text/html' }, 'café!'.dup.force_encoding(Encoding::ASCII_8BIT)] }
         stubs.get('/filtered_body') { [200, { 'Content-Type' => 'text/html' }, 'soylent green is people'] }
         stubs.get('/filtered_headers') { [200, { 'Content-Type' => 'text/html' }, 'headers response'] }
         stubs.get('/filtered_params') { [200, { 'Content-Type' => 'text/html' }, 'params response'] }
@@ -236,6 +237,11 @@ RSpec.describe Faraday::Response::Logger do
     it 'logs response body' do
       conn.post '/ohai'
       expect(string_io.string).to match(%(fred))
+    end
+
+    it 'converts to UTF-8' do
+      conn.get '/8bit'
+      expect(string_io.string).to match(%(caf��!))
     end
 
     after do

--- a/spec/faraday/response/logger_spec.rb
+++ b/spec/faraday/response/logger_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Faraday::Response::Logger do
         stubs.post('/ohai') { [200, { 'Content-Type' => 'text/html' }, 'fred'] }
         stubs.post('/ohyes') { [200, { 'Content-Type' => 'text/html' }, 'pebbles'] }
         stubs.get('/rubbles') { [200, { 'Content-Type' => 'application/json' }, rubbles] }
-        stubs.get('/8bit') { [200, { 'Content-Type' => 'text/html' }, 'café!'.dup.force_encoding(Encoding::ASCII_8BIT)] }
+        stubs.get('/8bit') { [200, { 'Content-Type' => 'text/html' }, (+'café!').force_encoding(Encoding::ASCII_8BIT)] }
         stubs.get('/filtered_body') { [200, { 'Content-Type' => 'text/html' }, 'soylent green is people'] }
         stubs.get('/filtered_headers') { [200, { 'Content-Type' => 'text/html' }, 'headers response'] }
         stubs.get('/filtered_params') { [200, { 'Content-Type' => 'text/html' }, 'params response'] }


### PR DESCRIPTION
## Description
If the HTTP response body contains 8bit characters, and the adapter does not set the encoding of `body` to UTF-8 (like here: https://github.com/lostisland/faraday-net_http/pull/13), the logger middleware fails with an error such as this:

> log writing failed. "\xC3" from ASCII-8BIT to UTF-8


With this PR, the body is converted to UTF-8, replacing any 8-bit characters with the [replacement character](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character) (U+FFFD, �).