### PR TITLE
Rebuild the middleware application after duplicating a builder

### DIFF
--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -73,6 +73,7 @@ module Faraday
       super
       @adapter = original.adapter
       @handlers = original.handlers.dup
+      @app = nil
     end
 
     def build


### PR DESCRIPTION
## Summary

Clear the cached middleware app when duplicating a builder.

## Reproduction and verification

Make a request on a test-adapter connection, duplicate it, replace the copy's adapter and make another request. Baseline still calls the original adapter. The fix builds the copied app and leaves the original unchanged.

- Individual patch: 6 focused Faraday checks passed (builder); all 639 existing RSpec examples pass; changed-file RuboCop and Ruby syntax pass.
- Combined installed-release-based branch: 639 existing examples, 1,124 focused checks, full RuboCop (75 files), YARD checks and gem packaging pass.
- External faraday-net_http adapter suite: 386 existing examples, zero failures with the combined fixes.
- Ruby 4.0.6 through rbenv. No production or live external HTTP operations.

## Limitations

No test/spec files were added or changed because the originating repository explicitly forbids this. Reproductions ran outside the repository. This differs from Faraday's requested regression-test contribution convention and is disclosed for maintainer review. Other Ruby versions/platforms were not run locally. This PR includes only the focused source change; the other fixes and the consumer's separately verified merged JSON decoder patch #1687 are not added here.

## Breaking-change notes

Restores the editable-copy contract described in #55; no new API.
