### PR TITLE
Lint: use filter_map

### DIFF
--- a/lib/faraday/encoders/flat_params_encoder.rb
+++ b/lib/faraday/encoders/flat_params_encoder.rb
@@ -76,9 +76,9 @@ module Faraday
 
       empty_accumulator = {}
 
-      split_query = (query.split('&').map do |pair|
+      split_query = query.split('&').filter_map do |pair|
         pair.split('=', 2) if pair && !pair.empty?
-      end).compact
+      end
       split_query.each_with_object(empty_accumulator.dup) do |pair, accu|
         pair[0] = unescape(pair[0])
         pair[1] = true if pair[1].nil?


### PR DESCRIPTION
## Description

In another PR, we had lint issues with latest RuboCop, #1636. So, this fixes that in separation.

