### PR TITLE
Document Options struct attributes for YARD (Fixes #1490)

### DIFF
--- a/lib/faraday/options/connection_options.rb
+++ b/lib/faraday/options/connection_options.rb
@@ -4,6 +4,33 @@ module Faraday
   # @!parse
   #   # ConnectionOptions contains the configurable properties for a Faraday
   #   # connection object.
+  #   #
+  #   # @!attribute request
+  #   #   @return [RequestOptions] default request options for the connection
+  #   #
+  #   # @!attribute proxy
+  #   #   @return [ProxyOptions] proxy options for the connection
+  #   #
+  #   # @!attribute ssl
+  #   #   @return [SSLOptions] SSL options for the connection
+  #   #
+  #   # @!attribute builder
+  #   #   @return [RackBuilder] the middleware stack builder for the connection
+  #   #
+  #   # @!attribute url
+  #   #   @return [String, URI] the base URL for the connection
+  #   #
+  #   # @!attribute parallel_manager
+  #   #   @return [Object] manager used when the connection runs in parallel mode
+  #   #
+  #   # @!attribute params
+  #   #   @return [Hash] default query parameters for the connection
+  #   #
+  #   # @!attribute headers
+  #   #   @return [Hash] default headers for the connection
+  #   #
+  #   # @!attribute builder_class
+  #   #   @return [Class] the class used to build the middleware stack
   #   class ConnectionOptions < Options; end
   ConnectionOptions = Options.new(:request, :proxy, :ssl, :builder, :url,
                                   :parallel_manager, :params, :headers,

--- a/lib/faraday/options/proxy_options.rb
+++ b/lib/faraday/options/proxy_options.rb
@@ -4,6 +4,15 @@ module Faraday
   # @!parse
   #   # ProxyOptions contains the configurable properties for the proxy
   #   # configuration used when making an HTTP request.
+  #   #
+  #   # @!attribute uri
+  #   #   @return [URI] the proxy server URI
+  #   #
+  #   # @!attribute user
+  #   #   @return [String] the proxy server username
+  #   #
+  #   # @!attribute password
+  #   #   @return [String] the proxy server password
   #   class ProxyOptions < Options; end
   ProxyOptions = Options.new(:uri, :user, :password) do
     extend Forwardable

--- a/lib/faraday/options/request_options.rb
+++ b/lib/faraday/options/request_options.rb
@@ -3,6 +3,41 @@
 module Faraday
   # @!parse
   #   # RequestOptions contains the configurable properties for a Faraday request.
+  #   #
+  #   # @!attribute params_encoder
+  #   #   @return [Object] the params encoder used to serialize the request params
+  #   #
+  #   # @!attribute proxy
+  #   #   @return [ProxyOptions] proxy options for this request
+  #   #
+  #   # @!attribute bind
+  #   #   @return [Hash] the local host and port to bind the connection to
+  #   #
+  #   # @!attribute timeout
+  #   #   @return [Integer] time limit for the entire request (in seconds)
+  #   #
+  #   # @!attribute open_timeout
+  #   #   @return [Integer] time limit for just the connection phase (in seconds)
+  #   #
+  #   # @!attribute read_timeout
+  #   #   @return [Integer] time limit for the first response byte received from
+  #   #           the server (in seconds)
+  #   #
+  #   # @!attribute write_timeout
+  #   #   @return [Integer] time limit for the client to send the request to the
+  #   #           server (in seconds)
+  #   #
+  #   # @!attribute boundary
+  #   #   @return [String] the boundary used for multipart request bodies
+  #   #
+  #   # @!attribute oauth
+  #   #   @return [Hash] OAuth options used by the OAuth middleware
+  #   #
+  #   # @!attribute context
+  #   #   @return [Hash] free-form storage carried alongside the request
+  #   #
+  #   # @!attribute on_data
+  #   #   @return [Proc] callback invoked with each chunk when streaming the response
   #   class RequestOptions < Options; end
   RequestOptions = Options.new(:params_encoder, :proxy, :bind,
                                :timeout, :open_timeout, :read_timeout,


### PR DESCRIPTION
Fixes #1490.

`Faraday::Options` subclasses are built dynamically with `Options.new(...)`, so YARD has no
static `attr_accessor` calls to pick up and the struct members end up undocumented. The
`@!parse` blocks in these three files documented the class but not its attributes.

This adds `@!attribute` tags inside the existing `@!parse` blocks for `ConnectionOptions`,
`RequestOptions` and `ProxyOptions`, with a `@return` type and a one-line description per
member. The tag names and order match the `Options.new(...)` member lists exactly.

Documentation only. No runtime code is touched.

**Verified locally (Ruby 3.3.7):**

| | upstream/main | this branch |
|---|---|---|
| YARD `Attributes` | 54 | **68** |
| Overall documented | 65.03% | **66.47%** |

- `bundle exec rspec` — 646 examples, 0 failures
- `bundle exec rubocop` — 75 files inspected, no offenses

Happy to adjust any of the type signatures or wording; a few were inferred from usage rather
than from an explicit declaration, so maintainer correction is welcome.
