### PR TITLE
Preserve request ports for no_proxy matching

### DIFF
--- a/lib/faraday/connection.rb
+++ b/lib/faraday/connection.rb
@@ -532,7 +532,7 @@ module Faraday
         uri = if uri.host.nil?
                 find_default_proxy
               else
-                URI.parse("#{uri.scheme}://#{uri.host}").find_proxy
+                URI.parse(uri.to_s).find_proxy
               end
       when URI
         uri = url.find_proxy


### PR DESCRIPTION
Proxy discovery rebuilds a host-only URI, so no_proxy entries scoped to an explicit port cannot match. Pass the complete request URI to URI find_proxy.

Verification: full suite 639 examples, zero failures; focused proxy and no_proxy port model; RuboCop and syntax pass. Source-only patch; no tests included.