### PR TITLE
Use newer Unprocessable Content naming for 422

### DIFF
--- a/docs/middleware/included/raising-errors.md
+++ b/docs/middleware/included/raising-errors.md
@@ -38,7 +38,7 @@ by the client. They raise error classes inheriting from `Faraday::ClientError`.
 | [407](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/407) | `Faraday::ProxyAuthError`           |
 | [408](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/408) | `Faraday::RequestTimeoutError`      |
 | [409](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) | `Faraday::ConflictError`            |
-| [422](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) | `Faraday::UnprocessableEntityError` |
+| [422](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) | `Faraday::UnprocessableContentError` |
 | [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) | `Faraday::TooManyRequestsError` |
 | 4xx (any other)                                                     | `Faraday::ClientError`              |
 

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -154,8 +154,13 @@ module Faraday
   class ConflictError < ClientError
   end
 
+  # Used to provide compatibility with legacy error name.
+  module UnprocessableEntityError
+  end
+
   # Raised by Faraday::Response::RaiseError in case of a 422 response.
-  class UnprocessableEntityError < ClientError
+  class UnprocessableContentError < ClientError
+    include UnprocessableEntityError
   end
 
   # Raised by Faraday::Response::RaiseError in case of a 429 response.

--- a/lib/faraday/error.rb
+++ b/lib/faraday/error.rb
@@ -154,14 +154,12 @@ module Faraday
   class ConflictError < ClientError
   end
 
-  # Used to provide compatibility with legacy error name.
-  module UnprocessableEntityError
-  end
-
   # Raised by Faraday::Response::RaiseError in case of a 422 response.
   class UnprocessableContentError < ClientError
-    include UnprocessableEntityError
   end
+
+  # Used to provide compatibility with legacy error name.
+  UnprocessableEntityError = UnprocessableContentError
 
   # Raised by Faraday::Response::RaiseError in case of a 429 response.
   class TooManyRequestsError < ClientError

--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -15,7 +15,7 @@ module Faraday
         404 => Faraday::ResourceNotFound,
         408 => Faraday::RequestTimeoutError,
         409 => Faraday::ConflictError,
-        422 => Faraday::UnprocessableEntityError,
+        422 => Faraday::UnprocessableContentError,
         429 => Faraday::TooManyRequestsError
       }.freeze
       # rubocop:enable Naming/ConstantName

--- a/spec/faraday/response/raise_error_spec.rb
+++ b/spec/faraday/response/raise_error_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Faraday::Response::RaiseError do
         stub.get('proxy-error') { [407, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('request-timeout') { [408, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('conflict') { [409, { 'X-Reason' => 'because' }, 'keep looking'] }
-        stub.get('unprocessable-entity') { [422, { 'X-Reason' => 'because' }, 'keep looking'] }
+        stub.get('unprocessable-content') { [422, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('too-many-requests') { [429, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('4xx') { [499, { 'X-Reason' => 'because' }, 'keep looking'] }
         stub.get('nil-status') { [nil, { 'X-Reason' => 'nil' }, 'fail'] }
@@ -103,9 +103,20 @@ RSpec.describe Faraday::Response::RaiseError do
     end
   end
 
-  it 'raises Faraday::UnprocessableEntityError for 422 responses' do
-    expect { conn.get('unprocessable-entity') }.to raise_error(Faraday::UnprocessableEntityError) do |ex|
-      expect(ex.message).to eq('the server responded with status 422 for GET http:/unprocessable-entity')
+  it 'raises legacy Faraday::UnprocessableEntityError for 422 responses' do
+    expect { conn.get('unprocessable-content') }.to raise_error(Faraday::UnprocessableEntityError) do |ex|
+      expect(ex.message).to eq('the server responded with status 422 for GET http:/unprocessable-content')
+      expect(ex.response[:headers]['X-Reason']).to eq('because')
+      expect(ex.response[:status]).to eq(422)
+      expect(ex.response_status).to eq(422)
+      expect(ex.response_body).to eq('keep looking')
+      expect(ex.response_headers['X-Reason']).to eq('because')
+    end
+  end
+
+  it 'raises Faraday::UnprocessableContentError for 422 responses' do
+    expect { conn.get('unprocessable-content') }.to raise_error(Faraday::UnprocessableContentError) do |ex|
+      expect(ex.message).to eq('the server responded with status 422 for GET http:/unprocessable-content')
       expect(ex.response[:headers]['X-Reason']).to eq('because')
       expect(ex.response[:status]).to eq(422)
       expect(ex.response_status).to eq(422)


### PR DESCRIPTION
## Description

Rename `Faraday::UnprocessableEntityError` to `Faraday::UnprocessableContentError` but provide compatibility with the older error constant through the use of an included module.

This is based on the status code name specified by [IETF RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110). Rack 3.1 was updated to account for this change (rack/rack#2137), and Rails has added support for it (rails/rails#53383), as well.