### PR TITLE
Fix type assumption in `Faraday::Error`

### DIFF
--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -81,7 +81,7 @@ module Faraday
     def exc_msg_and_response(exc, response = nil)
       if exc.is_a?(Exception)
         [exc, exc.message, response]
-      elsif exc.is_a?(Hash)
+      elsif exc.is_a?(Hash) || exc.is_a?(Faraday::Env)
         http_status = exc.fetch(:status)
 
         request = exc.fetch(:request, nil)


### PR DESCRIPTION
## Description

Following #1627, we began to assume that the parameter passed to `Faraday::Error#new` could only be either and `Exception` or a `Hash`.

As demonstrated in #1629, it turns out in the real world we're also passing `Faraday::Env` instances when building errors, which also respond to `each_key` and `[]` too.

Fixes #1629 