### PR TITLE
Upgrade CI lint step from Ruby 3 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Ruby 3.x
+      - name: Setup Ruby 4.x
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3
+          ruby-version: 4
           bundler-cache: true
 
       - name: Rubocop


### PR DESCRIPTION
## Description

Proposing we upgrade the version of Ruby used during CI linting (RuboCop, Yard-Junk) from 3 to 4.

Sort of a follow-up to https://github.com/lostisland/faraday/pull/1544.

## Testing

[Ruby 4.0.4](https://www.ruby-lang.org/en/news/2026/05/11/ruby-4-0-4-released/) (latest) used for linting and [all green](https://github.com/lostisland/faraday/actions/runs/25909108087/job/76149419430?pr=1673). ✅️

<img width="2040" height="958" alt="image" src="https://github.com/user-attachments/assets/27d9e35d-2fbe-4242-90e5-d59db968ffeb" />

## Todos

None.