### PR TITLE
Preserve literal plus signs when decoding URI userinfo

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -519,7 +519,7 @@ module Faraday
     def with_uri_credentials(uri)
       return unless uri.user && uri.password
 
-      yield(Utils.unescape(uri.user), Utils.unescape(uri.password))
+      yield(URI::DEFAULT_PARSER.unescape(uri.user), URI::DEFAULT_PARSER.unescape(uri.password))
     end
 
     def proxy_from_env(url)

--- a/lib/faraday/options/proxy_options.rb
+++ b/lib/faraday/options/proxy_options.rb
@@ -33,7 +33,7 @@ module Faraday
       super
     end
 
-    memoized(:user) { uri&.user && Utils.unescape(uri.user) }
-    memoized(:password) { uri&.password && Utils.unescape(uri.password) }
+    memoized(:user) { uri&.user && URI::DEFAULT_PARSER.unescape(uri.user) }
+    memoized(:password) { uri&.password && URI::DEFAULT_PARSER.unescape(uri.password) }
   end
 end


### PR DESCRIPTION
## Summary

Decode URI userinfo as percent-encoded text without converting literal plus signs to spaces.

## Reproduction and verification

Synthetic userinfo u+p:p+ss decodes incorrectly before the fix. Verified literal +, %2B, %20, %252B, %40 and %3A for proxy options and generated Basic headers. No real credentials used. RFC 3986 sections 2.2/3.2.1 permit literal +: https://www.rfc-editor.org/rfc/rfc3986#section-3.2.1

- Individual patch: 20 focused Faraday checks passed (userinfo); all 639 existing RSpec examples pass; changed-file RuboCop and Ruby syntax pass.
- Combined installed-release-based branch: 639 existing examples, 1,124 focused checks, full RuboCop (75 files), YARD checks and gem packaging pass.
- External faraday-net_http adapter suite: 386 existing examples, zero failures with the combined fixes.
- Ruby 4.0.6 through rbenv. No production or live external HTTP operations.

## Limitations

No test/spec files were added or changed because the originating repository explicitly forbids this. Reproductions ran outside the repository. This differs from Faraday's requested regression-test contribution convention and is disclosed for maintainer review. Other Ruby versions/platforms were not run locally. This PR includes only the focused source change; the other fixes and the consumer's separately verified merged JSON decoder patch #1687 are not added here.

## Breaking-change notes

Literal + now remains +; use %20 for a space. Form/query decoding is unchanged.
