### PR TITLE
Backport cve-2026-25765

### DIFF
--- a/lib/faraday/encoders/nested_params_encoder.rb
+++ b/lib/faraday/encoders/nested_params_encoder.rb
@@ -100,6 +100,8 @@ module Faraday
 
     def decode_pair(key, value, context)
       subkeys = key.scan(SUBKEYS_REGEX)
+      validate_params_depth!(subkeys.length)
+
       subkeys.each_with_index do |subkey, i|
         is_array = subkey =~ /[\[\]]+\Z/
         subkey = $` if is_array
@@ -139,6 +141,12 @@ module Faraday
       is_array ? context << value : context[subkey] = value
     end
 
+    def validate_params_depth!(depth)
+      return unless @param_depth_limit && depth > @param_depth_limit
+
+      raise Faraday::Error, "exceeded nested parameter depth limit of #{@param_depth_limit}"
+    end
+
     # Internal: convert a nested hash with purely numeric keys into an array.
     # FIXME: this is not compatible with Rack::Utils.parse_nested_query
     # @!visibility private
@@ -161,7 +169,7 @@ module Faraday
   # for your requests.
   module NestedParamsEncoder
     class << self
-      attr_accessor :sort_params
+      attr_accessor :sort_params, :param_depth_limit
 
       extend Forwardable
       def_delegators :'Faraday::Utils', :escape, :unescape
@@ -169,6 +177,7 @@ module Faraday
 
     # Useful default for OAuth and caching.
     @sort_params = true
+    @param_depth_limit = 100
 
     extend EncodeMethods
     extend DecodeMethods

--- a/spec/faraday/connection_spec.rb
+++ b/spec/faraday/connection_spec.rb
@@ -355,6 +355,18 @@ RSpec.describe Faraday::Connection do
       url = conn.build_url(nil, b: 2, c: 3)
       expect(url.to_s).to eq('http://sushi.com/nigiri?a=1&b=2&c=3')
     end
+
+    it 'raises a controlled error when URL query params exceed the nested depth limit' do
+      original_param_depth_limit = Faraday::NestedParamsEncoder.param_depth_limit
+      Faraday::NestedParamsEncoder.param_depth_limit = 2
+
+      expect { conn.build_url('/nigiri?a[b][c]=1') }.to raise_error(
+        Faraday::Error,
+        'exceeded nested parameter depth limit of 2'
+      )
+    ensure
+      Faraday::NestedParamsEncoder.param_depth_limit = original_param_depth_limit
+    end
   end
 
   describe '#build_request' do

--- a/spec/faraday/params_encoders/nested_spec.rb
+++ b/spec/faraday/params_encoders/nested_spec.rb
@@ -5,6 +5,13 @@ require 'rack/utils'
 RSpec.describe Faraday::NestedParamsEncoder do
   it_behaves_like 'a params encoder'
 
+  around do |example|
+    original_param_depth_limit = described_class.param_depth_limit
+    example.run
+  ensure
+    described_class.param_depth_limit = original_param_depth_limit
+  end
+
   it 'decodes arrays' do
     query    = 'a[1]=one&a[2]=two&a[3]=three'
     expected = { 'a' => %w[one two three] }
@@ -52,6 +59,28 @@ RSpec.describe Faraday::NestedParamsEncoder do
     expected = { 'a' => { 'b' => { 'c' => { 'd' => { 'e' => '1' } } } } }
     expect(subject.decode(query)).to eq(expected)
   end
+
+  it 'allows nested params within the configured depth limit' do
+    described_class.param_depth_limit = 3
+
+    expect(subject.decode('a[b][c]=1')).to eq({ 'a' => { 'b' => { 'c' => '1' } } })
+  end
+
+  it 'raises a controlled error when nested params exceed the depth limit' do
+    described_class.param_depth_limit = 2
+
+    expect { subject.decode('a[b][c]=1') }.to raise_error(
+      Faraday::Error,
+      'exceeded nested parameter depth limit of 2'
+    )
+  end
+
+  it 'allows disabling the nested params depth limit' do
+    described_class.param_depth_limit = nil
+
+    expect(subject.decode('a[b][c][d]=1')).to eq({ 'a' => { 'b' => { 'c' => { 'd' => '1' } } } })
+  end
+
 
   it 'decodes nested final value overrides any type' do
     query    = 'a[b][c]=1&a[b]=2'


### PR DESCRIPTION
## Description
Back ports the fix for CVE-2026-25765 to 1.x based on original fix commit https://github.com/lostisland/faraday/commit/36764bfc48aa9fc08336d36600ea67af149c80fa

## Todos
List any remaining work that needs to be done, i.e:
- [ ] Tests
- [ ] Documentation

## Additional Notes
Optional section
