### PR TITLE
[LOW] Keep Coveralls token out of pull-request code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 env:
   GIT_COMMIT_SHA: ${{ github.sha }}
   GIT_BRANCH: ${{ github.ref }}
-  COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
 permissions:
   contents: read # to fetch code (actions/checkout)
@@ -61,9 +60,10 @@ jobs:
       - name: RSpec
         continue-on-error: ${{ matrix.experimental }}
         run: bundle exec rake
+        env:
+          COVERALLS_REPO_TOKEN: ${{ github.event_name == 'push' && secrets.COVERALLS_REPO_TOKEN || '' }}
 
       - name: Test External Adapters
         continue-on-error: ${{ matrix.experimental }}
         run: bundle exec bake test:external
-
 


### PR DESCRIPTION
## Summary

Keep the Coveralls repository token out of pull-request, lint, and external-adapter execution.

The token was previously defined at workflow scope, so every step inherited it. It is now provided only to the RSpec step on trusted `push` events. Pull requests still run the same suite and generate local coverage, but receive an empty token; external adapter code never receives the credential.

## Verification

- Traced the workflow dataflow from the global `env` through repository-controlled Rake/RSpec code and the external-adapter task.
- Confirmed GitHub already withholds secrets from fork PRs; this change additionally covers same-repository branch PRs and removes the token from unrelated steps.
- The changed workflow parses successfully with Ruby's YAML parser.
- Existing Ruby 4.0.6 and Ruby 3.2.11 suites pass: 646 examples, zero failures each.
- `git diff --check` passes.

No GitHub or Coveralls credential was read during verification.

## Limitations

A contributor who can push to one of the workflow's configured branches can still run code with the coverage token; that matches the trusted push boundary needed for coverage submission. The token's exact Coveralls-side permissions were not available for inspection.

## Breaking-change notes

No gem API change. Coverage submission moves from every job to the RSpec step on push events; pull requests continue to produce local coverage without authenticated submission.
