### PR TITLE
Explicit top-level namespace reference

### DIFF
--- a/lib/faraday/logging/formatter.rb
+++ b/lib/faraday/logging/formatter.rb
@@ -63,7 +63,7 @@ module Faraday
 
       def dump_body(body)
         if body.respond_to?(:to_str)
-          body.to_str.encode(Encoding::UTF_8, undef: :replace, invalid: :replace)
+          body.to_str.encode(::Encoding::UTF_8, undef: :replace, invalid: :replace)
         else
           pretty_inspect(body)
         end


### PR DESCRIPTION
## Description
Use top-level constant operator to reference root namespace.

Fixes the issue raised by @stanley90 in https://github.com/lostisland/faraday/pull/1624#issuecomment-3627584422.  I cannot reproduce it, but I assume it is an issue triggered by Zeitwerk or autoload.