### PR TITLE
Memoize false option values without recomputing

### DIFF
--- a/lib/faraday/options.rb
+++ b/lib/faraday/options.rb
@@ -186,7 +186,8 @@ module Faraday
     def [](key)
       key = key.to_sym
       if (method = self.class.memoized_attributes[key])
-        super || (self[key] = instance_eval(&method))
+        value = super
+        value.nil? ? (self[key] = instance_eval(&method)) : value
       else
         super
       end


### PR DESCRIPTION
Memoized option readers use boolean OR, so a valid false result is recomputed on every access. Treat only nil as absent.

Verification: full suite 639 examples, zero failures; focused false-value model; RuboCop and syntax pass. Source-only patch; no tests included.