### PR TITLE
Lint rack_builder.rb: avoid naming a method

### DIFF
--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -221,7 +221,7 @@ module Faraday
     end
 
     def raise_if_adapter(klass)
-      return unless (klass <= Faraday::Adapter)
+      return unless klass <= Faraday::Adapter
 
       raise 'Adapter should be set using the `adapter` method, not `use`'
     end


### PR DESCRIPTION

## Description

This lints, by inlining an expression. 

The method name gave a complaint.

#1625 had some issues running the tests due to that.
