### PR TITLE
Freeze the default allowed status list

### DIFF
--- a/lib/faraday/response/raise_error.rb
+++ b/lib/faraday/response/raise_error.rb
@@ -20,7 +20,7 @@ module Faraday
       }.freeze
       # rubocop:enable Naming/ConstantName
 
-      DEFAULT_OPTIONS = { include_request: true, allowed_statuses: [] }.freeze
+      DEFAULT_OPTIONS = { include_request: true, allowed_statuses: [].freeze }.freeze
 
       def on_complete(env)
         return if Array(options[:allowed_statuses]).include?(env[:status])


### PR DESCRIPTION
RaiseError freezes its default options hash but leaves the nested allowed_statuses array mutable, so one caller can change process-wide defaults. Freeze the nested default as well.

Verification: full suite 639 examples, zero failures; focused default-ownership model; RuboCop and syntax pass. Source-only patch; no tests included.