### PR TITLE
Reject adapter changes after locking the stack

### DIFF
--- a/lib/faraday/rack_builder.rb
+++ b/lib/faraday/rack_builder.rb
@@ -115,6 +115,7 @@ module Faraday
     def adapter(klass = NO_ARGUMENT, *args, **kwargs, &block)
       return @adapter if klass == NO_ARGUMENT || klass.nil?
 
+      raise_if_locked
       klass = Faraday::Adapter.lookup_middleware(klass) if klass.is_a?(Symbol)
       @adapter = self.class::Handler.new(klass, *args, **kwargs, &block)
     end


### PR DESCRIPTION
RackBuilder rejects middleware changes after the stack is locked, but adapter changes bypass the same guard and silently leave the built application unchanged. Apply the existing lock check consistently.

Verification: full suite 639 examples, zero failures; focused locked-stack model; RuboCop and syntax pass. Source-only patch; no tests included.