### PR TITLE
Support JSON 3

### DIFF
--- a/lib/faraday/response/json.rb
+++ b/lib/faraday/response/json.rb
@@ -33,7 +33,7 @@ module Faraday
 
         decoder, method_name = @decoder_options
 
-        decoder.public_send(method_name, body, @parser_options || {})
+        decoder.public_send(method_name, body, **(@parser_options || {}))
       end
 
       def parse_response?(env)


### PR DESCRIPTION
In the upcoming `json 3.x`, `JSON.parse` and `JSON.load` take keyword arguments rather than a positional option Hash.

So the options must be splatted.

Thankfully, when splatting on a method that doesn't take keyword arguments, Ruby pass the arguments as positional:

```ruby
def load(source, options = {})
  p options
end

kwargs = {a: 1, b: 2}
load('null', **kwargs) # => {a: 1, b: 2}
```

So the change is compatible with both `json 2.x` and `json 3.x`