### PR TITLE
[LOW] Bound memory retained by remote header names

### DIFF
--- a/lib/faraday/utils/headers.rb
+++ b/lib/faraday/utils/headers.rb
@@ -38,13 +38,11 @@ module Faraday
 
       # symbol -> string mapper + cache
       KeyMap = Hash.new do |map, key|
-        value = if key.respond_to?(:to_str)
-                  key
-                else
-                  key.to_s.split('_') # user_agent: %w(user agent)
-                     .each(&:capitalize!) # => %w(User Agent)
-                     .join('-') # => "User-Agent"
-                end
+        next key if key.respond_to?(:to_str)
+
+        value = key.to_s.split('_') # user_agent: %w(user agent)
+                   .each(&:capitalize!) # => %w(User Agent)
+                   .join('-') # => "User-Agent"
         keymap_mutex.synchronize { map[key] = value }
       end
       KeyMap[:etag] = 'ETag'


### PR DESCRIPTION
## Summary

Prevent remote response header names from accumulating in Faraday's process-global normalization cache.

Faraday still caches symbol-to-header-name normalization, but string names now stay scoped to the individual `Headers` object. This closes a persistent-memory growth path when a remote peer returns fresh valid header names across repeated responses.

## Reproduction and verification

A bounded external reproduction creates 10,000 response-style `Headers` objects with unique names and releases them:

- `v2.14.3`: 10,000 global cache entries retained; 1,258,752 measured hash/key bytes on Ruby 4.0.6.
- This branch: zero global cache entries and zero measured cache bytes retained.
- Ruby 3.2.11 reproduced the same result (1,258,680 bytes before; zero after).
- Existing suite: 646 examples, zero failures on Ruby 4.0.6 and Ruby 3.2.11.
- Changed-file RuboCop, Ruby syntax, and `git diff --check` pass.

The byte measurement covers the cache hash and its keys/values after GC; it is not an RSS or throughput claim.

## Limitations

HTTP adapters and servers typically bound headers per response, so exploitation requires repeated responses from an attacker-controlled or compromised endpoint. Only field names, not header values, were retained globally.

No test/spec files were added or changed under the originating audit's no-new-tests policy; the focused reproduction remained outside the repository.

## Breaking-change notes

No intended public API change. String header names are no longer retained in the internal process-global `KeyMap`; symbol normalization, including the special `ETag` mapping, remains cached.
