### PR TITLE
Fix Response#to_hash to return empty hash when not finished

### DIFF
--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -33,6 +33,10 @@ module Faraday
       finished? ? env.body : nil
     end
 
+    def url
+      finished? ? env.url : nil
+    end
+
     def finished?
       !!env
     end
@@ -59,12 +63,10 @@ module Faraday
     end
 
     def to_hash
-      return {} unless finished?
-
       {
-        status: env.status, body: env.body,
-        response_headers: env.response_headers,
-        url: env.url
+        status: status, body: body,
+        response_headers: headers,
+        url: url
       }
     end
 

--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -59,6 +59,8 @@ module Faraday
     end
 
     def to_hash
+      return {} unless finished?
+
       {
         status: env.status, body: env.body,
         response_headers: env.response_headers,

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Faraday::Response do
     it { expect(hash[:response_headers]).to eq(subject.headers) }
     it { expect(hash[:body]).to eq(subject.body) }
     it { expect(hash[:url]).to eq(subject.env.url) }
+
+    context 'when response is not finished' do
+      subject { Faraday::Response.new.to_hash }
+
+      it { is_expected.to eq({}) }
+    end
   end
 
   describe 'marshal serialization support' do

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Faraday::Response do
   it { expect(subject.success?).to be_falsey }
   it { expect(subject.status).to eq(404) }
   it { expect(subject.body).to eq('yikes') }
+  it { expect(subject.url).to eq(URI('https://lostisland.github.io/faraday')) }
   it { expect(subject.headers['Content-Type']).to eq('text/plain') }
   it { expect(subject['content-type']).to eq('text/plain') }
 
@@ -35,7 +36,7 @@ RSpec.describe Faraday::Response do
     context 'when response is not finished' do
       subject { Faraday::Response.new.to_hash }
 
-      it { is_expected.to eq({}) }
+      it { is_expected.to eq({ status: nil, body: nil, response_headers: {}, url: nil }) }
     end
   end
 


### PR DESCRIPTION
## Description

I found that `Response#to_hash` might cause `NoMethodError` when it's initialized without `env`.

```ruby
irb(main):001> require 'faraday'
=> true
irb(main):002> Faraday::Response.new.to_hash
/Users/yykamei/git/Fork/faraday/lib/faraday/response.rb:63:in 'Faraday::Response#to_hash': undefined method 'status' for nil (NoMethodError)

        status: env.status, body: env.body,
                   ^^^^^^^
	from (irb):2:in '<main>'
	from <internal:kernel>:168:in 'Kernel#loop'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/irb-1.14.3/exe/irb:9:in '<top (required)>'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems.rb:319:in 'Kernel#load'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/site_ruby/3.4.0/rubygems.rb:319:in 'Gem.activate_and_load_bin_path'
	from /Users/yykamei/.rbenv/versions/3.4.5/bin/irb:25:in '<top (required)>'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/cli/exec.rb:59:in 'Kernel.load'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/cli.rb:452:in 'Bundler::CLI#exec'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
	from /Users/yykamei/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/gems/bundler-2.6.8/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
	... 6 levels...
```

In this case, `#to_hash` cannot return any data, so I added guard clause to return `{}` when response is not finished.

## Todos
List any remaining work that needs to be done, i.e:
- [x] Tests
- ~[ ] Documentation~
  - I think the changes don't require documentation changes.
