### PR TITLE
[MEDIUM] Lock the RubyGems release dependency graph

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: Publish to Rubygems
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: Gemfile.release
 
     permissions:
       contents: write

--- a/Gemfile.release
+++ b/Gemfile.release
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Rakefile loads both libraries before defining Bundler::GemHelper's release task.
+gem 'rake', '~> 13.4'
+gem 'rspec', '~> 3.13'
+
+gemspec

--- a/Gemfile.release.lock
+++ b/Gemfile.release.lock
@@ -1,0 +1,62 @@
+PATH
+  remote: .
+  specs:
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.6.2)
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
+    json (2.21.2)
+    logger (1.7.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    rake (13.4.2)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    uri (1.1.1)
+
+PLATFORMS
+  arm64-darwin-25
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  faraday!
+  rake (~> 13.4)
+  rspec (~> 3.13)
+
+CHECKSUMS
+  bundler (4.0.18) sha256=02d9a17429de1847b4e0c9f27a9ee4b20c0a74c0a641b4e77195d6019e3618ac
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  faraday (2.14.3)
+  faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+
+BUNDLED WITH
+  4.0.18


### PR DESCRIPTION
## Summary

Bind Faraday publication to a minimal, checksummed Ruby dependency graph instead of resolving the full development/test toolchain inside the OIDC-authorized release job.

The workflow now sets `BUNDLE_GEMFILE=Gemfile.release`. That file contains only the project gemspec plus the Rake and RSpec libraries eagerly loaded by the existing Rakefile. `Gemfile.release.lock` fixes all 13 resolved gems and records RubyGems SHA-256 checksums.

## Verification

- Release graph installs and passes `bundle check` on Ruby 4.0.6 and Ruby 3.2.11.
- `bundle exec rake build` succeeds under the release graph on both Rubies.
- Both builds contain the same 75 files with byte-identical unpacked contents.
- The unpacked build is byte-identical to the package built from current main with the normal Gemfile; the release-only Gemfiles are excluded by the existing explicit gemspec allowlist.
- Gem metadata still requires Ruby >= 3.0 and retains the same runtime dependency requirements.
- Publish workflow parses successfully; `git diff --check` passes.

No publication, credential use, or production operation occurred.

## Maintenance

Dependabot or a deliberate release-dependency update should refresh `Gemfile.release.lock`; checksum changes remain reviewable. The ordinary unlocked Gemfile remains unchanged so CI can continue testing against the supported dependency ranges.

## Limitations

This narrows the Ruby dependency surface but does not pin the GitHub Actions themselves; that is handled separately in #1710. The lock was generated with Bundler 4.0.18, matching the current release environment, and is not packaged into the gem.

## Breaking-change notes

No gem API, runtime dependency, or package-content change. Maintainers running the release task directly should use `BUNDLE_GEMFILE=Gemfile.release` so they reproduce the workflow graph.
