### PR TITLE
Include HTTP method and URL in Faraday::Error messages for improved exception log transparency

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -86,10 +86,12 @@ module Faraday
 
         request = exc.fetch(:request, nil)
 
-        exception_message = if request.nil?
-          "the server responded with status #{http_status} - method and url are not available due to include_request: false on Faraday::Response::RaiseError middleware"
+        if request.nil?
+          exception_message = "the server responded with status #{http_status} - method and url are not available " \
+                              'due to include_request: false on Faraday::Response::RaiseError middleware'
         else
-          "the server responded with status #{http_status} for #{request.fetch(:method).upcase} #{request.fetch(:url)}"
+          exception_message = "the server responded with status #{http_status} for #{request.fetch(:method).upcase} " \
+                              "#{request.fetch(:url)}"
         end
 
         [nil, exception_message, exc]

--- a/spec/faraday/error_spec.rb
+++ b/spec/faraday/error_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Faraday::Error do
 
       it { expect(subject.wrapped_exception).to be_nil }
       it { expect(subject.response).to eq(exception) }
-      it { expect(subject.message).to eq('the server responded with status 400') }
+      it { expect(subject.message).to eq('the server responded with status 400 - method and url are not available due to include_request: false on Faraday::Response::RaiseError middleware') }
       if RUBY_VERSION >= '3.4'
         it { expect(subject.inspect).to eq('#<Faraday::Error response={status: 400}>') }
       else

--- a/spec/faraday/response/raise_error_spec.rb
+++ b/spec/faraday/response/raise_error_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Faraday::Response::RaiseError do
 
   it 'raises Faraday::BadRequestError for 400 responses' do
     expect { conn.get('bad-request') }.to raise_error(Faraday::BadRequestError) do |ex|
-      expect(ex.message).to eq('the server responded with status 400')
+      expect(ex.message).to eq('the server responded with status 400 for GET http:/bad-request')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(400)
       expect(ex.response_status).to eq(400)
@@ -39,7 +39,7 @@ RSpec.describe Faraday::Response::RaiseError do
 
   it 'raises Faraday::UnauthorizedError for 401 responses' do
     expect { conn.get('unauthorized') }.to raise_error(Faraday::UnauthorizedError) do |ex|
-      expect(ex.message).to eq('the server responded with status 401')
+      expect(ex.message).to eq('the server responded with status 401 for GET http:/unauthorized')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(401)
       expect(ex.response_status).to eq(401)
@@ -50,7 +50,7 @@ RSpec.describe Faraday::Response::RaiseError do
 
   it 'raises Faraday::ForbiddenError for 403 responses' do
     expect { conn.get('forbidden') }.to raise_error(Faraday::ForbiddenError) do |ex|
-      expect(ex.message).to eq('the server responded with status 403')
+      expect(ex.message).to eq('the server responded with status 403 for GET http:/forbidden')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(403)
       expect(ex.response_status).to eq(403)
@@ -61,7 +61,7 @@ RSpec.describe Faraday::Response::RaiseError do
 
   it 'raises Faraday::ResourceNotFound for 404 responses' do
     expect { conn.get('not-found') }.to raise_error(Faraday::ResourceNotFound) do |ex|
-      expect(ex.message).to eq('the server responded with status 404')
+      expect(ex.message).to eq('the server responded with status 404 for GET http:/not-found')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(404)
       expect(ex.response_status).to eq(404)
@@ -83,7 +83,7 @@ RSpec.describe Faraday::Response::RaiseError do
 
   it 'raises Faraday::RequestTimeoutError for 408 responses' do
     expect { conn.get('request-timeout') }.to raise_error(Faraday::RequestTimeoutError) do |ex|
-      expect(ex.message).to eq('the server responded with status 408')
+      expect(ex.message).to eq('the server responded with status 408 for GET http:/request-timeout')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(408)
       expect(ex.response_status).to eq(408)
