### PR TITLE
Preserve response state while releasing callbacks

### DIFF
--- a/lib/faraday/response.rb
+++ b/lib/faraday/response.rb
@@ -54,7 +54,9 @@ module Faraday
       raise 'response already finished' if finished?
 
       @env = env.is_a?(Env) ? env : Env.from(env)
-      @on_complete_callbacks.each { |callback| callback.call(@env) }
+      callbacks = @on_complete_callbacks
+      @on_complete_callbacks = []
+      callbacks.each { |callback| callback.call(@env) }
       self
     end
 
@@ -76,7 +78,8 @@ module Faraday
     end
 
     def marshal_load(env)
-      @env = Env.from(env)
+      @env = Env.from(env) if env
+      @on_complete_callbacks = []
     end
 
     # Expand the env with more properties, without overriding existing ones.


### PR DESCRIPTION
Release completion callbacks once a response finishes and initialize callback state when unmarshalling, while preserving unfinished response state instead of coercing nil through Env.from.

Verification: full suite 639 examples, zero failures; focused finished and unfinished marshal and callback-retention model; RuboCop and syntax pass. Source-only patch; no tests included.