### PR TITLE
Define HTTP verb methods on Faraday so tools can see them

### DIFF
--- a/lib/faraday.rb
+++ b/lib/faraday.rb
@@ -137,6 +137,38 @@ module Faraday
       @default_connection_options = ConnectionOptions.from(options)
     end
 
+    # HTTP verb methods, forwarded to {.default_connection}.
+    #
+    # They take the same arguments as their {Faraday::Connection} counterparts,
+    # see {Faraday::Connection#get} and {Faraday::Connection#post}.
+    # Defining them here rather than relying on {method_missing} keeps them
+    # visible to `Faraday.methods`, `pry`'s `ls`, documentation tools and
+    # editor autocomplete.
+
+    # @!visibility private
+    METHODS_WITH_QUERY.each do |method|
+      class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        # def get(url = nil, params = nil, headers = nil, &block)
+        #   default_connection.get(url, params, headers, &block)
+        # end
+        def #{method}(url = nil, params = nil, headers = nil, &block)
+          default_connection.#{method}(url, params, headers, &block)
+        end
+      RUBY
+    end
+
+    # @!visibility private
+    METHODS_WITH_BODY.each do |method|
+      class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        # def post(url = nil, body = nil, headers = nil, &block)
+        #   default_connection.post(url, body, headers, &block)
+        # end
+        def #{method}(url = nil, body = nil, headers = nil, &block)
+          default_connection.#{method}(url, body, headers, &block)
+        end
+      RUBY
+    end
+
     private
 
     # Internal: Proxies method calls on the Faraday constant to

--- a/spec/faraday_spec.rb
+++ b/spec/faraday_spec.rb
@@ -40,4 +40,30 @@ RSpec.describe Faraday do
       Faraday.default_connection = nil
     end
   end
+
+  context 'HTTP verb methods' do
+    let(:mock_connection) { double('Connection') }
+
+    before do
+      Faraday.default_connection = mock_connection
+    end
+
+    (Faraday::METHODS_WITH_QUERY + Faraday::METHODS_WITH_BODY).each do |http_method|
+      it "defines .#{http_method} and forwards it to the default_connection" do
+        expect(Faraday.singleton_class.instance_methods(false)).to include(http_method.to_sym)
+
+        block = proc { |request| request }
+        expect(mock_connection).to receive(http_method) do |*args, &blk|
+          expect(args).to eq(['/foo', { page: 1 }, { 'X-Custom' => 'yes' }])
+          expect(blk).to be(block)
+        end
+
+        Faraday.public_send(http_method, '/foo', { page: 1 }, { 'X-Custom' => 'yes' }, &block)
+      end
+    end
+
+    after do
+      Faraday.default_connection = nil
+    end
+  end
 end


### PR DESCRIPTION
This implements the approach discussed in #1168, following what @iMacTia said there:

> But if we can fix `pry`'s discovery by adding dynamic definitions or delegations to the main `Faraday` module, then that's something I'd be OK with.

### What

`Faraday.get`, `.post` and friends only exist at runtime today — they reach `default_connection` via the private `method_missing` proxy. So they're absent from `Faraday.methods` and `ls Faraday` in pry, they don't turn up in generated docs or editor autocomplete, and static analysis tools flag them as undefined.

Since the verb set is already fixed in `METHODS_WITH_QUERY` and `METHODS_WITH_BODY`, the methods are now generated from those constants using the same `class_eval` loop `Faraday::Connection` already uses for its own verbs — no hand-written list, and the per-shape signature (`url, params, headers` / `url, body, headers`, plus the block) is preserved, so `Faraday.method(:get).parameters` is meaningful.

```ruby
Faraday.methods(false).grep(/get|post/)  # => [:get, :post]
Faraday.method(:get).parameters          # => [[:opt, :url], [:opt, :params], [:opt, :headers], [:block, :block]]
```

### No behavior change

The generated methods call the exact same `default_connection` methods the proxy called. `method_missing` and `respond_to_missing?` are untouched and still handle everything else they forwarded, `Faraday.options` included.

### Tested

`bundle exec rake` (646 examples, 0 failures), `bundle exec rubocop` (clean) and `bundle exec yard-junk --path lib` (clean) on Ruby 4.0. The added spec asserts each verb is really defined on the singleton class (not resolved through `method_missing`) and that url, second argument, headers and the block all arrive at the connection.

Happy to add YARD `@!method` directives on top if you'd like the rubydoc side covered too — left out here to keep the diff small.