@@ -94,7 +94,7 @@ RSpec.describe Faraday::Response::RaiseError do
 
   it 'raises Faraday::ConflictError for 409 responses' do
     expect { conn.get('conflict') }.to raise_error(Faraday::ConflictError) do |ex|
-      expect(ex.message).to eq('the server responded with status 409')
+      expect(ex.message).to eq('the server responded with status 409 for GET http:/conflict')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(409)
       expect(ex.response_status).to eq(409)
@@ -105,7 +105,7 @@ RSpec.describe Faraday::Response::RaiseError do
 
   it 'raises Faraday::UnprocessableEntityError for 422 responses' do
     expect { conn.get('unprocessable-entity') }.to raise_error(Faraday::UnprocessableEntityError) do |ex|
-      expect(ex.message).to eq('the server responded with status 422')
+      expect(ex.message).to eq('the server responded with status 422 for GET http:/unprocessable-entity')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(422)
       expect(ex.response_status).to eq(422)
@@ -116,7 +116,7 @@ RSpec.describe Faraday::Response::RaiseError do
 
   it 'raises Faraday::TooManyRequestsError for 429 responses' do
     expect { conn.get('too-many-requests') }.to raise_error(Faraday::TooManyRequestsError) do |ex|
-      expect(ex.message).to eq('the server responded with status 429')
+      expect(ex.message).to eq('the server responded with status 429 for GET http:/too-many-requests')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(429)
       expect(ex.response_status).to eq(429)
@@ -138,7 +138,7 @@ RSpec.describe Faraday::Response::RaiseError do
 
   it 'raises Faraday::ClientError for other 4xx responses' do
     expect { conn.get('4xx') }.to raise_error(Faraday::ClientError) do |ex|
-      expect(ex.message).to eq('the server responded with status 499')
+      expect(ex.message).to eq('the server responded with status 499 for GET http:/4xx')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(499)
       expect(ex.response_status).to eq(499)
@@ -149,7 +149,7 @@ RSpec.describe Faraday::Response::RaiseError do
 
   it 'raises Faraday::ServerError for 500 responses' do
     expect { conn.get('server-error') }.to raise_error(Faraday::ServerError) do |ex|
-      expect(ex.message).to eq('the server responded with status 500')
+      expect(ex.message).to eq('the server responded with status 500 for GET http:/server-error')
       expect(ex.response[:headers]['X-Error']).to eq('bailout')
       expect(ex.response[:status]).to eq(500)
       expect(ex.response_status).to eq(500)


### PR DESCRIPTION
## Description

Created in continuation of https://github.com/lostisland/faraday/discussions/1627

## Rubocop violations

I am new to the Faraday code base, so please forgive me if my assumptions or style is wrong. I noticed there is a .rubocop.yml that enforces a maximum line length of 120 characters. I have two violations because the new exception messages are longer. How to deal with that?

## Type checking

During the work on `exc_msg_and_response` in `error.rb`, I found myself shifting away from the ducktyping style towards a stricter more explicitly type-oriented approach? I like it (that shifting did happen deliberately on my part), but how do the maintainers of Faraday feel about it? Specs don't break, but could there be code hiding somewhere - perhaps in other gems - that relies on the weaker duck-typed approach?

## Peculiar URL's generated by the Faraday Test adapter (I think)

I noticed when going through the specs, that the full URL would look something like `http:/not-found` which I have never  seen before. Is this deliberate? Is it a valid URL? It doesn't have a hostname and there seems to be missing a slash after the scheme. I would it expect the generated test url to be something like `http://example.com/not-found`

## The `include_request` middleware option can limit the functionality

Method and URL cannot be included when this Middleware option for RaiseError is set. I guess if somebody uses that option, they would probably have a reason and might also prefer the existing log messages that only reveal the status code. Any thoughts on this?

## Todos

List any remaining work that needs to be done, i.e:
- [x] Tests - I think it is covered by updating the existing examples.
- [ ] Documentation - maybe? I'm not sure if new documentation should be added. Perhaps mention this change in the changelog at release time, but I think that's on the maintainer to do.
- [x] 2 rubocop violations - how to deal with that?
