### PR TITLE
Add Ruby 4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', '3.1', '3.2', '3.3', '3.4' ]
+        ruby: [ '3.0', '3.1', '3.2', '3.3', '3.4', '4.0' ]
         experimental: [false]
         include:
           - ruby: head


### PR DESCRIPTION
## Description

Simply adds Ruby 4 to the CI matrix, as it's been out for about a month and a half now.

- https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/
- https://www.ruby-lang.org/en/news/2026/01/13/ruby-4-0-1-released/

According to local test running at least, I think `faraday` should support Ruby 4 just fine.

## Todos
List any remaining work that needs to be done, i.e:

None :no_good_man: 

## Additional Notes

Local testing and RuboCop, for reference.

<img width="2880" height="1856" alt="Screenshot From 2026-02-07 18-17-51" src="https://github.com/user-attachments/assets/12a7a1a8-9b16-4662-bea1-f314acb8a8cc" />
<img width="2880" height="1856" alt="Screenshot From 2026-02-07 18-17-56" src="https://github.com/user-attachments/assets/00243adb-394e-49c3-b786-ae76020c350b" />