### PR TITLE
[MEDIUM] Pin actions used for RubyGems publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,12 @@ jobs:
       BUNDLE_WITHOUT: development:test
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Ruby 4.x
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: 4
           bundler-cache: true
@@ -52,8 +54,10 @@ jobs:
             experimental: true
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
@@ -65,5 +69,4 @@ jobs:
       - name: Test External Adapters
         continue-on-error: ${{ matrix.experimental }}
         run: bundle exec bake test:external
-
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,15 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Ruby 3.x
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           bundler-cache: true
           ruby-version: 3
 
       - name: Publish to RubyGems
-        uses: rubygems/release-gem@v1
+        uses: rubygems/release-gem@7f9650160c1a4e7989fdc9855807bdbd421d8b6b # v1.4.1


### PR DESCRIPTION
## Summary

Pin every third-party action used by Faraday's CI and RubyGems publication workflows to a reviewed immutable commit.

The release job has `id-token: write` for RubyGems trusted publishing and `contents: write` for the release task. Rolling action tags could otherwise change the code running with that authority. Checkout credential persistence is also disabled; the pinned `rubygems/release-gem` action explicitly configures its own short-lived GitHub credential for required tag operations.

Pinned versions:

- `actions/checkout` v7.0.1 (`3d3c42e...`)
- `ruby/setup-ruby` v1.321.0 (`95ef2b0...`)
- `rubygems/release-gem` v1.4.1 (`7f96501...`)

## Verification

- Confirmed each full SHA resolves to the named upstream release/tag.
- Reviewed the pinned `release-gem` composite action: it explicitly configures and later clears a credential-cache entry from its token input, so it does not depend on checkout's persisted credential.
- Both changed workflow files parse successfully with Ruby's YAML parser.
- `git diff --check` passes.

No release was triggered and no repository or RubyGems credentials were used.

## Limitations

The pins require deliberate dependency-update PRs to receive future action fixes. This change does not alter the Ruby dependency graph resolved by the release job.

## Breaking-change notes

No application or gem API change. CI/release behavior should be unchanged except that workflow dependencies no longer follow mutable tags and checkout does not persist credentials.
