### PR TITLE
Preserve false request bodies for JSON encoding

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -445,7 +445,7 @@ module Faraday
         req.options.proxy = proxy_for_request(url)
         req.url(url)                if url
         req.headers.update(headers) if headers
-        req.body = body             if body
+        req.body = body             unless body.nil?
         yield(req) if block_given?
       end
 


### PR DESCRIPTION
## Summary

Preserve false bodies so JSON middleware can encode them.

## Reproduction and verification

With request :json and the test adapter echoing env.body, post('/', false) produces an empty string before the fix and 'false' afterward. Verified POST/PUT/PATCH, true/zero/hash/array/string bodies and block overrides.

- Individual patch: 21 focused Faraday checks passed (body); all 639 existing RSpec examples pass; changed-file RuboCop and Ruby syntax pass.
- Combined installed-release-based branch: 639 existing examples, 1,124 focused checks, full RuboCop (75 files), YARD checks and gem packaging pass.
- External faraday-net_http adapter suite: 386 existing examples, zero failures with the combined fixes.
- Ruby 4.0.6 through rbenv. No production or live external HTTP operations.

## Limitations

No test/spec files were added or changed because the originating repository explicitly forbids this. Reproductions ran outside the repository. This differs from Faraday's requested regression-test contribution convention and is disclosed for maintainer review. Other Ruby versions/platforms were not run locally. This PR includes only the focused source change; the other fixes and the consumer's separately verified merged JSON decoder patch #1687 are not added here.

## Breaking-change notes

False now reaches middleware instead of being silently discarded. Nil behavior is unchanged.
