### PR TITLE
Apply logging filters to exception messages

### DIFF
--- a/lib/faraday/logging/formatter.rb
+++ b/lib/faraday/logging/formatter.rb
@@ -41,7 +41,7 @@ module Faraday
       def exception(exc)
         return unless log_errors?
 
-        public_send(log_level) { "error: #{exc.full_message}" }
+        public_send(log_level) { "error: #{apply_filters(exc.full_message)}" }
 
         log_headers('error', exc.response_headers) if exc.respond_to?(:response_headers) && log_headers?(:error)
         return unless exc.respond_to?(:response_body) && exc.response_body && log_body?(:error)


### PR DESCRIPTION
The logger filters request and response data but writes exception full_message without applying the configured filters, which can expose values users explicitly registered for redaction. Apply the same filter chain to the exception text.

Verification: full suite 639 examples, zero failures; focused multi-line exception model; RuboCop and syntax pass. Source-only patch; no tests included.